### PR TITLE
Remove fromHex, tests for edge case fromBuffer errors

### DIFF
--- a/src/hdwallet.js
+++ b/src/hdwallet.js
@@ -57,10 +57,6 @@ HDWallet.fromBase58 = function(string) {
   return HDWallet.fromBuffer(payload)
 }
 
-HDWallet.fromHex = function(input) {
-  return HDWallet.fromBuffer(new Buffer(input, 'hex'))
-}
-
 HDWallet.fromBuffer = function(input) {
   assert.strictEqual(input.length, HDWallet.LENGTH, 'Invalid buffer length')
 

--- a/test/hdwallet.js
+++ b/test/hdwallet.js
@@ -53,6 +53,21 @@ describe('HDWallet', function() {
         assert(hd.pub)
       })
     })
+
+    describe('fromBuffer', function() {
+      it('fails for invalid parent fingerprint', function() {
+        var buffer = new HDWallet(seed).toBuffer()
+        buffer.writeUInt8(0x00, 4)
+        buffer.writeUInt32BE(0xFFFFFFFF, 5)
+        assert.throws(function() { HDWallet.fromBuffer(buffer) }, /Invalid parent fingerprint/)
+      })
+
+      it('fails for invalid index', function() {
+        var buffer = new HDWallet(seed).toBuffer()
+        buffer.writeUInt32BE(0xFFFFFFFF, 9)
+        assert.throws(function() { HDWallet.fromBuffer(buffer) }, /Invalid index/)
+      })
+    })
   })
 
   describe('Test vectors', function() {
@@ -246,6 +261,12 @@ describe('HDWallet', function() {
 
     it('throws an exception when unknown network type is passed in', function() {
       assert.throws(function() { new HDWallet(new Buffer('foobar'), 'doge') })
+    })
+
+    it('throws an exception with bad network type using fromBuffer', function() {
+      var buffer = new HDWallet(new Buffer('foobar'), 'bitcoin').toBuffer()
+      buffer.writeUInt32BE(0x00000000, 0)
+      assert.throws(function() { HDWallet.fromBuffer(buffer) }, /Could not find version 0/)
     })
   })
 })


### PR DESCRIPTION
This pulls fromHex from `HDWallet` and adds a few tests to catch a couple edge-case fromBuffer errors missing in the coverage (that would only happen from data corruption probably).
