### PR TITLE
Add support for continuous coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ node_js:
 env:
   - TEST_SUITE=unit
   - TEST_SUITE=integration
+  - TEST_SUITE=coveralls
 script: "npm run-script $TEST_SUITE"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test": "npm run-script unit",
     "integration": "./node_modules/.bin/_mocha --reporter list test/integration/*.js",
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --reporter list test/*.js",
+    "coveralls": "npm run-script coverage && node ./node_modules/.bin/coveralls < coverage/lcov.info",
     "compile": "./node_modules/.bin/browserify ./src/index.js -s Bitcoin | ./node_modules/.bin/uglifyjs > bitcoinjs-min.js"
   },
   "dependencies": {


### PR DESCRIPTION
Giving integration of Coveralls.io the old college try.

We'll know if this worked when Travis reports a success and Coveralls.io starts returning data.
