### PR TITLE
include 'network' in the library exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ module.exports = {
     TransactionOut: require('./transaction').TransactionOut,
     ECPointFp: require('./jsbn/ec').ECPointFp,
     Wallet: require('./wallet'),
+    network: require('./network'),
 
     ecdsa: require('./ecdsa'),
     HDWallet: require('./hdwallet.js'),


### PR DESCRIPTION
This way I can do something like:  address.version == Bitcoin.network.mainnet.addressVersion to compare an Address object's network version and see if it's mainnet or not, for instance.
