### PR TITLE
Wallet test fixes

### DIFF
--- a/test/wallet.js
+++ b/test/wallet.js
@@ -633,9 +633,11 @@ describe('Wallet', function() {
         })
 
         it('skips change if it is not above dust threshold', function() {
-          var fee = 14570
-          var tx = wallet.createTx(to, value)
-          assert.equal(tx.outs.length, 1)
+          var tx1 = wallet.createTx(to, value - 546)
+          assert.equal(tx1.outs.length, 1)
+
+          var tx2 = wallet.createTx(to, value - 547)
+          assert.equal(tx2.outs.length, 2)
         })
       })
     })


### PR DESCRIPTION
As per the suggestion in #247, ~~this PR removes the use of `sinon` in `Transaction` and instead tests that the `Transaction` is exactly as it should be since the hash is deterministic.~~

It also makes a few fixes thanks to jshint and re-works a test in `Wallet` which was not testing the desired behaviour. 
