### PR TITLE
Pads zeros in toBytes output, fixes #121

### DIFF
--- a/src/eckey.js
+++ b/src/eckey.js
@@ -85,6 +85,10 @@ ECKey.prototype.toHex = function() {
 
 ECKey.prototype.toBytes = function() {
   var bytes = this.priv.toByteArrayUnsigned()
+
+  // ensure 32 bytes
+  while (bytes.length < 32) bytes.unshift(0)
+
   if (this.compressed) bytes.push(1)
   return bytes
 }


### PR DESCRIPTION
This adds an immediate (but preliminary) fix for #121 until I can submit the pull request for the stricter constructors code.

Basically just re-applying 24881584c721adc268fbd8c58f57e04fb82c5a08 to the newer code base.
