### PR TITLE
Removes deprecated ECKey.export function

### DIFF
--- a/src/eckey.js
+++ b/src/eckey.js
@@ -59,14 +59,6 @@ ECKey.prototype.getPub = function(compressed) {
     return ECPubKey(ecparams.getG().multiply(this.priv),compressed)
 }
 
-/**
- * @deprecated Reserved keyword, factory pattern. Use toHex, toBytes, etc.
- */
-ECKey.prototype['export'] = function(format) {
-    var format = format || 'hex'
-    return this['to' + format.substr(0, 1).toUpperCase() + format.substr(1)]()
-}
-
 ECKey.prototype.toBin = function() {
     return convert.bytesToString(this.toBytes())
 }
@@ -152,11 +144,6 @@ ECPubKey.prototype.add = function(key) {
 
 ECPubKey.prototype.multiply = function(key) {
     return ECPubKey(this.pub.multiply(ECKey(key).priv),this.compressed)
-}
-
-ECPubKey.prototype['export'] = function(format) {
-    var format = format || 'hex';
-    return this['to' + format.substr(0, 1).toUpperCase() + format.substr(1)]()
 }
 
 ECPubKey.prototype.toBytes = function(compressed) {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -310,12 +310,12 @@ Transaction.prototype.sign = function(index, key, type) {
 
     // TODO: getPub is slow, sha256ripe160 probably is too.
     // This could be sped up a lot by providing these as inputs.
-    var pub = key.getPub().export('bytes'),
+    var pub = key.getPub().toBytes(),
         hash160 = util.sha256ripe160(pub),
         script = Script.createOutputScript(new Address(hash160)),
-        hash = this.hashTransactionForSignature( script, index, type),
+        hash = this.hashTransactionForSignature(script, index, type),
         sig = key.sign(hash).concat([type]);
-    this.ins[index].script = Script.createInputScript(sig,pub);
+    this.ins[index].script = Script.createInputScript(sig, pub);
 }
 
 // Takes outputs of the form [{ output: 'txhash:index', address: 'address' },...]

--- a/test/misc.js
+++ b/test/misc.js
@@ -13,8 +13,8 @@ function sha256FromBytesToBytes(message){
 }
 
 it('Keys & Key Management', function () {
-    var p1 = bitcoinjs.Key().getPub()['export']('bytes');
-    assert.equal(p1.length, 65);
+    var p1 = bitcoinjs.Key().getPub().toBytes()
+    assert.equal(p1.length, 65)
 
     var p1_q = ECPointFp.decodeFrom(ecparams.getCurve(), p1);
     assert.ok(p1_q);

--- a/test/transaction.js
+++ b/test/transaction.js
@@ -170,7 +170,7 @@ describe('Transaction', function() {
         var key = new ECKey('L44f7zxJ5Zw4EK9HZtyAnzCYz2vcZ5wiJf9AuwhJakiV4xVkxBeb')
         tx.sign(0, key)
 
-        var pub = key.getPub().export('bytes')
+        var pub = key.getPub().toBytes()
         var script = prevTx.outs[0].script.buffer
         var sig = tx.ins[0].script.chunks[0]
 
@@ -187,7 +187,7 @@ describe('Transaction', function() {
 
       it('returns true for valid signature', function(){
         var key = new ECKey('L44f7zxJ5Zw4EK9HZtyAnzCYz2vcZ5wiJf9AuwhJakiV4xVkxBeb')
-        var pub = key.getPub().export('bytes')
+        var pub = key.getPub().toBytes()
         var script = prevTx.outs[0].script.buffer
         var sig = validTx.ins[0].script.chunks[0]
 


### PR DESCRIPTION
This pull request removes `ECKey.export` and `ECPubKey.export`, as both had been deprecated in favour of their static bindings `toHex`, `toBytes` etc.  

Given how much the API is changing, it seems like a deprecation cycle would be mostly useless in this case (if that was indeed an intention).
