### PR TITLE
Updates README.md examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ These examples assume you are running bitcoinjs-lib in the browser.
 
 ```javascript
 
-key = Bitcoin.ECKey()
+key = new Bitcoin.ECKey()
 
-// Print your private key (used for signing transactions)
+// Print your private key (a hex string)
 console.log(key.toString())
-// => 5Jxfda2afuyMw3iaxzAwv6FvAs3XxmjV5y3GPAjZDEhRNJaFG5a
+// => 8c112cf628362ecf4d482f68af2dbb50c8a2cb90d226215de925417aa9336a48
 
-// Print your public key (Bitcoin address)
-console.log(key.getPub().toString())
-// => 18oxCAnbuKHDjP7KzLBDj8mLjggDBjE1Q9
+// Print your public key (defaults to a Bitcoin address)
+console.log(key.getPub().getAddress())
+// => 14bZ7YWde4KdRb5YN7GYkToz3EHVCvRxkF
 ```
 
 ### Creating a Transaction
@@ -73,7 +73,7 @@ tx.addInput("aa94ab02c182214f090e99a0d57021caffd0f195a81c24602b1028b130b63e31", 
 tx.addOutput("1Gokm82v6DmtwKEB8AiVhm82hyFSsEvBDK", 15000)
 
 // Initialize the private key you created earlier so you can sign the transaction
-key = Bitcoin.ECKey("5Jxfda2afuyMw3iaxzAwv6FvAs3XxmjV5y3GPAjZDEhRNJaFG5a")
+key = new Bitcoin.ECKey("5Jxfda2afuyMw3iaxzAwv6FvAs3XxmjV5y3GPAjZDEhRNJaFG5a")
 
 // Sign the first input with your key
 tx.sign(0, key)
@@ -81,6 +81,8 @@ tx.sign(0, key)
 // Print transaction serialized as hex. You can push the transaction onto the Bitcoin network manually
 // here: https://blockchain.info/pushtx
 console.log(tx.serializeHex())
+// => 0100000001313eb630b128102b60241ca895f1d0ffca2170d5a0990e094f2182c102ab94aa000000008a47304402200169f1f844936dc60df54e812345f5dd3e6681fea52e33c25154ad9cc23a330402204381ed8e73d74a95b15f312f33d5a0072c7a12dd6c3294df6e8efbe4aff27426014104e75628573696aed32d7656fb35e9c71ea08eb6492837e13d2662b9a36821d0fff992692fd14d74fdec20fae29128ba12653249cbeef521fc5eba84dde0689f27ffffffff01983a0000000000001976a914ad618cf4333b3b248f9744e8e81db2964d0ae39788ac00000000
+
 ```
 
 


### PR DESCRIPTION
Address is now properly displayed as per #80 and #81.

Adds example serialized transaction hex output.
