### PR TITLE
Removal of curveFpDecodePointHex

### DIFF
--- a/src/jsbn/ec.js
+++ b/src/jsbn/ec.js
@@ -283,38 +283,12 @@ function curveFpFromBigInteger(x) {
     return new ECFieldElementFp(this.q, x);
 }
 
-// for now, work with hex strings because they're easier in JS
-function curveFpDecodePointHex(s) {
-    switch(parseInt(s.substr(0,2), 16)) { // first byte
-    case 0:
-	return this.infinity;
-    case 2:
-    case 3:
-	// point compression not supported yet
-	return null;
-    case 4:
-    case 6:
-    case 7:
-	var len = (s.length - 2) / 2;
-	var xHex = s.substr(2, len);
-	var yHex = s.substr(len+2, len);
-
-	return new ECPointFp(this,
-			     this.fromBigInteger(new BigInteger(xHex, 16)),
-			     this.fromBigInteger(new BigInteger(yHex, 16)));
-
-    default: // unsupported
-	return null;
-    }
-}
-
 ECCurveFp.prototype.getQ = curveFpGetQ;
 ECCurveFp.prototype.getA = curveFpGetA;
 ECCurveFp.prototype.getB = curveFpGetB;
 ECCurveFp.prototype.equals = curveFpEquals;
 ECCurveFp.prototype.getInfinity = curveFpGetInfinity;
 ECCurveFp.prototype.fromBigInteger = curveFpFromBigInteger;
-ECCurveFp.prototype.decodePointHex = curveFpDecodePointHex;
 
 // prepends 0 if bytes < len
 // cuts off start if bytes > len

--- a/src/jsbn/sec.js
+++ b/src/jsbn/sec.js
@@ -185,7 +185,7 @@ function secp256r1() {
     var curve = new ECCurveFp(p, a, b);
 
     var x = fromHex("6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296")
-		var y = fromHex("4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5")
+    var y = fromHex("4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5")
     var G = new ECPointFp(curve,
                           curve.fromBigInteger(x),
                           curve.fromBigInteger(y))


### PR DESCRIPTION
The removal of this function is just a preliminary change to the total rework of the `ECKey` API.
It is currently not used by anywhere else but in `ec.js` as an almost negligible convenience function for initializing the curve parameters.

Other reasons for removing this function:
- It was not under test in any way
- It does not support EC point compression
- It has some weird return values
