### PR TITLE
Fixed issues with wallet.createTx using testnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
   "scripts": {
     "test": "./node_modules/.bin/istanbul test ./node_modules/.bin/_mocha -- --reporter list test/*.js",
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --reporter list test/*.js",
-    "compile": "./node_modules/.bin/browserify ./src/index.js -s Bitcoin | ./node_modules/.bin/uglifyjs > bitcoinjs-min.js",
-    "compile-big": "./node_modules/.bin/browserify ./src/index.js -s Bitcoin > bitcoinjs.js",
-    "splitPea-compile": "./node_modules/.bin/browserify ./src/index.js -s Bitcoin > ../splitPea/public/js/lib/bitcoinjs.js"
+    "compile": "./node_modules/.bin/browserify ./src/index.js -s Bitcoin | ./node_modules/.bin/uglifyjs > bitcoinjs-min.js"
   },
   "dependencies": {
     "bigi": "0.2.0",


### PR DESCRIPTION
There were some issues creating testnet transactions using the Wallet and I fixed them by checking against the network provided when the wallet was instantiated.
