### PR TITLE
new implementation of getNextAddress

### DIFF
--- a/src/wallet.js
+++ b/src/wallet.js
@@ -95,13 +95,11 @@ Bitcoin.Wallet = (function () {
         };
 
         this.getNextAddress = function () {
-            if (keys.length) {
-                // TODO: Create new addresses if we run out
-                this.addressPointer = (this.addressPointer + 1) % keys.length;
-                return keys[this.addressPointer].getBitcoinAddress();
-            } else {
-                return null;
+            this.addressPointer++;
+            if(!keys[this.addressPointer]) {
+                this.generateAddress();
             }
+            return keys[this.addressPointer].getBitcoinAddress();
         };
 
         this.signWithKey = function (pubKeyHash, hash) {


### PR DESCRIPTION
Hi,

I wrote another version of `wallet.getNextAddress` which takes into account that there could be a situation where we don't have new keys anymore. Maybe we should generate more then one new key?

Is there any reason why there are some functions part of the prototype and some not?

Regards
Philipp
