### PR TITLE
remove endian code in index.js nothing is using

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,3 @@
-// Bit-wise rotate left
-var rotl = function (n, b) {
-    return (n << b) | (n >>> (32 - b));
-};
-
-// Bit-wise rotate right
-var rotr = function (n, b) {
-    return (n << (32 - b)) | (n >>> b);
-};
-
-// Swap big-endian to little-endian and vice versa
-var endian = function (n) {
-    // If number given, swap endian
-    if (n.constructor == Number) {
-        return rotl(n,  8) & 0x00FF00FF | rotl(n, 24) & 0xFF00FF00;
-    }
-
-    // Else, assume array and swap all items
-    for (var i = 0; i < n.length; i++) {
-        n[i] = endian(n[i]);
-    }
-    return n;
-}
-
 var Key = require('./eckey');
 
 module.exports = {
@@ -49,7 +25,5 @@ module.exports = {
     base58: require('./base58'),
 
     // conversions
-    convert: require('./convert'),
-
-    endian: endian
+    convert: require('./convert')
 }


### PR DESCRIPTION
As far as I can tell, nothing is using this. Brings index.js coverage to 100%.
