### PR TITLE
Convert.js/Base58.js Cleanup

### DIFF
--- a/src/base58.js
+++ b/src/base58.js
@@ -10,7 +10,7 @@ var base = BigInteger.valueOf(58);
 
 var positions = {};
 for (var i=0 ; i < alphabet.length ; ++i) {
-    positions[alphabet[i]] = i;
+  positions[alphabet[i]] = i;
 }
 
 // Convert a byte array to a base58-encoded string.
@@ -18,31 +18,31 @@ for (var i=0 ; i < alphabet.length ; ++i) {
 //   Copyright (c) 2011 Google Inc.
 // Ported to JavaScript by Stefan Thomas.
 function encode(input) {
-    var bi = BigInteger.fromByteArrayUnsigned(input);
-    var chars = [];
+  var bi = BigInteger.fromByteArrayUnsigned(input);
+  var chars = [];
 
-    while (bi.compareTo(base) >= 0) {
-        var mod = bi.mod(base);
-        chars.push(alphabet[mod.intValue()]);
-        bi = bi.subtract(mod).divide(base);
-    }
-    chars.push(alphabet[bi.intValue()]);
+  while (bi.compareTo(base) >= 0) {
+    var mod = bi.mod(base);
+    chars.push(alphabet[mod.intValue()]);
+    bi = bi.subtract(mod).divide(base);
+  }
 
-    // Convert leading zeros too.
-    for (var i = 0; i < input.length; i++) {
-        if (input[i] == 0x00) {
-            chars.push(alphabet[0]);
-        } else break;
-    }
+  chars.push(alphabet[bi.intValue()]);
 
-    return chars.reverse().join('');
+  // Convert leading zeros too.
+  for (var i = 0; i < input.length; i++) {
+    if (input[i] == 0x00) {
+      chars.push(alphabet[0]);
+    } else break;
+  }
+
+  return chars.reverse().join('');
 }
 
 // decode a base58 string into a byte array
 // input should be a base58 encoded string
 // @return Array
 function decode(input) {
-
   var base = BigInteger.valueOf(58);
 
   var length = input.length;
@@ -50,54 +50,55 @@ function decode(input) {
   var leading_zero = 0;
   var seen_other = false;
   for (var i=0; i<length ; ++i) {
-      var chr = input[i];
-      var p = positions[chr];
+    var chr = input[i];
+    var p = positions[chr];
 
-      // if we encounter an invalid character, decoding fails
-      if (p === undefined) {
-          throw new Error('invalid base58 string: ' + input);
-      }
+    // if we encounter an invalid character, decoding fails
+    if (p === undefined) {
+      throw new Error('invalid base58 string: ' + input);
+    }
 
-      num = num.multiply(base).add(BigInteger.valueOf(p));
+    num = num.multiply(base).add(BigInteger.valueOf(p));
 
-      if (chr == '1' && !seen_other) {
-          ++leading_zero;
-      }
-      else {
-          seen_other = true;
-      }
+    if (chr == '1' && !seen_other) {
+      ++leading_zero;
+    }
+    else {
+      seen_other = true;
+    }
   }
 
   var bytes = num.toByteArrayUnsigned();
 
   // remove leading zeros
   while (leading_zero-- > 0) {
-      bytes.unshift(0);
+    bytes.unshift(0);
   }
 
   return bytes;
 }
 
 function checkEncode(input, vbyte) {
-    vbyte = vbyte || 0;
-    var front = [vbyte].concat(input)
-    return encode(front.concat(getChecksum(front)));
+  vbyte = vbyte || 0;
+
+  var front = [vbyte].concat(input);
+  return encode(front.concat(getChecksum(front)));
 }
 
 function checkDecode(input) {
-    var bytes = decode(input),
-        front = bytes.slice(0,bytes.length-4),
-        back = bytes.slice(bytes.length-4);
+  var bytes = decode(input),
+    front = bytes.slice(0,bytes.length-4),
+    back = bytes.slice(bytes.length-4);
 
-    var checksum = getChecksum(front)
+  var checksum = getChecksum(front);
 
-    if (""+checksum != ""+back) {
-        throw new Error("Checksum failed");
-    }
+  if ("" + checksum != "" + back) {
+    throw new Error("Checksum failed");
+  }
 
-    var o = front.slice(1);
-    o.version = front[0];
-    return o;
+  var o = front.slice(1);
+  o.version = front[0];
+  return o;
 }
 
 function getChecksum(bytes) {

--- a/src/convert.js
+++ b/src/convert.js
@@ -3,121 +3,121 @@ var WordArray = Crypto.lib.WordArray;
 var base64map = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
 function lpad(str, padString, length) {
-    while (str.length < length) str = padString + str;
-    return str;
+  while (str.length < length) str = padString + str;
+  return str;
 }
 
 /**
  * Convert a byte array to a hex string
  */
 function bytesToHex(bytes) {
-    return bytes.map(function(x) {
-        return lpad(x.toString(16), '0', 2)
-    }).join('');
+  return bytes.map(function(x) {
+    return lpad(x.toString(16), '0', 2)
+  }).join('');
 };
 
 /**
  * Convert a hex string to a byte array
  */
 function hexToBytes(hex) {
-    return hex.match(/../g).map(function(x) {
-        return parseInt(x,16)
-    });
+  return hex.match(/../g).map(function(x) {
+    return parseInt(x,16)
+  });
 }
 
 /**
  * Convert a byte array to a base-64 string
  */
 function bytesToBase64(bytes) {
-    var base64 = []
+  var base64 = []
 
-    for (var i = 0; i < bytes.length; i += 3) {
-        var triplet = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+  for (var i = 0; i < bytes.length; i += 3) {
+    var triplet = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
 
-        for (var j = 0; j < 4; j++) {
-            if (i * 8 + j * 6 <= bytes.length * 8) {
-                base64.push(base64map.charAt((triplet >>> 6 * (3 - j)) & 0x3F));
-            } else {
-                base64.push('=');
-            }
-        }
+    for (var j = 0; j < 4; j++) {
+      if (i * 8 + j * 6 <= bytes.length * 8) {
+        base64.push(base64map.charAt((triplet >>> 6 * (3 - j)) & 0x3F));
+      } else {
+        base64.push('=');
+      }
     }
+  }
 
-    return base64.join('');
+  return base64.join('');
 }
 
 /**
  * Convert a base-64 string to a byte array
  */
 function base64ToBytes(base64) {
-    // Remove non-base-64 characters
-    base64 = base64.replace(/[^A-Z0-9+\/]/ig, '');
+  // Remove non-base-64 characters
+  base64 = base64.replace(/[^A-Z0-9+\/]/ig, '');
 
-    var bytes = [];
-    var imod4 = 0;
+  var bytes = [];
+  var imod4 = 0;
 
-    for (var i = 0; i < base64.length; imod4 = ++i % 4) {
-        if (!imod4) continue
+  for (var i = 0; i < base64.length; imod4 = ++i % 4) {
+    if (!imod4) continue
 
-        bytes.push(
-            (
-                (base64map.indexOf(base64.charAt(i - 1)) & (Math.pow(2, -2 * imod4 + 8) - 1)) <<
-                (imod4 * 2)
-            ) |
-                (base64map.indexOf(base64.charAt(i)) >>> (6 - imod4 * 2))
-        );
-    }
+    bytes.push(
+      (
+        (base64map.indexOf(base64.charAt(i - 1)) & (Math.pow(2, -2 * imod4 + 8) - 1)) <<
+        (imod4 * 2)
+      ) |
+        (base64map.indexOf(base64.charAt(i)) >>> (6 - imod4 * 2))
+    );
+  }
 
-    return bytes;
+  return bytes;
 }
 
 /**
  * Hex only (allowing bin would be potentially risky, as 01010101 = \x01 * 4 or 85)
  */
 function coerceToBytes(input) {
-    if (typeof input != 'string') return input
-    return hexToBytes(input);
+  if (typeof input != 'string') return input
+  return hexToBytes(input);
 }
 
 function binToBytes(bin) {
-    return bin.match(/......../g).map(function(x) {
-        return parseInt(x,2)
-    });
+  return bin.match(/......../g).map(function(x) {
+    return parseInt(x,2)
+  });
 }
 
 function bytesToBin(bytes) {
-    return bytes.map(function(x) {
-        return lpad(x.toString(2), '0', 8)
-    }).join('');
+  return bytes.map(function(x) {
+    return lpad(x.toString(2), '0', 8)
+  }).join('');
 }
 
 function bytesToString(bytes) {
-    return bytes.map(function(x){
-        return String.fromCharCode(x)
-    }).join('');
+  return bytes.map(function(x){
+    return String.fromCharCode(x)
+  }).join('');
 }
 
 function stringToBytes(string) {
-    return string.split('').map(function(x) {
-        return x.charCodeAt(0)
-    });
+  return string.split('').map(function(x) {
+    return x.charCodeAt(0)
+  });
 }
 
 /**
  * Create a byte array representing a number with the given length
  */
 function numToBytes(num, bytes) {
-    if (bytes === undefined) bytes = 8;
-    if (bytes === 0) return [];
-    return [num % 256].concat(numToBytes(Math.floor(num / 256), bytes - 1));
+  if (bytes === undefined) bytes = 8;
+  if (bytes === 0) return [];
+  return [num % 256].concat(numToBytes(Math.floor(num / 256), bytes - 1));
 }
 
 /**
  * Convert a byte array to the number that it represents
  */
 function bytesToNum(bytes) {
-    if (bytes.length === 0) return 0;
-    return bytes[0] + 256 * bytesToNum(bytes.slice(1));
+  if (bytes.length === 0) return 0;
+  return bytes[0] + 256 * bytesToNum(bytes.slice(1));
 }
 
 /**
@@ -128,26 +128,26 @@ function bytesToNum(bytes) {
  * Returns a byte array.
  */
 function numToVarInt(num) {
-    if (num < 253) return [num];
-    if (num < 65536) return [253].concat(numToBytes(num, 2));
-    if (num < 4294967296) return [254].concat(numToBytes(num, 4));
-    return [253].concat(numToBytes(num, 8));
+  if (num < 253) return [num];
+  if (num < 65536) return [253].concat(numToBytes(num, 2));
+  if (num < 4294967296) return [254].concat(numToBytes(num, 4));
+  return [253].concat(numToBytes(num, 8));
 }
 
 function bytesToWords(bytes) {
-    var words = [];
-    for (var i = 0, b = 0; i < bytes.length; i++, b += 8) {
-        words[b >>> 5] |= bytes[i] << (24 - b % 32);
-    }
-    return words;
+  var words = [];
+  for (var i = 0, b = 0; i < bytes.length; i++, b += 8) {
+    words[b >>> 5] |= bytes[i] << (24 - b % 32);
+  }
+  return words;
 }
 
 function wordsToBytes(words) {
-    var bytes = [];
-    for (var b = 0; b < words.length * 32; b += 8) {
-        bytes.push((words[b >>> 5] >>> (24 - b % 32)) & 0xFF);
-    }
-    return bytes;
+  var bytes = [];
+  for (var b = 0; b < words.length * 32; b += 8) {
+    bytes.push((words[b >>> 5] >>> (24 - b % 32)) & 0xFF);
+  }
+  return bytes;
 }
 
 function bytesToWordArray(bytes) {


### PR DESCRIPTION
Changes all the function signatures in `convert.js` and `base58.js` to use the regular function notation and explicitly adds module exports at the end of the file (as per convention).

As indicated in #56, indentation has also been adjusted to 2 space soft-tabs.

This should be reviewed commit by commit, as the changes are most clear in isolation.
And on the surface, a lot of code has been touched.
