### PR TITLE
scripts: add dataOutput convenience function

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -241,9 +241,14 @@ function multisigInput(signatures, scriptPubKey) {
   return Script.fromChunks([].concat(ops.OP_0, signatures))
 }
 
+function dataOutput(data) {
+  return Script.fromChunks([ops.OP_RETURN, data])
+}
+
 module.exports = {
   classifyInput: classifyInput,
   classifyOutput: classifyOutput,
+  dataOutput: dataOutput,
   multisigInput: multisigInput,
   multisigOutput: multisigOutput,
   pubKeyHashInput: pubKeyHashInput,

--- a/test/fixtures/scripts.json
+++ b/test/fixtures/scripts.json
@@ -51,7 +51,8 @@
     },
     {
       "type": "nulldata",
-      "scriptPubKey": "OP_RETURN ffffffffffffffffffffffffffffffffffffffff"
+      "data": "deadffffffffffffffffffffffffffffffffbeef",
+      "scriptPubKey": "OP_RETURN deadffffffffffffffffffffffffffffffffbeef"
     }
   ],
   "invalid": {

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -184,4 +184,19 @@ describe('Scripts', function() {
       })
     })
   })
+
+  describe('data', function() {
+    fixtures.valid.forEach(function(f) {
+      if (f.type !== 'nulldata') return
+
+      var data = new Buffer(f.data, 'hex')
+      var scriptPubKey = scripts.dataOutput(data)
+
+      describe('output script', function() {
+        it('is generated correctly for ' + f.scriptPubKey, function() {
+          assert.equal(scriptPubKey.toASM(), f.scriptPubKey)
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
As the title says.

The script is very simple to build, so I'm not 100% whether this is necessary.

Example 1 (new method):

``` javascript
    var tx = new bitcoin.TransactionBuilder()

    var data = new Buffer('cafedeadbeef', 'hex')
    var dataScript = bitcoin.scripts.dataOutput(data)

    tx.addInput("aa94ab02c182214f090e99a0d57021caffd0f195a81c24602b1028b130b63e31", 0)
    tx.addOutput(dataScript, 1000)
    // ...
```

Example 2 (without this PR):

``` javascript
    var tx = new bitcoin.TransactionBuilder()

    var data = new Buffer('cafedeadbeef', 'hex')
    var dataScript = bitcoin.Script.fromChunks([bitcoin.opcodes.OP_RETURN, data])

    tx.addInput("aa94ab02c182214f090e99a0d57021caffd0f195a81c24602b1028b130b63e31", 0)
    tx.addOutput(dataScript, 1000)
    // ...
```

Personally, the second is as clear, but, I feel like the complexity surrounding this functionality is already high enough that perhaps this PR helps?
Thoughts?
