### PR TITLE
Standalone browserify bundle to expose API dependencies

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,9 +1,8 @@
-var bitcoin = require('./src/index')
+var bitcoin = require('../')
 
 var exports = {
   BigInteger: require('bigi'),
-  ecurve: require('ecurve'),
-  secureRandom: require('secure-random')
+  ecurve: require('ecurve')
 }
 
 for (var key in bitcoin) {

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "files": "test/*.js"
   },
   "scripts": {
-    "compile": "browserify ./src/index.js -s bitcoin | uglifyjs > bitcoinjs-min.js",
-    "compile-bundle": "browserify ./bundle.js -s bitcoin | uglifyjs > bitcoinjs-bundle-min.js",
+    "compile": "browserify ./dist/index.js -s bitcoin | uglifyjs > dist/bitcoinjs-min.js",
     "coverage": "istanbul cover _mocha -- test/*.js",
     "coveralls": "npm run-script coverage && coveralls < coverage/lcov.info",
     "integration": "mocha --reporter list test/integration/*.js",


### PR DESCRIPTION
Continuation of #231, with a focus on the _bundle_ aspect of the discussion.  This is for exposing API dependencies for standalone browserify users.
