### PR TITLE
message: return base64 for sign, make verify work with base64 string

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -31,18 +31,21 @@ function sign(privKey, message, network) {
   var e = BigInteger.fromBuffer(hash)
   var i = ecdsa.calcPubKeyRecoveryParam(ecparams, e, signature, privKey.pub.Q)
 
-  return signature.toCompact(i, privKey.pub.compressed)
+  return signature.toCompact(i, privKey.pub.compressed).toString('base64')
 }
 
 // TODO: network could be implied from address
-function verify(address, signatureBuffer, message, network) {
+function verify(address, signature, message, network) {
+  if(!Buffer.isBuffer(signature))
+    var signature = new Buffer(signature, 'base64')
+
   if (address instanceof Address) {
     address = address.toString()
   }
   network = network || networks.bitcoin
 
   var hash = magicHash(message, network)
-  var parsed = ECSignature.parseCompact(signatureBuffer)
+  var parsed = ECSignature.parseCompact(signature)
   var e = BigInteger.fromBuffer(hash)
   var Q = ecdsa.recoverPubKey(ecparams, e, parsed.signature, parsed.i)
 

--- a/test/message.js
+++ b/test/message.js
@@ -34,11 +34,10 @@ describe('Message', function() {
       it('verifies a valid signature for \"' + f.message + '\" (' + f.network + ')', function() {
         var network = networks[f.network]
 
-        var signature = new Buffer(f.signature, 'base64')
-        assert.ok(Message.verify(f.address, signature, f.message, network))
+        assert.ok(Message.verify(f.address, f.signature, f.message, network))
 
         if (f.compressed) {
-          var compressedSignature = new Buffer(f.compressed.signature, 'base64')
+          var compressedSignature = f.compressed.signature
 
           assert.ok(Message.verify(f.compressed.address, compressedSignature, f.message, network))
         }


### PR DESCRIPTION
This PR is related to #217.

This returns a base64 signature for Message.sign, and allows verify to work with a base64 string (or a buffer). It's using the existing test suite and fixtures.

I'm more than a little confused about the standardization around base64 here, but it does seem to be the convention for everyone using it. Noteworthy is that we actually reduce test code because the fixture signatures are in base64.

We could also make a helper function (ala `signBase64`) instead, if we preferred to return a buffer here. But we should definitely provide an easy way for people to do this, since it seems to be common usage.
