### PR TITLE
Address.fromOutputScript for pubkey script

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
 var base58check = require('bs58check')
+var ECPubKey = require('./ecpubkey')
 var networks = require('./networks')
 var scripts = require('./scripts')
 
@@ -37,6 +38,7 @@ Address.fromOutputScript = function(script, network) {
 
   if (type === 'pubkeyhash') return new Address(script.chunks[2], network.pubKeyHash)
   if (type === 'scripthash') return new Address(script.chunks[1], network.scriptHash)
+  if (type === 'pubkey') return ECPubKey.fromBuffer(script.chunks[0]).getAddress(network)
 
   assert(false, type + ' has no matching Address')
 }


### PR DESCRIPTION
Support obsolete pay-to-pubkey transactions
Probably need tests, but if just add script to address fixtures it's break toOutputScript tests
