### PR TITLE
Wallet fee & utxo fixups

### DIFF
--- a/src/wallet.js
+++ b/src/wallet.js
@@ -175,7 +175,13 @@ function Wallet(seed, network) {
 
       var output = txinId + ':' + txIn.index
 
-      if(me.outputs[output]) delete me.outputs[output]
+      if (!(output in me.outputs)) return
+
+      if (isPending) {
+        return me.outputs[output].pending = true
+      }
+
+      delete me.outputs[output]
     })
   }
 

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -264,11 +264,34 @@ describe('Wallet', function() {
     })
 
     describe("processPendingTx", function(){
-      it("sets the pending flag on output", function(){
+      it("incoming: sets the pending flag on output", function(){
         wallet.addresses = [addresses[0]]
         wallet.processPendingTx(tx)
 
         verifyOutputAdded(0, true)
+      })
+
+      describe("when tx ins outpoint contains a known txhash:i", function(){
+        var spendTx
+        beforeEach(function(){
+          wallet.addresses = [addresses[0]]
+          wallet.processConfirmedTx(tx)
+
+          spendTx = Transaction.fromHex(fixtureTx2Hex)
+        })
+
+        it("outgoing: sets the pending flag on output instead of deleting it", function(){
+          var txIn = spendTx.ins[0]
+          var txInId = new Buffer(txIn.hash)
+          Array.prototype.reverse.call(txInId)
+          txInId = txInId.toString('hex')
+
+          var key = txInId + ':' + txIn.index
+          assert(!wallet.outputs[key].pending)
+
+          wallet.processPendingTx(spendTx)
+          assert(wallet.outputs[key].pending)
+        })
       })
     })
 


### PR DESCRIPTION
- `utxo.receive` renamed to `utxo.from`
- `getUnspentOutputs` now includes the `pending` field
- do not overestimate fees when `network` has `dustSoftThreshold`

`estimateFeePadChangeOutput` was adding an output with amount zero, which works for bitcoin as it does not care about the amount when estimating tx fee. It causes a consistent overestimation when it comes to networks with a soft dust threshold used for applying additional fees when the output amount is below that threshold. 

Now with the proposed modification there's a chance that we could be underestimating -- when the change amount happens to fall below the soft dust threshold. But for lite & doge the slight underestimation is acceptable?
