### PR TITLE
100% coverage of wallet.js

### DIFF
--- a/src/wallet.js
+++ b/src/wallet.js
@@ -3,7 +3,7 @@ var Transaction = require('./transaction').Transaction
 var HDNode = require('./hdwallet.js')
 var rng = require('secure-random')
 
-var Wallet = function (seed, options) {
+function Wallet(seed, options) {
   if (!(this instanceof Wallet)) { return new Wallet(seed, options); }
 
   var options = options || {}
@@ -119,20 +119,20 @@ var Wallet = function (seed, options) {
   function validateUnspentOutput(uo) {
     var missingField
 
-    if(isNullOrUndefined(uo.hash) && isNullOrUndefined(uo.hashLittleEndian)){
+    if (isNullOrUndefined(uo.hash) && isNullOrUndefined(uo.hashLittleEndian)) {
       missingField = "hash(or hashLittleEndian)"
     }
 
     var requiredKeys = ['outputIndex', 'address', 'value']
-    requiredKeys.forEach(function(key){
-      if(isNullOrUndefined(uo[key])){
+    requiredKeys.forEach(function (key) {
+      if (isNullOrUndefined(uo[key])){
         missingField = key
       }
     })
 
-    if(missingField) {
+    if (missingField) {
       var message = [
-        'Invalid unspent output: key', field, 'is missing.',
+        'Invalid unspent output: key', missingField, 'is missing.',
         'A valid unspent output must contain'
       ]
       message.push(requiredKeys.join(', '))
@@ -141,7 +141,7 @@ var Wallet = function (seed, options) {
     }
   }
 
-  function isNullOrUndefined(value){
+  function isNullOrUndefined(value) {
     return value == undefined
   }
 

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -22,6 +22,10 @@ describe('Wallet', function() {
   })
 
   describe('constructor', function() {
+    it('should be ok to call without new', function() {
+      assert.ok(Wallet(seed) instanceof Wallet)
+    })
+
     it('defaults to Bitcoin mainnet', function() {
       assert.equal(wallet.getMasterKey().network, 'mainnet')
     })


### PR DESCRIPTION
1. Added test to check `Wallet(seed)` without new.
2. Fixed bug with `field` being used instead of `missingField`. I assume this caused a throw but before the error was being thrown causing the following rows to not be covered: https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/src/wallet.js#L138-L140
