### PR TITLE
Ignore Webstorm IDE related generated output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 bitcoinjs-min.js
 coverage
+.idea
+*.log


### PR DESCRIPTION
I'm using Webstorm for development. It tends to write output into the source directories. This ignores them.
