### PR TITLE
ECDSA Tests and Public key recovery

### DIFF
--- a/src/ecdsa.js
+++ b/src/ecdsa.js
@@ -272,10 +272,7 @@ var ECDSA = {
       throw new Error("Pubkey recovery unsuccessful");
     }
 
-    // TODO (shtylman) this is stupid because this file and eckey
-    // have circular dependencies
-    var ECPubKey = require('./eckey').ECPubKey;
-    return ECPubKey(Q);
+    return Q
   },
 
   /**
@@ -293,7 +290,7 @@ var ECDSA = {
     for (var i = 0; i < 4; i++) {
       var pubKey = ECDSA.recoverPubKey(r, s, hash, i)
 
-      if (pubKey.pub.equals(origPubKey.pub)) {
+      if (pubKey.equals(origPubKey)) {
         return i
       }
     }

--- a/src/message.js
+++ b/src/message.js
@@ -3,6 +3,7 @@
 var Address = require('./address')
 var convert = require('./convert')
 var ecdsa = require('./ecdsa')
+var ECPubKey = require('./eckey').ECPubKey
 var SHA256 = require('crypto-js/sha256')
 
 var Message = {}
@@ -32,7 +33,7 @@ Message.signMessage = function (key, message) {
   var sig = key.sign(hash)
   var obj = ecdsa.parseSig(sig)
 
-  var i = ecdsa.calcPubKeyRecoveryParam(key.getPub(), obj.r, obj.s, hash)
+  var i = ecdsa.calcPubKeyRecoveryParam(key.getPub().pub, obj.r, obj.s, hash)
 
   i += 27
   if (key.compressed) {
@@ -57,7 +58,7 @@ Message.verifyMessage = function (address, sig, message) {
   var hash = Message.getHash(message)
 
   var isCompressed = !!(sig.i & 4)
-  var pubKey = ecdsa.recoverPubKey(sig.r, sig.s, hash, sig.i)
+  var pubKey = new ECPubKey(ecdsa.recoverPubKey(sig.r, sig.s, hash, sig.i))
   pubKey.compressed = isCompressed
 
   // Compare address to expected address

--- a/test/ecdsa.js
+++ b/test/ecdsa.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var convert = require('../').convert
 var ecdsa = require('../').ecdsa
+var ECPubKey = require('../').ECPubKey
 var Message = require('../').Message
 
 describe('ecdsa', function() {
@@ -12,7 +13,7 @@ describe('ecdsa', function() {
 
       var hash = Message.getHash('1111')
       var obj = ecdsa.parseSigCompact(signature)
-      var pubKey = ecdsa.recoverPubKey(obj.r, obj.s, hash, obj.i)
+      var pubKey = new ECPubKey(ecdsa.recoverPubKey(obj.r, obj.s, hash, obj.i))
 
       assert.equal(pubKey.toHex(true), '02e8fcf4d749b35879bc1f3b14b49e67ab7301da3558c5a9b74a54f1e6339c334c')
     })


### PR DESCRIPTION
This pull request removes the unnecessary calculation of the network address when recovering public keys from message signatures.

It also provides a baseline test for `calcPubKeyRecoveryParam`.
