### PR TITLE
Brainwallet signature generation upgraded to latest bitcoinjs API

### DIFF
--- a/test/integration/brainwallet_bitcoinsig.js
+++ b/test/integration/brainwallet_bitcoinsig.js
@@ -10,37 +10,43 @@ var assert = require('assert');
 var Bitcoin = require('../../')
 var BigInteger = require('bigi');
 
-function sha256(b) {
-    return Bitcoin.crypto.sha256(b);
-}
 
-function bitcoinsig_test() {
+describe('bitcoin_sig', function() {
+
+    function sha256(b) {
+        return Bitcoin.crypto.sha256(b);
+    }
     var k = '5JeWZ1z6sRcLTJXdQEDdB986E6XfLAkj9CgNE4EHzr5GmjrVFpf';
     var a = '17mDAmveV5wBwxajBsY7g1trbMW1DVWcgL';
     var s = 'HDiv4Oe9SjM1FFVbKk4m3N34efYiRgkQGGoEm564ldYt44jHVTuX23+WnihNMi4vujvpUs1M529P3kftjDezn9E=';
     var m = 'test message';
 
     var secp256k1 = Bitcoin.ECKey.curve;
-
-    // Part un - Verify pre-signed message
-    var siginfo = new Bitcoin.ECSignature.parseCompact(new Buffer(s,"base64"));
-    //var hash = Bitcoin.Message.magicHash(m, Bitcoin.networks.bitcoin);
     var hash = Bitcoin.Message.magicHash(m, {magicPrefix: '\x18Bitcoin Signed Message:\n'});
-    assert.equal(hash.toString("base64"), "EiYXnd9jg/vPUQLJSSU4tyBsc5rnnrBkQIwqvWfTm+0=");
 
-    // Is there way to do this without pulling in BigInteger?
-    var e = BigInteger.fromBuffer(hash);
-    var pubkeyQ = Bitcoin.ecdsa.recoverPubKey(secp256k1, e, siginfo.signature, siginfo.i);
-    var pubkey = new Bitcoin.ECPubKey(pubkeyQ, siginfo.compressed);
-    assert.equal(pubkey.getAddress().toBase58Check(), a, "Extract pub address from signature should match pub addr");
-    var v1 = Bitcoin.ecdsa.verify(secp256k1, hash, siginfo.signature, pubkeyQ);
-    assert(v1, "Signature should pass");
-    // Part deux - do signing and reverify
-    var payload = Base58.decode(k);
-    var priv = Bitcoin.ECKey.fromWIF(k)
-    var sig = priv.sign(hash);
-    var v2 = Bitcoin.ecdsa.verify(secp256k1, hash, siginfo.signature, pubkeyQ);
-    assert(v2, "Signature should pass after re-signing")
-}
+    it('can verify a pre-signed message', function(done) {
+        // Part un - Verify pre-signed message
+        var siginfo = new Bitcoin.ECSignature.parseCompact(new Buffer(s, "base64"));
+        assert.equal(hash.toString("base64"), "EiYXnd9jg/vPUQLJSSU4tyBsc5rnnrBkQIwqvWfTm+0=");
+        // Is there way to do this without pulling in BigInteger?
+        var e = BigInteger.fromBuffer(hash);
+        var pubkeyQ = Bitcoin.ecdsa.recoverPubKey(secp256k1, e, siginfo.signature, siginfo.i);
+        var pubkey = new Bitcoin.ECPubKey(pubkeyQ, siginfo.compressed);
+        assert.equal(pubkey.getAddress().toBase58Check(), a, "Extract pub address from signature should match pub addr");
+        var v1 = Bitcoin.ecdsa.verify(secp256k1, hash, siginfo.signature, pubkeyQ);
+        assert(v1, "Signature should pass");
+        done();
+    });
 
-bitcoinsig_test();
+    it('can sign a message and verify the signed messaged', function(done) {
+        var payload = Base58.decode(k);
+        var priv = Bitcoin.ECKey.fromWIF(k)
+        var sig = priv.sign(hash);
+        var e = BigInteger.fromBuffer(hash);
+        var pubkeyQ = Bitcoin.ecdsa.recoverPubKey(secp256k1, e, sig, 1);
+        var v2 = Bitcoin.ecdsa.verify(secp256k1, hash, sig, pubkeyQ);
+        assert(v2, "Signature should pass after re-signing")
+        done();
+    })
+
+})


### PR DESCRIPTION
Per IRC discussion with @dcousens , an integration test to cover Brainwallet signature capability with latest API. Test case covers the previous discussed Ecurve dependency issue, which is now fixed in master.
