### PR TITLE
ECKey: adds tests for makeRandom

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "bigi": "1.1.0",
     "crypto-js": "3.1.2-3",
     "ecurve": "0.10.0",
-    "secure-random": "0.2.1"
+    "secure-random": "1.0.0"
   }
 }

--- a/src/eckey.js
+++ b/src/eckey.js
@@ -43,9 +43,11 @@ ECKey.fromWIF = function(string) {
 }
 
 ECKey.makeRandom = function(compressed, rng) {
-  rng = rng || secureRandom
+  rng = rng || secureRandom.randomBuffer
 
-  var buffer = new Buffer(rng(32))
+  var buffer = rng(32)
+  assert(Buffer.isBuffer(buffer), 'Expected Buffer, got ' + buffer)
+
   var d = BigInteger.fromBuffer(buffer)
   d = d.mod(curve.n)
 


### PR DESCRIPTION
This pull request adds tests for `ECKey.makeRandom`, which has previously not been under appropriate test.
It uses a stubbed RNG as the `secure-random` RNG is not the focus of this test.

`secure-random` was also upgraded to version `1.0.0` to use `randomBuffer`.
