### PR TITLE
Updates network.js constant names

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -1,7 +1,7 @@
 var base58 = require('./base58')
 var base58check = require('./base58check')
 var convert = require('./convert')
-var mainnet = require('./network').mainnet.addressVersion
+var bitcoin = require('./network').bitcoin.pubKeyHash
 
 function Address(bytes, version) {
   if (!(this instanceof Address)) {
@@ -21,7 +21,7 @@ function Address(bytes, version) {
     }
     else if (bytes.length <= 40) {
       this.hash = convert.hexToBytes(bytes)
-      this.version = version || mainnet
+      this.version = version || bitcoin
     }
     else {
       throw new Error('Invalid or unrecognized input')
@@ -29,7 +29,7 @@ function Address(bytes, version) {
   }
   else {
     this.hash = bytes
-    this.version = version || mainnet
+    this.version = version || bitcoin
   }
 }
 

--- a/src/eckey.js
+++ b/src/eckey.js
@@ -74,7 +74,7 @@ ECKey.version_bytes = {
 }
 
 ECKey.prototype.toWif = function(version) {
-  version = version || Network.mainnet.addressVersion
+  version = version || Network.bitcoin.pubKeyHash
 
   return base58check.encode(this.toBytes(), ECKey.version_bytes[version])
 }
@@ -169,7 +169,7 @@ ECPubKey.prototype.toBin = function(compressed) {
 }
 
 ECPubKey.prototype.toWif = function(version) {
-  version = version || Network.mainnet.addressVersion
+  version = version || Network.bitcoin.pubKeyHash
 
   return base58check.encode(this.toBytes(), version)
 }
@@ -177,7 +177,7 @@ ECPubKey.prototype.toWif = function(version) {
 ECPubKey.prototype.toString = ECPubKey.prototype.toHex
 
 ECPubKey.prototype.getAddress = function(version) {
-  version = version || Network.mainnet.addressVersion
+  version = version || Network.bitcoin.pubKeyHash
 
   return new Address(crypto.hash160(this.toBytes()), version)
 }

--- a/src/hdwallet.js
+++ b/src/hdwallet.js
@@ -21,7 +21,7 @@ function HDWallet(seed, network) {
 
   var I = HmacSHA512(seed, 'Bitcoin seed')
   this.chaincode = I.slice(32)
-  this.network = network || 'mainnet'
+  this.network = network || 'bitcoin'
   if(!Network.hasOwnProperty(this.network)) {
     throw new Error("Unknown network: " + this.network)
   }
@@ -77,7 +77,7 @@ HDWallet.fromBytes = function(input) {
 
   var hd = new HDWallet()
 
-  // 4 byte: version bytes (mainnet: 0x0488B21E public, 0x0488ADE4 private
+  // 4 byte: version bytes (bitcoin: 0x0488B21E public, 0x0488ADE4 private
   // testnet: 0x043587CF public, 0x04358394 private)
   var versionBytes = input.slice(0, 4)
   var versionWord = convert.bytesToWords(versionBytes)[0]
@@ -86,8 +86,8 @@ HDWallet.fromBytes = function(input) {
   for(var name in Network) {
     var network = Network[name]
 
-    for(var t in network.hdVersions) {
-      if (versionWord != network.hdVersions[t]) continue
+    for(var t in network.bip32) {
+      if (versionWord != network.bip32[t]) continue
 
       type = t
       hd.network = name
@@ -141,9 +141,9 @@ HDWallet.prototype.toBytes = function(priv) {
   var buffer = []
 
   // Version
-  // 4 byte: version bytes (mainnet: 0x0488B21E public, 0x0488ADE4 private; testnet: 0x043587CF public,
+  // 4 byte: version bytes (bitcoin: 0x0488B21E public, 0x0488ADE4 private; testnet: 0x043587CF public,
   // 0x04358394 private)
-  var version = Network[this.network].hdVersions[priv ? 'priv' : 'pub']
+  var version = Network[this.network].bip32[priv ? 'priv' : 'pub']
   var vBytes = convert.wordsToBytes([version])
 
   buffer = buffer.concat(vBytes)
@@ -248,7 +248,7 @@ HDWallet.prototype.derivePrivate = function(index) {
 }
 
 HDWallet.prototype.getKeyVersion = function() {
-  return Network[this.network].addressVersion
+  return Network[this.network].pubKeyHash
 }
 
 HDWallet.prototype.toString = HDWallet.prototype.toBase58

--- a/src/network.js
+++ b/src/network.js
@@ -1,19 +1,29 @@
+// https://en.bitcoin.it/wiki/List_of_address_prefixes
 module.exports = {
-  mainnet: {
-    addressVersion: 0,
-    p2shVersion: 5,
-    hdVersions: {
-      pub: 0x0488B21E,
-      priv: 0x0488ADE4
-    }
+  bitcoin: {
+    bip32: {
+      pub: 0x0488b21e,
+      priv: 0x0488ade4
+    },
+    pubKeyHash: 0x00,
+    scriptHash: 0x05,
+    wif: 0x80
+  },
+  dogecoin: {
+    pubKeyHash: 0x30,
+    scriptHash: 0x20,
+    wif: 0x9e
+  },
+  litecoin: {
+    scriptHash: 0x30,
   },
   testnet: {
-    addressVersion: 111,
-    p2shVersion: 196,
-    hdVersions: {
-      pub: 0x043587CF,
+    bip32: {
+      pub: 0x043587cf,
       priv: 0x04358394
-    }
+    },
+    pubKeyHash: 0x6f,
+    scriptHash: 0xc4,
+    wif: 0xef
   }
 }
-

--- a/src/script.js
+++ b/src/script.js
@@ -369,8 +369,8 @@ Script.prototype.writeBytes = function(data) {
 Script.createOutputScript = function(address) {
   var script = new Script()
   address = new Address(address)
-  if (address.version == network.mainnet.p2shVersion ||
-      address.version == network.testnet.p2shVersion) {
+  if (address.version == network.bitcoin.scriptHash ||
+      address.version == network.testnet.scriptHash) {
     // Standard pay-to-script-hash
     script.writeOp(Opcode.map.OP_HASH160)
     script.writeBytes(address.hash)

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -7,7 +7,7 @@ function Wallet(seed, options) {
   if (!(this instanceof Wallet)) { return new Wallet(seed, options); }
 
   var options = options || {}
-  var network = options.network || 'mainnet'
+  var network = options.network || 'bitcoin'
 
   // Stored in a closure to make accidental serialization less likely
   var masterkey = null

--- a/test/address.js
+++ b/test/address.js
@@ -3,26 +3,26 @@ var Address = require('../src/address')
 var network = require('../src/network')
 var base58 = require('../src/base58')
 var base58check = require('../src/base58check')
-var mainnet = network.mainnet.addressVersion
-var testnet = network.testnet.addressVersion
+var bitcoin = network.bitcoin.pubKeyHash
+var testnet = network.testnet.pubKeyHash
 
 describe('Address', function() {
-  var testnetAddress, mainnetAddress
-  var testnetP2shAddress, mainnetP2shAddress
+  var testnetAddress, bitcoinAddress
+  var testnetP2shAddress, bitcoinP2shAddress
 
   beforeEach(function(){
-    mainnetAddress = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
+    bitcoinAddress = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
     testnetAddress = 'mzBc4XEFSdzCDcTxAgf6EZXgsZWpztRhef'
-    mainnetP2shAddress = '3NJZLcZEEYBpxYEUGewU4knsQRn1WM5Fkt'
+    bitcoinP2shAddress = '3NJZLcZEEYBpxYEUGewU4knsQRn1WM5Fkt'
     testnetP2shAddress = '2MxKEf2su6FGAUfCEAHreGFQvEYrfYNHvL7'
   })
 
   describe('parsing', function() {
     it('works with Address object', function() {
-      var addr = new Address(new Address('mwrB4fgT1KSBCqELaWv7o7tsExuQzW3NY3', network.testnet.addressVersion))
+      var addr = new Address(new Address('mwrB4fgT1KSBCqELaWv7o7tsExuQzW3NY3', network.testnet.pubKeyHash))
 
       assert.equal(addr.toString(), 'mwrB4fgT1KSBCqELaWv7o7tsExuQzW3NY3')
-      assert.equal(addr.version, network.testnet.addressVersion)
+      assert.equal(addr.version, network.testnet.pubKeyHash)
     })
 
     it('works with hex', function() {
@@ -37,15 +37,15 @@ describe('Address', function() {
     })
 
     it('works for byte input', function() {
-      var hash = base58check.decode(mainnetAddress)
+      var hash = base58check.decode(bitcoinAddress)
       var addr = new Address(hash.payload)
       assert.equal(addr.hash, hash.payload)
-      assert.equal(network.mainnet.addressVersion, hash.version)
+      assert.equal(network.bitcoin.pubKeyHash, hash.version)
 
       var hash = base58check.decode(testnetAddress)
       var addr = new Address(hash.payload)
       assert.equal(addr.hash, hash.payload)
-      assert.equal(network.testnet.addressVersion, hash.version)
+      assert.equal(network.testnet.pubKeyHash, hash.version)
     })
 
     it('fails for bad input', function() {
@@ -57,8 +57,8 @@ describe('Address', function() {
 
   describe('getVersion', function() {
     it('returns the proper address version', function() {
-      assert.equal(Address.getVersion(mainnetAddress), network.mainnet.addressVersion)
-      assert.equal(Address.getVersion(testnetAddress), network.testnet.addressVersion)
+      assert.equal(Address.getVersion(bitcoinAddress), network.bitcoin.pubKeyHash)
+      assert.equal(Address.getVersion(testnetAddress), network.testnet.pubKeyHash)
     })
   })
 
@@ -72,9 +72,9 @@ describe('Address', function() {
   describe('Constructor', function(){
     it('resolves version correctly', function(){
       assert.equal((new Address(testnetAddress)).version, testnet)
-      assert.equal((new Address(mainnetAddress)).version, mainnet)
-      assert.equal((new Address(testnetP2shAddress)).version, network.testnet.p2shVersion)
-      assert.equal((new Address(mainnetP2shAddress)).version, network.mainnet.p2shVersion)
+      assert.equal((new Address(bitcoinAddress)).version, bitcoin)
+      assert.equal((new Address(testnetP2shAddress)).version, network.testnet.scriptHash)
+      assert.equal((new Address(bitcoinP2shAddress)).version, network.bitcoin.scriptHash)
     })
   })
 
@@ -85,7 +85,7 @@ describe('Address', function() {
       }
 
       validate(testnetAddress)
-      validate(mainnetAddress)
+      validate(bitcoinAddress)
       validate('12KYrjTdVGjFMtaxERSk3gphreJ5US8aUP')
       validate('12QeMLzSrB8XH8FvEzPMVoRxVAzTr5XM2y')
       validate('1oNLrsHnBcR6dpaBpwz3LSwutbUNkNSjs')
@@ -94,7 +94,7 @@ describe('Address', function() {
 
       // p2sh addresses
       validate(testnetP2shAddress)
-      validate(mainnetP2shAddress)
+      validate(bitcoinP2shAddress)
     })
 
     it('does not validate illegal examples', function() {

--- a/test/eckey.js
+++ b/test/eckey.js
@@ -6,7 +6,7 @@ var bytesToHex = convert.bytesToHex
 var hexToBytes = convert.hexToBytes
 var Address = require('../src/address')
 var Network = require('../src/network')
-var testnet = Network.testnet.addressVersion
+var testnet = Network.testnet.pubKeyHash
 
 describe('ECKey', function() {
   describe('constructor', function() {
@@ -83,7 +83,7 @@ describe('ECKey', function() {
       return ECPubKey(x).toHex(false)
     })
 
-    it('mainnet', function() {
+    it('bitcoin', function() {
       var addresses = [
         '19SgmoUj4xowEjwtXvNAtYTAgbvR9iBCui',
         '1MsHWS1BnwMc3tLE8G35UXsS58fKipzB7a',

--- a/test/hdwallet.js
+++ b/test/hdwallet.js
@@ -2,8 +2,8 @@ var HDWallet = require('../src/hdwallet.js')
 var assert = require('assert')
 var convert = require('../src/convert.js')
 var Network = require('../src/network')
-var mainnet = Network.mainnet.addressVersion
-var testnet = Network.testnet.addressVersion
+var bitcoin = Network.bitcoin.pubKeyHash
+var testnet = Network.testnet.pubKeyHash
 
 var b2h = convert.bytesToHex
 
@@ -241,8 +241,8 @@ describe('HDWallet', function() {
   })
 
   describe('network types', function() {
-    it('ensures that a mainnet Wallet generates mainnet addresses', function() {
-      var wallet = new HDWallet('foobar', 'mainnet')
+    it('ensures that a bitcoin Wallet generates bitcoin addresses', function() {
+      var wallet = new HDWallet('foobar', 'bitcoin')
       assert.equal(wallet.getAddress().toString(), '1JNymexJHEr5u1BndiChMStFkCgPm4EQ6o')
     })
 

--- a/test/message.js
+++ b/test/message.js
@@ -2,7 +2,7 @@ var assert = require('assert')
 var convert = require('../').convert
 var ECKey = require('../src/eckey').ECKey
 var Message = require('../').Message
-var testnet = require('../').network.testnet.addressVersion
+var testnet = require('../').network.testnet.pubKeyHash
 
 describe('Message', function() {
   var msg

--- a/test/script.js
+++ b/test/script.js
@@ -109,7 +109,7 @@ describe('Script', function() {
         '02fab2dea1458990793f56f42e4a47dbf35a12a351f26fa5d7e0cc7447eaafa21f',
         '036c6802ce7e8113723dd92cdb852e492ebb157a871ca532c3cb9ed08248ff0e19']
         numSigs = 2
-        network = Network.mainnet.p2shVersion
+        network = Network.bitcoin.scriptHash
     })
 
     it('should create valid multi-sig address', function() {
@@ -118,7 +118,7 @@ describe('Script', function() {
       var multiSigAddress = Address(multisig, network).toString()
 
       assert.ok(Address.validate(multiSigAddress))
-      assert.equal(Address.getVersion(multiSigAddress), Network.mainnet.p2shVersion)
+      assert.equal(Address.getVersion(multiSigAddress), Network.bitcoin.scriptHash)
       assert.equal(multiSigAddress,'32vYjxBb7pHJJyXgNk8UoK3BdRDxBzny2v')
     })
 

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -25,8 +25,8 @@ describe('Wallet', function() {
       assert.ok(Wallet(seed) instanceof Wallet)
     })
 
-    it('defaults to Bitcoin mainnet', function() {
-      assert.equal(wallet.getMasterKey().network, 'mainnet')
+    it('defaults to Bitcoin network', function() {
+      assert.equal(wallet.getMasterKey().network, 'bitcoin')
     })
 
     it("generates m/0' as the main account", function() {


### PR DESCRIPTION
This pull request updates `network.js` to use the same naming scheme for version constants as seen in #125.

It also adds the constants as they appear on https://en.bitcoin.it/wiki/List_of_address_prefixes for Dogecoin and Litecoin respectively.
This does not signify support for these other networks, but was added to show how it should take place.
