### PR TITLE
Adding integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "node-browserify": "https://github.com/substack/node-browserify/tarball/master",
     "sinon": "1.9.0",
     "coveralls": "~2.10.0",
-    "mocha-lcov-reporter": "0.0.1"
+    "mocha-lcov-reporter": "0.0.1",
+    "helloblock-js": "^0.2.1"
   },
   "testling": {
     "browsers": [

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,0 +1,79 @@
+var assert = require('assert');
+
+var Address = require('../src/address');
+var ECKey = require('../src/eckey').ECKey;
+var T = require('../src/transaction');
+var Transaction = T.Transaction;
+var Script = require('../src/script');
+var network = require('../src/network');
+var crypto = require('../src/crypto');
+
+var helloblock = require('helloblock-js')({
+  network: 'testnet'
+});
+
+describe('integration', function() {
+  this.timeout(10000);
+
+  it('scripthash transactions', function(done) {
+    // 2-of-2 scripthash
+    var privKeys = [
+      '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',
+      '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT'
+    ].map(function(wif) {
+      return ECKey.fromWIF(wif)
+    })
+
+    var pubKeys = privKeys.map(function(eck) {
+      return eck.pub
+    })
+    var pubKeyBuffers = pubKeys.map(function(q) {
+      return q.toBuffer()
+    })
+    var redeemScript = Script.createMultisigOutputScript(2, pubKeyBuffers)
+    var hash160 = crypto.hash160(redeemScript.buffer)
+    var multisigAddress = new Address(hash160, network.testnet.scriptHash)
+
+    // Check what our target address's starting value is
+    var targetAddress = 'mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r';
+    helloblock.addresses.get(targetAddress, function(err, resp, resource) {
+      if (err) done(err);
+      var startingBalance = resource.balance
+
+      // Send some testnet coins to the multisig address so we ensure it has some unspents
+      helloblock.faucet.withdraw(multisigAddress.toString(), 100000, function(err, resp, resource) {
+        if (err) done(err);
+
+        // Get latest unspents from the mutlsigAddress
+        helloblock.addresses.getUnspents(multisigAddress.toString(), function(err, resp, resource) {
+          if (err) done(err);
+
+          var tx = new Transaction()
+          var unspent = resource[0];
+          tx.addInput(unspent.txHash, unspent.index)
+          tx.addOutput(targetAddress, 100000, network.testnet)
+
+          var signatures = privKeys.map(function(privKey) {
+            return tx.signScriptSig(0, redeemScript, privKey)
+          })
+
+          var scriptSig = Script.createP2SHMultisigScriptSig(signatures, redeemScript)
+          tx.setScriptSig(0, scriptSig)
+
+          // Send from mutlsigAddress to targetAddress
+          helloblock.transactions.propagate(tx.serializeHex(), function(err, resp, resource) {
+            // no err means that transaction has been successfully propagated
+            if (err) done(err);
+
+            // Check that the funds (100000) indeed arrived at the intended target address
+            helloblock.addresses.get(targetAddress, function(err, resp, resource) {
+              if (err) done(err);
+              assert.equal(resource.balance, startingBalance + 100000)
+              done()
+            })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
I think it would be beneficial to have integration tests that way it gives definitive confidence that the library works as intended.

This is a proof of concept integration test for a 2-of-2 scripthash transaction. If this proof of concept was accepted, I would like to transform this test into a function which then automatically tests 1-of-2; 1-of-3; 2-of-3; 3-of-3; Making sure that each variation of transaction is actually valid and acceptable by the network.

In future tests, I would like to extend integration tests to the wallet module, and then pubkeyhash transactions, OP_RETURN (nulldata) if supported.

The basic workflow of the tests works as follows:
1. Start with private keys and generate P2SH address
2. Use an API (testnet faucet) to send some testnet coins to the P2SH address to ensure that it has some bitcoin
3. Create a transaction from P2SH address to a target address
4. Make sure that transaction is propagated to the network and check the balance of the target address and make sure that the fund actually arrived at that address.

Note:
1. Added Dev Dependency: Client library for the API that runs the integration tests. 
2. This runs in both the browser as well as in nodejs.
