### PR TITLE
Adds CryptoJS to index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ module.exports = {
   BigInteger: require('./jsbn/jsbn'),
   convert: require('./convert'),
   crypto: require('./crypto'),
+  CryptoJS: require('crypto-js'),
   ecdsa: require('./ecdsa'),
   ECKey: Key.ECKey,
   ECPointFp: require('./jsbn/ec').ECPointFp,


### PR DESCRIPTION
I think it's useful to export CryptoJS by default because it contains functions like AES, which are useful for Bitcoin applications in general.
