### PR TITLE
Remove Number.isFinite check on tx input index

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -361,7 +361,7 @@ Transaction.prototype.signWithKeys = function(keys, outputs, type) {
 Transaction.prototype.signScriptSig = function(index, script, key, type) {
   type = type || SIGHASH_ALL
 
-  assert(Number.isFinite(index) && (index >= 0), 'Invalid vin index')
+  assert((index >= 0), 'Invalid vin index')
   assert(script instanceof Script, 'Invalid Script object')
   assert(key instanceof ECKey, 'Invalid private key')
 //  assert.equal(type & 0x7F, type, 'Invalid type') // TODO


### PR DESCRIPTION
There's only so much we can do to prevent one from shooting oneself in the foot. Number.isFinite is an ES6 feature that's not fully supported yet across browsers. At this point, I don't think the benefit of type checking justifies sacrificing browser support (safari for example).

Once both this and #165 are merged there will be no more usage of Number.isFinite in this repo.
