### PR TITLE
HDNode / BIP32 Neutering

### DIFF
--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -157,7 +157,13 @@ HDNode.prototype.toBase58 = function(isPrivate) {
 }
 
 HDNode.prototype.toBuffer = function(isPrivate) {
-  if (isPrivate == undefined) isPrivate = !!this.privKey
+  if (isPrivate == undefined) {
+    isPrivate = !!this.privKey
+
+  // FIXME: remove in 2.x.y
+  } else {
+    console.warn('isPrivate flag is deprecated, please use the .neutered() method instead')
+  }
 
   // Version
   var version = isPrivate ? this.network.bip32.private : this.network.bip32.public
@@ -183,6 +189,7 @@ HDNode.prototype.toBuffer = function(isPrivate) {
 
   // 33 bytes: the public key or private key data
   if (isPrivate) {
+    // FIXME: remove in 2.x.y
     assert(this.privKey, 'Missing private key')
 
     // 0x00 + k for private keys

--- a/test/hdnode.js
+++ b/test/hdnode.js
@@ -88,9 +88,9 @@ describe('HDNode', function() {
   describe('toBase58', function() {
     fixtures.valid.forEach(function(f) {
       it('exports ' + f.master.base58 + ' (public) correctly', function() {
-        var hd = HDNode.fromSeedHex(f.master.seed)
+        var hd = HDNode.fromSeedHex(f.master.seed).neutered()
 
-        assert.equal(hd.toBase58(false), f.master.base58)
+        assert.equal(hd.toBase58(), f.master.base58)
       })
     })
 
@@ -98,10 +98,11 @@ describe('HDNode', function() {
       it('exports ' + f.master.base58Priv + ' (private) correctly', function() {
         var hd = HDNode.fromSeedHex(f.master.seed)
 
-        assert.equal(hd.toBase58(true), f.master.base58Priv)
+        assert.equal(hd.toBase58(), f.master.base58Priv)
       })
     })
 
+    // FIXME: remove in 2.x.y
     it('fails when there is no private key', function() {
       var hd = HDNode.fromBase58(fixtures.valid[0].master.base58)
 
@@ -166,9 +167,9 @@ describe('HDNode', function() {
   describe('toBuffer/toHex', function() {
     fixtures.valid.forEach(function(f) {
       it('exports ' + f.master.hex + ' (public) correctly', function() {
-        var hd = HDNode.fromSeedHex(f.master.seed)
+        var hd = HDNode.fromSeedHex(f.master.seed).neutered()
 
-        assert.equal(hd.toHex(false), f.master.hex)
+        assert.equal(hd.toHex(), f.master.hex)
       })
     })
 
@@ -176,10 +177,11 @@ describe('HDNode', function() {
       it('exports ' + f.master.hexPriv + ' (private) correctly', function() {
         var hd = HDNode.fromSeedHex(f.master.seed)
 
-        assert.equal(hd.toHex(true), f.master.hexPriv)
+        assert.equal(hd.toHex(), f.master.hexPriv)
       })
     })
 
+    // FIXME: remove in 2.x.y
     it('fails when there is no private key', function() {
       var hd = HDNode.fromHex(fixtures.valid[0].master.hex)
 


### PR DESCRIPTION
This pull request adds BIP32 style neutering of nodes by re-creating a node with all the private key information stripped.
This is useful for when you want to distinctly store or transport a `HDnode` without exporting it publicly then re-importing it as can be seen in af47371.
