### PR TITLE
Integration tests running async causing wrong balance

### DIFF
--- a/test/integration/p2sh.js
+++ b/test/integration/p2sh.js
@@ -30,8 +30,7 @@ describe('Bitcoin-js', function() {
 
     var pubKeys = privKeys.map(function(eck) { return eck.pub })
     var redeemScript = Script.createMultisigScriptPubKey(2, pubKeys)
-    var hash160 = crypto.hash160(new Buffer(redeemScript.buffer))
-    var multisigAddress = new Address(hash160, networks.testnet.scriptHash).toString()
+    var multisigAddress = new Address(redeemScript.getHash(), networks.testnet.scriptHash).toString()
 
     // Send some testnet coins to the multisig address to ensure it has some unspents for later
     helloblock.faucet.withdraw(multisigAddress, coldAmount, function(err) {


### PR DESCRIPTION
As can be seen after a [small commit](https://github.com/bitcoinjs/bitcoinjs-lib/commit/4332c9e3d41a086b4a8768c3c1c750da374ab309) to just the README, the build has switched from `passing` to `failed`.

The error is an `Uncaught AssertionError: 18600000 == 18500000`, that is, the funds received on that address were **more** than expected.
Knowing that the assertion code is actually:

```
assert.equal(resource.balance, startingBalance + 100000)
```

It received twice as much as it should.  This indicates that the code was run twice before the assertion was made.

Looking at the [transaction history](https://test.helloblock.io/addresses/mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r), it can be seen that the two transactions around this time were performed asynchronously.

To resolve this, I have made the following changes:
- `targetAddress` is now a random address.
- No need to check `targetAddress` balance, if we regenerate an address with a non-zero balance, a failing integration test would be the least of our worries.
- Decreased the number of Satoshi's by a magnitude of 10 (now 0.0001BTC).
- Cleaned up the integration test some (formatting and clearer comments etc), and
- Don't withdraw from the faucet _every_ time.
