### PR TITLE
Uses low 's' values for signatures

### DIFF
--- a/test/eckey.js
+++ b/test/eckey.js
@@ -1,8 +1,4 @@
 var assert = require('assert')
-var ecdsa = require('../src/ecdsa.js')
-var sec = require('../src/jsbn/sec.js')
-var BigInteger = require('../src/jsbn/jsbn.js')
-var ecparams = sec("secp256k1")
 var ECKey = require('../src/eckey.js').ECKey
 var ECPubKey = require('../src/eckey.js').ECPubKey
 var convert = require('../src/convert.js')
@@ -151,19 +147,6 @@ describe('ECKey', function() {
 
       assert(priv.verify(message, signature))
     })
-
-    it('should sign with low S value', function() {
-      var priv = new ECKey(hpriv)
-      var signature = priv.sign(message)
-      var parsed = ecdsa.parseSig(signature)
-
-      // Check that the 's' value is 'low', to prevent possible transaction malleability as per
-      // https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures
-      assert(parsed.s.compareTo(ecparams.getN().divide(BigInteger.valueOf(2))) <= 0)
-
-      assert(priv.verify(message, signature))
-    })
-
 
     it('should verify against the public key', function() {
       var priv = new ECKey(hpriv)


### PR DESCRIPTION
As per https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures, using values of `s` bounded by `curve.order()/2` can help preventing transaction malleability, by making sure no one other than sender can make different signatures for the same transaction. Combined with additional bitcoind validation to be implemented for transactions with `nVersion=3` it prevents issues with transactions modified by third parties otherwise not having control over them.

This change enables this "low S values" behaviour by default in bitcoinjs-lib, without any additional configuration. I think it is important step for compatibility with `nVersion=3` and is a good idea to always do it, because there are no counterindications for it AFAICS.
