### PR TITLE
Updated License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,21 @@
-Copyright (c) 2011 Stefan Thomas
+The MIT License (MIT)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2011-2014 Bitcoinjs-lib contributors
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ console.log(tx.toHex())
 
 ``` javascript
 var bitcoin = require('bitcoinjs-lib')
- 
+
 var privKeys = [bitcoin.ECKey.makeRandom(), bitcoin.ECKey.makeRandom(), bitcoin.ECKey.makeRandom()]
 var pubKeys = privKeys.map(function(x) { return x.pub })
- 
+
 var redeemScript = bitcoin.scripts.multisigOutput(2, pubKeys) // 2 of 3
 var scriptPubKey = bitcoin.scripts.scriptHashOutput(redeemScript.getHash())
- 
+
 var multisigAddress = bitcoin.Address.fromOutputScript(scriptPubKey).toString()
 
 console.log("multisigP2SH:", multisigAddress)
@@ -138,7 +138,7 @@ console.log("multisigP2SH:", multisigAddress)
 - [Dogechain Wallet](https://dogechain.info)
 - [GreenAddress](https://greenaddress.it)
 - [DecentralBank](http://decentralbank.com)
- 
+
 ## Contributors
 
 Stefan Thomas is the inventor and creator of this project. His pioneering work made Bitcoin web wallets possible.
@@ -174,6 +174,7 @@ Please make your best effort to adhere to these when contributing to save on tri
 - [Bitcore](https://github.com/bitpay/bitcore)
 - [Cryptocoin](https://github.com/cryptocoinjs/cryptocoin)
 
+
 ## License
 
 This library is free and open-source software released under the MIT license.
@@ -181,5 +182,5 @@ This library is free and open-source software released under the MIT license.
 
 ## Copyright
 
-BitcoinJS (c) 2011-2012 Stefan Thomas
+BitcoinJS (c) 2011-2014 Bitcoinjs-lib contributors
 Released under MIT license


### PR DESCRIPTION
As per #254, this pull request updates the copyright date for this library up to 2014.
However this pull request also updates the copyright holders to be inclusive of all contributed works to the bitcoinjs-lib library throughout this period.

This should be acceptable as @justmoon's copyright notice would still be in effect for the work he originally contributed throughout 2011 and after; while recognizing new authors/contributors.

It also formats the LICENSE to be a bit more readable in its raw form.
