### PR TITLE
No more Address object

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -1,64 +1,54 @@
 var assert = require('assert')
 var base58check = require('bs58check')
-var enforceType = require('./types')
 var networks = require('./networks')
 var scripts = require('./scripts')
 
-function findScriptTypeByVersion(version) {
-  for (var networkName in networks) {
-    var network = networks[networkName]
-
-    if (version === network.pubKeyHash) return 'pubkeyhash'
-    if (version === network.scriptHash) return 'scripthash'
-  }
-}
-
-function Address(hash, version) {
-  enforceType('Buffer', hash)
-
-  assert.strictEqual(hash.length, 20, 'Invalid hash length')
-  assert.strictEqual(version & 0xff, version, 'Invalid version byte')
-
-  this.hash = hash
-  this.version = version
-}
-
-Address.fromBase58Check = function(string) {
-  var payload = base58check.decode(string)
-  var version = payload.readUInt8(0)
-  var hash = payload.slice(1)
-
-  return new Address(hash, version)
-}
-
-Address.fromOutputScript = function(script, network) {
+function fromOutputScript(script, network) {
   network = network || networks.bitcoin
 
   var type = scripts.classifyOutput(script)
+  var version
+  var hash
 
-  if (type === 'pubkeyhash') return new Address(script.chunks[2], network.pubKeyHash)
-  if (type === 'scripthash') return new Address(script.chunks[1], network.scriptHash)
+  if (type === 'pubkeyhash') {
+    version = network.pubKeyHash
+    hash = script.chunks[2]
 
-  assert(false, type + ' has no matching Address')
-}
+  } else if (type === 'scripthash') {
+    version = network.scriptHash
+    hash = script.chunks[1]
 
-Address.prototype.toBase58Check = function () {
+  } else {
+    assert(false, type + ' has no matching Address')
+  }
+
   var payload = new Buffer(21)
-  payload.writeUInt8(this.version, 0)
-  this.hash.copy(payload, 1)
+  payload.writeUInt8(version, 0)
+  hash.copy(payload, 1)
 
   return base58check.encode(payload)
 }
 
-Address.prototype.toOutputScript = function() {
-  var scriptType = findScriptTypeByVersion(this.version)
+function toOutputScript(address) {
+  var payload = base58check.decode(address)
+  var version = payload.readUInt8(0)
+  var hash = payload.slice(1)
 
-  if (scriptType === 'pubkeyhash') return scripts.pubKeyHashOutput(this.hash)
-  if (scriptType === 'scripthash') return scripts.scriptHashOutput(this.hash)
+  for (var networkName in networks) {
+    var network = networks[networkName]
 
-  assert(false, this.toString() + ' has no matching Script')
+    if (version === network.pubKeyHash) {
+      return scripts.pubKeyHashOutput(hash)
+
+    } else if (version === network.scriptHash) {
+      return scripts.scriptHashOutput(hash)
+    }
+  }
+
+  assert(false, address + ' has no matching Script')
 }
 
-Address.prototype.toString = Address.prototype.toBase58Check
-
-module.exports = Address
+module.exports = {
+  fromOutputScript: fromOutputScript,
+  toOutputScript: toOutputScript
+}

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -7,7 +7,6 @@ var ecurve = require('ecurve')
 var enforceType = require('./types')
 var networks = require('./networks')
 
-var Address = require('./address')
 var BigInteger = require('bigi')
 
 function findNetworkByWIFVersion(version) {
@@ -120,8 +119,14 @@ ECPair.prototype.toWIF = function() {
 
 ECPair.prototype.getAddress = function() {
   var pubKey = this.getPublicKeyBuffer()
+  var hash = bcrypto.hash160(pubKey)
+  var version = this.network.pubKeyHash
 
-  return new Address(bcrypto.hash160(pubKey), this.network.pubKeyHash)
+  var payload = new Buffer(21)
+  payload.writeUInt8(version, 0)
+  hash.copy(payload, 1)
+
+  return base58check.encode(payload)
 }
 
 ECPair.prototype.getPublicKeyBuffer = function() {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -150,14 +150,9 @@ Transaction.prototype.addOutput = function(scriptPubKey, value) {
     return (signature.hashType & 0x1f) === RawTransaction.SIGHASH_SINGLE
   }), 'No, this would invalidate signatures')
 
-  // Attempt to get a valid address if it's a base58 address string
+  // Attempt to get a valid script if it's a base58 address
   if (typeof scriptPubKey === 'string') {
-    scriptPubKey = Address.fromBase58Check(scriptPubKey)
-  }
-
-  // Attempt to get a valid script if it's an Address object
-  if (scriptPubKey instanceof Address) {
-    scriptPubKey = scriptPubKey.toOutputScript()
+    scriptPubKey = Address.toOutputScript(scriptPubKey)
   }
 
   return this.tx.addOutput(scriptPubKey, value)
@@ -246,7 +241,7 @@ Transaction.prototype.sign = function(index, keyPair, redeemScript, hashType) {
     hash = this.tx.hashForSignature(index, redeemScript, hashType)
 
   } else {
-    prevOutScript = prevOutScript || keyPair.getAddress().toOutputScript()
+    prevOutScript = prevOutScript || Address.toOutputScript(keyPair.getAddress())
     prevOutType = prevOutType || 'pubkeyhash'
 
     assert.notEqual(prevOutType, 'scripthash', 'PrevOutScript is P2SH, missing redeemScript')

--- a/test/address.js
+++ b/test/address.js
@@ -7,45 +7,13 @@ var Script = require('../src/script')
 var fixtures = require('./fixtures/address.json')
 
 describe('Address', function() {
-  describe('Constructor', function() {
-    it('does not mutate the input', function() {
-      fixtures.valid.forEach(function(f) {
-        var hash = new Buffer(f.hex, 'hex')
-        var addr = new Address(hash, f.version)
-
-        assert.equal(addr.version, f.version)
-        assert.equal(addr.hash.toString('hex'), f.hex)
-      })
-    })
-  })
-
-  describe('fromBase58Check', function() {
-    fixtures.valid.forEach(function(f) {
-      it('imports ' + f.description + '(' + f.network + ') correctly', function() {
-        var addr = Address.fromBase58Check(f.base58check)
-
-        assert.equal(addr.version, f.version)
-        assert.equal(addr.hash.toString('hex'), f.hex)
-      })
-    })
-
-    fixtures.invalid.fromBase58Check.forEach(function(f) {
-      it('throws on ' + f.description, function() {
-        assert.throws(function() {
-          Address.fromBase58Check(f.base58check)
-        }, new RegExp(f.exception))
-      })
-    })
-  })
-
   describe('fromOutputScript', function() {
     fixtures.valid.forEach(function(f) {
       it('imports ' + f.description + '(' + f.network + ') correctly', function() {
         var script = Script.fromHex(f.script)
         var addr = Address.fromOutputScript(script, networks[f.network])
 
-        assert.equal(addr.version, f.version)
-        assert.equal(addr.hash.toString('hex'), f.hex)
+        assert.equal(addr, f.address)
       })
     })
 
@@ -60,22 +28,10 @@ describe('Address', function() {
     })
   })
 
-  describe('toBase58Check', function() {
-    fixtures.valid.forEach(function(f) {
-      it('exports ' + f.description + '(' + f.network + ') correctly', function() {
-        var addr = Address.fromBase58Check(f.base58check)
-        var result = addr.toBase58Check()
-
-        assert.equal(result, f.base58check)
-      })
-    })
-  })
-
   describe('toOutputScript', function() {
     fixtures.valid.forEach(function(f) {
       it('imports ' + f.description + '(' + f.network + ') correctly', function() {
-        var addr = Address.fromBase58Check(f.base58check)
-        var script = addr.toOutputScript()
+        var script = Address.toOutputScript(f.address)
 
         assert.equal(script.toHex(), f.script)
       })
@@ -83,10 +39,8 @@ describe('Address', function() {
 
     fixtures.invalid.toOutputScript.forEach(function(f) {
       it('throws when ' + f.description, function() {
-        var addr = new Address(new Buffer(f.hex, 'hex'), f.version)
-
         assert.throws(function() {
-          addr.toOutputScript()
+          Address.toOutputScript(f.address)
         }, new RegExp(f.description))
       })
     })

--- a/test/bitcoin.core.js
+++ b/test/bitcoin.core.js
@@ -41,32 +41,25 @@ describe('Bitcoin-core', function() {
   })
 
   // base58_keys_valid
-  describe('Address', function() {
+  describe('bs58check', function() {
     base58_keys_valid.forEach(function(f) {
       var string = f[0]
       var hex = f[1]
       var params = f[2]
-      var network = networks.bitcoin
 
       if (params.isPrivkey) return
-      if (params.isTestnet) network = networks.testnet
 
-      it('can import ' + string, function() {
-        var address = Address.fromBase58Check(string)
+      it('can decode ' + string, function() {
+        var payload = base58check.decode(string)
+        var hash = payload.slice(1)
 
-        assert.equal(address.hash.toString('hex'), hex)
-        if (params.addrType === 'pubkey') {
-          assert.equal(address.version, network.pubKeyHash)
-
-        } else if (params.addrType === 'script') {
-          assert.equal(address.version, network.scriptHash)
-        }
+        assert.equal(hash.toString('hex'), hex)
       })
     })
   })
 
   // base58_keys_invalid
-  describe('Address', function() {
+  describe('bs58check', function() {
     var allowedNetworks = [
       networks.bitcoin.pubkeyhash,
       networks.bitcoin.scripthash,
@@ -79,9 +72,12 @@ describe('Bitcoin-core', function() {
 
       it('throws on ' + string, function() {
         assert.throws(function() {
-          var address = Address.fromBase58Check(string)
+          var payload = base58check.decode(string)
+          var version = payload[0]
+          var hash = payload.slice(1)
 
-          assert.notEqual(allowedNetworks.indexOf(address.version), -1, 'Invalid network')
+          assert.equal(hash.length, 20, 'Invalid hash length')
+          assert.notEqual(allowedNetworks.indexOf(version), -1, 'Invalid network')
         }, /Invalid (checksum|hash length|network)/)
       })
     })

--- a/test/fixtures/address.json
+++ b/test/fixtures/address.json
@@ -3,49 +3,29 @@
     {
       "description": "pubKeyHash",
       "network": "bitcoin",
-      "version": 0,
-      "hex": "751e76e8199196d454941c45d1b3a323f1433bd6",
-      "base58check": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
+      "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
       "script": "76a914751e76e8199196d454941c45d1b3a323f1433bd688ac"
     },
     {
       "description": "scriptHash",
       "network": "bitcoin",
-      "version": 5,
-      "hex": "cd7b44d0b03f2d026d1e586d7ae18903b0d385f6",
-      "base58check": "3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr",
+      "address": "3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr",
       "script": "a914cd7b44d0b03f2d026d1e586d7ae18903b0d385f687"
     },
     {
       "description": "pubKeyHash",
       "network": "testnet",
-      "version": 111,
-      "hex": "751e76e8199196d454941c45d1b3a323f1433bd6",
-      "base58check": "mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r",
+      "address": "mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r",
       "script": "76a914751e76e8199196d454941c45d1b3a323f1433bd688ac"
     },
     {
       "description": "scriptHash",
       "network": "testnet",
-      "version": 196,
-      "hex": "cd7b44d0b03f2d026d1e586d7ae18903b0d385f6",
-      "base58check": "2NByiBUaEXrhmqAsg7BbLpcQSAQs1EDwt5w",
+      "address": "2NByiBUaEXrhmqAsg7BbLpcQSAQs1EDwt5w",
       "script": "a914cd7b44d0b03f2d026d1e586d7ae18903b0d385f687"
     }
   ],
   "invalid": {
-    "fromBase58Check": [
-      {
-        "description": "hash too short",
-        "base58check": "7SeEnXWPaCCALbVrTnszCVGfRU8cGfx",
-        "exception": "Invalid hash length"
-      },
-      {
-        "description": "hash too long",
-        "base58check": "j9ywUkWg2fTQrouxxh5rSZhRvrjMkEUfuiKe",
-        "exception": "Invalid hash length"
-      }
-    ],
     "fromOutputScript": [
       {
         "description": "pubkey has no matching Address",
@@ -63,8 +43,7 @@
     "toOutputScript": [
       {
         "description": "24kPZCmVgzfkpGdXExy56234MRHrsqQxNWE has no matching Script",
-        "hex": "751e76e8199196d454941c45d1b3a323f1433bd6",
-        "version": 153
+        "address": "24kPZCmVgzfkpGdXExy56234MRHrsqQxNWE"
       }
     ]
   }

--- a/test/integration/p2sh.js
+++ b/test/integration/p2sh.js
@@ -46,7 +46,7 @@ describe('Bitcoin-js', function() {
       var spendAmount = Math.min(unspent.value, outputAmount)
 
       // make a random key pair
-      var targetAddress = ECPair.makeRandom({ network: networks.testnet }).getAddress().toString()
+      var targetAddress = ECPair.makeRandom({ network: networks.testnet }).getAddress()
 
       var txb = new Transaction()
       txb.addInput(unspent.txHash, unspent.index)

--- a/test/message.js
+++ b/test/message.js
@@ -1,7 +1,6 @@
 var assert = require('assert')
 var networks = require('../src/networks')
 
-var Address = require('../src/address')
 var BigInteger = require('bigi')
 var ECPair = require('../src/ecpair')
 var Message = require('../src/message')
@@ -25,8 +24,7 @@ describe('Message', function() {
       var f = fixtures.valid.verify[0]
       var network = networks[f.network]
 
-      var address = Address.fromBase58Check(f.address)
-      assert(Message.verify(address, f.signature, f.message, network))
+      assert(Message.verify(f.address, f.signature, f.message, network))
     })
 
     fixtures.valid.verify.forEach(function(f) {

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+var bs58check = require('bs58check')
 var scripts = require('../src/scripts')
 
 var Address = require('../src/address')
@@ -85,7 +86,8 @@ describe('Scripts', function() {
 
       describe('output script', function() {
         it('is generated correctly for ' + address, function() {
-          var scriptPubKey = scripts.pubKeyHashOutput(address.hash)
+          var hash = bs58check.decode(address).slice(1)
+          var scriptPubKey = scripts.pubKeyHashOutput(hash)
           assert.equal(scriptPubKey.toASM(), f.scriptPubKey)
         })
       })

--- a/test/transaction.js
+++ b/test/transaction.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var scripts = require('../src/scripts')
 
+var Address = require('../src/address')
 var BigInteger = require('bigi')
 var ECPair = require('../src/ecpair')
 var RawTransaction = require('../src/raw_transaction')
@@ -10,7 +11,7 @@ var Transaction = require('../src/transaction')
 var fixtures = require('./fixtures/transaction')
 
 describe('Transaction', function() {
-  var privAddress, privAddressBs58, privScript
+  var privAddress, privScript
   var prevTx, prevTxHash, prevTxId
   var keyPair
   var txb
@@ -28,8 +29,7 @@ describe('Transaction', function() {
 
     keyPair = new ECPair(BigInteger.ONE, null, { compressed: false })
     privAddress = keyPair.getAddress()
-    privAddressBs58 = privAddress.toString()
-    privScript = privAddress.toOutputScript()
+    privScript = Address.toOutputScript(privAddress)
     value = 10000
   })
 
@@ -90,15 +90,6 @@ describe('Transaction', function() {
 
   describe('addOutput', function() {
     it('accepts an address string and value', function() {
-      var vout = txb.addOutput(privAddressBs58, 1000)
-      assert.equal(vout, 0)
-
-      var txout = txb.tx.outs[0]
-      assert.deepEqual(txout.script, privScript)
-      assert.equal(txout.value, 1000)
-    })
-
-    it('accepts an Address object and value', function() {
       var vout = txb.addOutput(privAddress, 1000)
       assert.equal(vout, 0)
 


### PR DESCRIPTION
This is a `2.0.0` PR.
Chained on #290.

It removes the Address object maintaining the utility functions that it was mostly used for.
