### PR TITLE
wallet: reintroduce output.to to track pending spent utxo

### DIFF
--- a/src/wallet.js
+++ b/src/wallet.js
@@ -65,7 +65,7 @@ function Wallet(seed, network) {
 
     for(var key in this.outputs){
       var output = this.outputs[key]
-      utxo.push(outputToUnspentOutput(output))
+      if(!output.to) utxo.push(outputToUnspentOutput(output))
     }
 
     return utxo
@@ -167,7 +167,7 @@ function Wallet(seed, network) {
       }
     })
 
-    tx.ins.forEach(function(txIn) {
+    tx.ins.forEach(function(txIn, i) {
       // copy and convert to big-endian hex
       var txinId = new Buffer(txIn.hash)
       Array.prototype.reverse.call(txinId)
@@ -178,10 +178,11 @@ function Wallet(seed, network) {
       if (!(output in me.outputs)) return
 
       if (isPending) {
-        return me.outputs[output].pending = true
+        me.outputs[output].to = txid + ':' + i
+        me.outputs[output].pending = true
+      } else {
+        delete me.outputs[output]
       }
-
-      delete me.outputs[output]
     })
   }
 

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -215,6 +215,13 @@ describe('Wallet', function() {
       it('parses wallet outputs to the expect format', function(){
         assert.deepEqual(wallet.getUnspentOutputs(), [expectedUtxo])
       })
+
+      it("ignores pending spending outputs (outputs with 'to' property)", function(){
+        var output = wallet.outputs[expectedOutputKey]
+        output.to = fakeTxId(0) + ':' + 0
+        output.pending = true
+        assert.deepEqual(wallet.getUnspentOutputs(), [])
+      })
     })
 
     describe('setUnspentOutputs', function(){
@@ -280,7 +287,7 @@ describe('Wallet', function() {
           spendTx = Transaction.fromHex(fixtureTx2Hex)
         })
 
-        it("outgoing: sets the pending flag on output instead of deleting it", function(){
+        it("outgoing: sets the pending flag and 'to' on output", function(){
           var txIn = spendTx.ins[0]
           var txInId = new Buffer(txIn.hash)
           Array.prototype.reverse.call(txInId)
@@ -291,6 +298,7 @@ describe('Wallet', function() {
 
           wallet.processPendingTx(spendTx)
           assert(wallet.outputs[key].pending)
+          assert.equal(wallet.outputs[key].to, spendTx.getId() + ':' + 0)
         })
       })
     })


### PR DESCRIPTION
By simply marking an utxo as pending makes it impossible to differentiate incoming and outgoing pending utxos, which leads to erroneous results for `getBalance`. This PR fixes that by attaching the `to` property to a pending spending utxo. 

`getUnspentOutputs` excludes such pending spending utxos because from a wallet point view, it should be able to trust spending transactions created by itself, and exclude any pending spent utxo from **unspent** transaction outputs. 
