### PR TITLE
Prefer Array.prototype.slice over map

### DIFF
--- a/src/jsbn/jsbn.js
+++ b/src/jsbn/jsbn.js
@@ -1201,9 +1201,7 @@ BigInteger.valueOf = nbv;
  */
 BigInteger.fromByteArrayUnsigned = function(ba) {
   // FIXME: BigInteger doesn't yet support Buffers
-  if (Buffer.isBuffer(ba)) {
-    ba = Array.prototype.map.bind(ba, function(x) { return x })()
-  }
+  if (Buffer.isBuffer(ba)) ba = Array.prototype.slice.call(ba)
 
   if (!ba.length) {
     return new BigInteger.valueOf(0);

--- a/src/script.js
+++ b/src/script.js
@@ -339,9 +339,7 @@ Script.prototype.writeOp = function(opcode) {
  */
 Script.prototype.writeBytes = function(data) {
   // FIXME: Script module doesn't support buffers yet
-  if (Buffer.isBuffer(data)) {
-    data = Array.prototype.map.bind(data, function(x) { return x })()
-  }
+  if (Buffer.isBuffer(data)) data = Array.prototype.slice.call(data)
 
   if (data.length < Opcode.map.OP_PUSHDATA1) {
     this.buffer.push(data.length)


### PR DESCRIPTION
This pull request makes the minor change of using `Array.prototype.slice.call` by default instead of `map`.
The performance game is insignificant, but it is at least now consistent with how it is being done across the code base.
