### PR TITLE
Transaction tests

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -39,7 +39,6 @@ Transaction.prototype.addInput = function(tx, index, sequence) {
 
   if (typeof tx === 'string') {
     hash = new Buffer(tx, 'hex')
-    assert.equal(hash.length, 32, 'Expected Transaction, txId or txHash, got ' + tx)
 
     // TxId hex is big-endian, we need little-endian
     Array.prototype.reverse.call(hash)
@@ -48,10 +47,11 @@ Transaction.prototype.addInput = function(tx, index, sequence) {
     hash = tx.getHash()
 
   } else {
-    assert(Buffer.isBuffer(tx), 'Expected Transaction, txId or txHash, got ' + tx)
     hash = tx
   }
 
+  assert(Buffer.isBuffer(hash), 'Expected Transaction, txId or txHash, got ' + tx)
+  assert.equal(hash.length, 32, 'Expected hash length of 32, got ' + hash.length)
   assert.equal(typeof index, 'number', 'Expected number index, got ' + index)
 
   return (this.ins.push({

--- a/test/fixtures/transaction.json
+++ b/test/fixtures/transaction.json
@@ -166,6 +166,18 @@
     }
   ],
   "invalid": {
+    "addInput": [
+      {
+        "exception": "Expected hash length of 32, got 30",
+        "hash": "0aed1366a73b6057ee7800d737bff1bdf8c448e98d86bc0998f2b009816d",
+        "index": 0
+      },
+      {
+        "exception": "Expected hash length of 32, got 34",
+        "hash": "0aed1366a73b6057ee7800d737bff1bdf8c448e98d86bc0998f2b009816da9b0ffff",
+        "index": 0
+      }
+    ],
     "fromBuffer": [
       {
         "exception": "Transaction has unexpected data",

--- a/test/transaction.js
+++ b/test/transaction.js
@@ -113,6 +113,17 @@ describe('Transaction', function() {
         })
       })
     })
+
+    fixtures.invalid.addInput.forEach(function(f) {
+      it('throws on ' + f.exception, function() {
+        var tx = new Transaction()
+        var hash = new Buffer(f.hash, 'hex')
+
+        assert.throws(function() {
+          tx.addInput(hash, f.index)
+        }, new RegExp(f.exception))
+      })
+    })
   })
 
   describe('addOutput', function() {


### PR DESCRIPTION
This pull request adds data driven tests for `Transaction`.
It also re-adds `getHash` as an operation on `Transaction`, and moves the constants to the `Transaction` object for public access.
