### PR TITLE
Remove potential for private key loss

### DIFF
--- a/src/eckey.js
+++ b/src/eckey.js
@@ -1,58 +1,64 @@
-var BigInteger = require('./jsbn/jsbn');
-var sec = require('./jsbn/sec');
-var base58 = require('./base58');
-var util = require('./util');
-var convert = require('./convert');
-var Address = require('./address');
-var ecdsa = require('./ecdsa');
-var ECPointFp = require('./jsbn/ec').ECPointFp;
+var Address = require('./address')
+var assert = require('assert')
+var convert = require('./convert')
+var base58 = require('./base58')
+var BigInteger = require('./jsbn/jsbn')
+var ecdsa = require('./ecdsa')
+var ECPointFp = require('./jsbn/ec').ECPointFp
+var sec = require('./jsbn/sec')
 var Network = require('./network')
+var util = require('./util')
 
-var ecparams = sec("secp256k1");
+var ecparams = sec("secp256k1")
 
 // input can be nothing, array of bytes, hex string, or base58 string
 var ECKey = function (input, compressed) {
-    if (!(this instanceof ECKey)) { return new ECKey(input, compressed); }
-    if (!input) {
-        // Generate new key
-        var n = ecparams.getN();
-        this.priv = ecdsa.getBigRandom(n);
-        this.compressed = compressed || false;
-    }
-    else this.import(input,compressed)
-};
+  if (!(this instanceof ECKey)) { return new ECKey(input, compressed) }
+  if (!input) {
+    // Generate new key
+    var n = ecparams.getN()
+    this.priv = ecdsa.getBigRandom(n)
+    this.compressed = compressed || false
+  }
+  else this.import(input,compressed)
+}
 
 ECKey.prototype.import = function (input, compressed) {
-    function has(li, v) { return li.indexOf(v) >= 0 }
-    function fromBin(x) { return BigInteger.fromByteArrayUnsigned(x) }
-    this.priv =
-          input instanceof ECKey                   ? input.priv
-        : input instanceof BigInteger              ? input.mod(ecparams.getN())
-        : Array.isArray(input)                     ? fromBin(input.slice(0, 32))
-        : typeof input != "string"                 ? null
-        : input.length == 44                       ? fromBin(convert.base64ToBytes(input))
-        : input.length == 51 && input[0] == '5'    ? fromBin(base58.checkDecode(input))
-        : input.length == 51 && input[0] == '9'    ? fromBin(base58.checkDecode(input))
-        : input.length == 52 && has('LK', input[0]) ? fromBin(base58.checkDecode(input).slice(0, 32))
-        : input.length == 52 && input[0] == 'c'    ? fromBin(base58.checkDecode(input).slice(0, 32))
-        : has([64,65],input.length)                ? fromBin(convert.hexToBytes(input.slice(0, 64)))
-                                                   : null
+  function has(li, v) { return li.indexOf(v) >= 0 }
+  function fromBin(x) { return BigInteger.fromByteArrayUnsigned(x) }
 
-    this.compressed =
-          compressed !== undefined                 ? compressed
-        : input instanceof ECKey                   ? input.compressed
-        : input instanceof BigInteger              ? false
-        : Array.isArray(input)                     ? false
-        : typeof input != "string"                 ? null
-        : input.length == 44                       ? false
-        : input.length == 51 && input[0] == '5'    ? false
-        : input.length == 51 && input[0] == '9'    ? false
-        : input.length == 52 && has('LK', input[0]) ? true
-        : input.length == 52 && input[0] == 'c'    ? true
-        : input.length == 64                       ? false
-        : input.length == 65                       ? true
-                                                   : null
-};
+  this.priv =
+      input instanceof ECKey                   ? input.priv
+    : input instanceof BigInteger              ? input.mod(ecparams.getN())
+    : Array.isArray(input)                     ? fromBin(input.slice(0, 32))
+    : typeof input != "string"                 ? null
+    : input.length == 44                       ? fromBin(convert.base64ToBytes(input))
+    : input.length == 51 && input[0] == '5'    ? fromBin(base58.checkDecode(input))
+    : input.length == 51 && input[0] == '9'    ? fromBin(base58.checkDecode(input))
+    : input.length == 52 && has('LK', input[0]) ? fromBin(base58.checkDecode(input).slice(0, 32))
+    : input.length == 52 && input[0] == 'c'    ? fromBin(base58.checkDecode(input).slice(0, 32))
+    : has([64,65],input.length)                ? fromBin(convert.hexToBytes(input.slice(0, 64)))
+    : null
+
+  assert(this.priv !== null)
+
+  this.compressed =
+      compressed !== undefined                 ? compressed
+    : input instanceof ECKey                   ? input.compressed
+    : input instanceof BigInteger              ? false
+    : Array.isArray(input)                     ? false
+    : typeof input != "string"                 ? null
+    : input.length == 44                       ? false
+    : input.length == 51 && input[0] == '5'    ? false
+    : input.length == 51 && input[0] == '9'    ? false
+    : input.length == 52 && has('LK', input[0]) ? true
+    : input.length == 52 && input[0] == 'c'    ? true
+    : input.length == 64                       ? false
+    : input.length == 65                       ? true
+    : null
+
+  assert(this.compressed !== null)
+}
 
 ECKey.prototype.getPub = function(compressed) {
     if (compressed === undefined) compressed = this.compressed
@@ -127,21 +133,23 @@ var ECPubKey = function(input, compressed) {
 }
 
 ECPubKey.prototype.import = function(input, compressed) {
-    var decode = function(x) { return ECPointFp.decodeFrom(ecparams.getCurve(), x) }
+  var decode = function(x) { return ECPointFp.decodeFrom(ecparams.getCurve(), x) }
 
-    this.pub =
-          input instanceof ECPointFp ? input
-        : input instanceof ECKey     ? ecparams.getG().multiply(input.priv)
-        : input instanceof ECPubKey  ? input.pub
-        : typeof input == "string"   ? decode(convert.hexToBytes(input))
-        : Array.isArray(input)       ? decode(input)
-                                     : null
+  this.pub =
+      input instanceof ECPointFp ? input
+    : input instanceof ECKey     ? ecparams.getG().multiply(input.priv)
+    : input instanceof ECPubKey  ? input.pub
+    : typeof input == "string"   ? decode(convert.hexToBytes(input))
+    : Array.isArray(input)       ? decode(input)
+    : null
 
-    this.compressed =
-          compressed                 ? compressed
-        : input instanceof ECPointFp ? input.compressed
-        : input instanceof ECPubKey  ? input.compressed
-                                     : (this.pub[0] < 4)
+  assert(this.pub !== null)
+
+  this.compressed =
+      compressed                 ? compressed
+    : input instanceof ECPointFp ? input.compressed
+    : input instanceof ECPubKey  ? input.compressed
+    : (this.pub[0] < 4)
 }
 
 ECPubKey.prototype.add = function(key) {


### PR DESCRIPTION
This pull request removes a potentially fatal mistake that could be made by a developer using the current API.
It removes the implicit private key generation for the `ECPubKey` with an empty constructor; with which they can generate and never a recover private key.

There is no reason (that I can see) to include this feature in the API, if the developer wishes to throw away a private key, let them do it explicitly?

```
var lonelyPubKey = new ECKey().getPub()
```

As it stands, this just seems potentially dangerous with no real benefit.
