### PR TITLE
Renames `ec.js` test description appropriately

### DIFF
--- a/test/ec.js
+++ b/test/ec.js
@@ -4,7 +4,7 @@ var ecdsa = require('../').ecdsa
 
 var ecparams = sec('secp256k1')
 
-describe('ecdsa', function() {
+describe('ec', function() {
   it('handles point multiplication', function() {
     var G = ecparams.getG()
     var n = ecparams.getN()


### PR DESCRIPTION
The current test description in `test/ec.js` is `ecdsa`, while related, it may be confused with the tests in `test/ecdsa.js`.

This pull request therefore resolves the possibility by renaming the test description to `ec` instead of `ecdsa`.
