### PR TITLE
Makeshift instanceof: check constructor function name instead

### DIFF
--- a/src/ecdsa.js
+++ b/src/ecdsa.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
 var crypto = require('./crypto')
+var getClass = require('./getclass')
 
 var BigInteger = require('bigi')
 var ECSignature = require('./ecsignature')
@@ -8,7 +9,7 @@ var ECSignature = require('./ecsignature')
 function deterministicGenerateK(curve, hash, d) {
   assert(Buffer.isBuffer(hash), 'Hash must be a Buffer, not ' + hash)
   assert.equal(hash.length, 32, 'Hash must be 256 bit')
-  assert(d instanceof BigInteger, 'Private key must be a BigInteger')
+  assert.equal(getClass(d), "BigInteger", 'Private key must be a BigInteger')
 
   var x = d.toBuffer(32)
   var k = new Buffer(32)

--- a/src/ecpubkey.js
+++ b/src/ecpubkey.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var crypto = require('./crypto')
 var ecdsa = require('./ecdsa')
+var getClass = require('./getclass')
 var networks = require('./networks')
 
 var Address = require('./address')
@@ -9,7 +10,7 @@ var ecurve = require('ecurve')
 var curve = ecurve.getCurveByName('secp256k1')
 
 function ECPubKey(Q, compressed) {
-  assert(Q instanceof ecurve.Point, 'Expected Point, got ' + Q)
+  assert.equal(getClass(Q), "Point", 'Expected Point, got ' + Q)
 
   if (compressed == undefined) compressed = true
   assert.strictEqual(typeof compressed, 'boolean', 'Expected boolean, got ' + compressed)

--- a/src/ecsignature.js
+++ b/src/ecsignature.js
@@ -1,9 +1,10 @@
 var assert = require('assert')
+var getClass = require('./getclass')
 var BigInteger = require('bigi')
 
 function ECSignature(r, s) {
-  assert(r instanceof BigInteger, 'Expected BigInteger, got ' + r)
-  assert(s instanceof BigInteger, 'Expected BigInteger, got ' + s)
+  assert.equal(getClass(r), "BigInteger", 'Expected BigInteger, got ' + r)
+  assert.equal(getClass(s), "BigInteger", 'Expected BigInteger, got ' + s)
   this.r = r
   this.s = s
 }

--- a/src/getclass.js
+++ b/src/getclass.js
@@ -1,0 +1,3 @@
+module.exports = function (obj){
+  return obj.constructor.toString().match(/function (.*)\(/)[1]
+}

--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var base58check = require('bs58check')
 var crypto = require('./crypto')
+var getClass = require('./getclass')
 var networks = require('./networks')
 
 var BigInteger = require('bigi')
@@ -39,7 +40,7 @@ function HDNode(K, chainCode, network) {
   this.index = 0
   this.network = network
 
-  if (K instanceof BigInteger) {
+  if (getClass(K) === "BigInteger") {
     this.privKey = new ECKey(K, true)
     this.pubKey = this.privKey.pub
   } else {

--- a/src/message.js
+++ b/src/message.js
@@ -4,6 +4,7 @@ var BigInteger = require('bigi')
 var bufferutils = require('./bufferutils')
 var crypto = require('./crypto')
 var ecdsa = require('./ecdsa')
+var getClass = require('./getclass')
 var networks = require('./networks')
 
 var Address = require('./address')
@@ -40,7 +41,7 @@ function verify(address, signature, message, network) {
     signature = new Buffer(signature, 'base64')
   }
 
-  if (address instanceof Address) {
+  if (getClass(address) === "Address") {
     address = address.toString()
   }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+var getClass = require('./getclass')
 var opcodes = require('./opcodes')
 
 // FIXME: use ECPubKey, currently the circular dependency breaks everything.
@@ -18,7 +19,7 @@ var ECSignature = require('./ecsignature')
 var Script = require('./script')
 
 function classifyOutput(script) {
-  assert(script instanceof Script, 'Expected Script, got ', script)
+  assert.equal(getClass(script), "Script", 'Expected Script, got ', script)
 
   if (isPubKeyHashOutput.call(script)) {
     return 'pubkeyhash'
@@ -36,7 +37,7 @@ function classifyOutput(script) {
 }
 
 function classifyInput(script) {
-  assert(script instanceof Script, 'Expected Script, got ', script)
+  assert(getClass(script), ".equalScript", 'Expected Script, got ', script)
 
   if (isPubKeyHashInput.call(script)) {
     return 'pubkeyhash'

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var bufferutils = require('./bufferutils')
 var crypto = require('./crypto')
+var getClass = require('./getclass')
 var opcodes = require('./opcodes')
 var scripts = require('./scripts')
 
@@ -40,7 +41,7 @@ Transaction.prototype.addInput = function(tx, index, sequence) {
     // TxId hex is big-endian, we need little-endian
     hash = bufferutils.reverse(new Buffer(tx, 'hex'))
 
-  } else if (tx instanceof Transaction) {
+  } else if (getClass(tx) === "Transaction") {
     hash = tx.getHash()
 
   } else {
@@ -77,11 +78,11 @@ Transaction.prototype.addOutput = function(scriptPubKey, value) {
   }
 
   // Attempt to get a valid script if it's an Address object
-  if (scriptPubKey instanceof Address) {
+  if (getClass(scriptPubKey) === "Address") {
     scriptPubKey = scriptPubKey.toOutputScript()
   }
 
-  assert(scriptPubKey instanceof Script, 'Expected Address or Script, got ' + scriptPubKey)
+  assert.equal(getClass(scriptPubKey), "Script", 'Expected Address or Script, got ' + scriptPubKey)
   assert(isFinite(value), 'Expected number value, got ' + value)
 
   // Add the output and return the output's index
@@ -163,7 +164,7 @@ Transaction.prototype.toHex = function() {
  */
 Transaction.prototype.hashForSignature = function(inIndex, prevOutScript, hashType) {
   // FIXME: remove in 2.x.y
-  if (arguments[0] instanceof Script) {
+  if (getClass(arguments[0]) === "Script") {
     console.warn('hashForSignature(prevOutScript, inIndex, ...) has been deprecated. Use hashForSignature(inIndex, prevOutScript, ...)')
 
     // swap the arguments (must be stored in tmp, arguments is special)
@@ -174,7 +175,7 @@ Transaction.prototype.hashForSignature = function(inIndex, prevOutScript, hashTy
 
   assert(inIndex >= 0, 'Invalid vin index')
   assert(inIndex < this.ins.length, 'Invalid vin index')
-  assert(prevOutScript instanceof Script, 'Invalid Script object')
+  assert.equal(getClass(prevOutScript), "Script", 'Invalid Script object')
 
   var txTmp = this.clone()
   var hashScript = prevOutScript.without(opcodes.OP_CODESEPARATOR)

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+var getClass = require('./getclass')
 var scripts = require('./scripts')
 
 var ECPubKey = require('./ecpubkey')
@@ -112,7 +113,7 @@ TransactionBuilder.prototype.addInput = function(prevTx, index, sequence, prevOu
     // TxId hex is big-endian, we want little-endian hash
     Array.prototype.reverse.call(prevOutHash)
 
-  } else if (prevTx instanceof Transaction) {
+  } else if (getClass(prevTx) === "Transaction") {
     prevOutHash = prevTx.getHash()
     prevOutScript = prevTx.outs[index].script
 

--- a/test/getclass.js
+++ b/test/getclass.js
@@ -1,0 +1,19 @@
+var assert = require('assert')
+var ecurve = require('ecurve')
+var curve = ecurve.getCurveByName('secp256k1')
+var getClass = require('../src/getclass')
+
+var BigInteger = require('bigi')
+var ECKey = require('../src/eckey')
+
+describe('getClass', function() {
+  it("returns the name of the object's constructor function", function() {
+    assert.equal(getClass(ECKey.makeRandom()), "ECKey")
+    assert.equal(getClass(BigInteger.ZERO), "BigInteger")
+  })
+
+  it("does not include the namespace", function() {
+    var point = new ecurve.Point(curve, BigInteger.ONE, BigInteger.ONE, BigInteger.ONE)
+    assert.equal(getClass(point), "Point")
+  })
+})


### PR DESCRIPTION
Based on discussions in #255, #274, #231 and IRC, my conclusion is that proper duck typing seems too verbose and not checking types at all seems too dangerous. This is my attempt at finding a middle ground. 
