### PR TITLE
Fixes ECDSA capitalization

### DIFF
--- a/src/ecdsa.js
+++ b/src/ecdsa.js
@@ -51,7 +51,7 @@ function deterministicGenerateK(hash,key) {
   return BigInteger.fromByteArrayUnsigned(vArr)
 }
 
-var ECDSA = {
+var ecdsa = {
   getBigRandom: function (limit) {
     return new BigInteger(limit.bitLength(), rng).
       mod(limit.subtract(BigInteger.ONE)).
@@ -69,13 +69,13 @@ var ECDSA = {
 
     var s = k.modInverse(n).multiply(e.add(d.multiply(r))).mod(n)
 
-    return ECDSA.serializeSig(r, s)
+    return ecdsa.serializeSig(r, s)
   },
 
   verify: function (hash, sig, pubkey) {
     var r,s
     if (Array.isArray(sig)) {
-      var obj = ECDSA.parseSig(sig)
+      var obj = ecdsa.parseSig(sig)
       r = obj.r
       s = obj.s
     } else if ("object" === typeof sig && sig.r && sig.s) {
@@ -95,7 +95,7 @@ var ECDSA = {
     }
     var e = BigInteger.fromByteArrayUnsigned(hash)
 
-    return ECDSA.verifyRaw(e, r, s, Q)
+    return ecdsa.verifyRaw(e, r, s, Q)
   },
 
   verifyRaw: function (e, r, s, Q) {
@@ -265,7 +265,7 @@ var ECDSA = {
     var Q = implShamirsTrick(R, s, G, eNeg).multiply(rInv)
 
     Q.validate()
-    if (!ECDSA.verifyRaw(e, r, s, Q)) {
+    if (!ecdsa.verifyRaw(e, r, s, Q)) {
       throw new Error("Pubkey recovery unsuccessful")
     }
 
@@ -285,7 +285,7 @@ var ECDSA = {
    */
   calcPubKeyRecoveryParam: function (origPubKey, r, s, hash) {
     for (var i = 0; i < 4; i++) {
-      var pubKey = ECDSA.recoverPubKey(r, s, hash, i)
+      var pubKey = ecdsa.recoverPubKey(r, s, hash, i)
 
       if (pubKey.equals(origPubKey)) {
         return i
@@ -296,4 +296,4 @@ var ECDSA = {
   }
 }
 
-module.exports = ECDSA
+module.exports = ecdsa

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -6,7 +6,7 @@ var Script = require('./script')
 var convert = require('./convert')
 var crypto = require('./crypto')
 var ECKey = require('./eckey').ECKey
-var ECDSA = require('./ecdsa')
+var ecdsa = require('./ecdsa')
 
 var Transaction = function (doc) {
   if (!(this instanceof Transaction)) { return new Transaction(doc) }
@@ -364,7 +364,7 @@ Transaction.prototype.applyMultisigs = function(index, script, sigs/*, type*/) {
 Transaction.prototype.validateSig = function(index, script, sig, pub) {
   script = new Script(script)
   var hash = this.hashTransactionForSignature(script,index,1)
-  return ECDSA.verify(hash, convert.coerceToBytes(sig),
+  return ecdsa.verify(hash, convert.coerceToBytes(sig),
                       convert.coerceToBytes(pub))
 }
 

--- a/test/ec.js
+++ b/test/ec.js
@@ -4,7 +4,7 @@ var ecdsa = require('../').ecdsa
 
 var ecparams = sec('secp256k1')
 
-describe('ec', function() {
+describe('EC', function() {
   it('handles point multiplication', function() {
     var G = ecparams.getG()
     var n = ecparams.getN()


### PR DESCRIPTION
The following pull request capitalizes the use of `ECDSA` consistently throughout the project.
I opted for the lower case alternative, which seemed most consistent with non-instantiating modules (such as `BigInteger` or `Transaction`).
