### PR TITLE
Fixes #167

### DIFF
--- a/src/hdwallet.js
+++ b/src/hdwallet.js
@@ -205,6 +205,7 @@ HDWallet.prototype.derive = function(i) {
     I = HmacFromBytesToBytes(SHA512, KPar.concat(iBytes), cPar)
   }
 
+
   // FIXME: Boo, CSJ.algo.SHA512 uses byte arrays
   I = new Buffer(I)
 
@@ -225,7 +226,7 @@ HDWallet.prototype.derive = function(i) {
     hd.pub = hd.priv.pub
   } else {
     // Ki = (IL + kpar)*G = IL*G + Kpar
-    var Ki = IL.multiply(ecparams.getG()).add(this.pub.Q)
+    var Ki = ecparams.getG().multiply(IL).add(this.pub.Q)
 
     hd.pub = new ECPubKey(Ki, true)
   }

--- a/test/hdwallet.js
+++ b/test/hdwallet.js
@@ -231,6 +231,17 @@ describe('HDWallet', function() {
     })
   })
 
+  describe('derive', function() {
+    describe('m/0', function() {
+      it('works', function() {
+        var wallet = HDWallet.fromBase58('xpub6CxuB8ifZCMXeS3KbyNkYvrsJEHqxedCSiUhrNwH1nKtb8hcJpxDbDxkdoVCTR2bQ1G8hY4UMv85gef9SEpgFFUftBjt37FUSZxVx4AU9Qh').derive(0)
+
+        assert.equal(wallet.depth, 4)
+        assert.equal(wallet.toBase58(), 'xpub6DyYbqDaPgHkj1Sk5EaqC4HgGN7xRePCGJeei9En2kCK8kZk8HRnnPuKSbNX6vwQVvmYnTPhK8vpUEXTBd5BQ9MUKBewhGJtL49YuUfQwJw')
+      })
+    })
+  })
+
   describe('network types', function() {
     it('ensures that a bitcoin Wallet generates bitcoin addresses', function() {
       var wallet = new HDWallet(new Buffer('foobar'), 'bitcoin')


### PR DESCRIPTION
This pull request fixes the multiplication order in `HDWallet.derive` for extended public keys, which until now, has clearly not been under test.
The `ECPointFp` (the type of a typical public key)  class only supports multiplication of the form `ECPointFp.prototype.multiply :: ECPointFp -> BigInteger -> ECPointFp`.
Therefore, as pointed in #167, when done in the commutative form, the `BigIngeter.prototype.multiply` fails. (`ECPointFp` missing `BigInteger` methods etc).

Better tests will follow up eventually to address #169.
