### PR TITLE
Integration test to reproduce same output as defaut Brainwallet page

### DIFF
--- a/test/integration/brainwallet.js
+++ b/test/integration/brainwallet.js
@@ -28,4 +28,20 @@ describe('bitcoinjs-lib (brainwallet examples)', function() {
 
     assert(bitcoin.Message.verify(address, signature, message))
   })
+
+    it('can generate same text as default Brainwallet page', function() {
+        // Open Brainwallet at https://brainwallet.github.io/
+        // and you'll see these strings
+
+        var hash = bitcoin.crypto.sha256('') // Empty passphrase
+        assert.equal (hash.toString('hex'),'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+        var d = bigi.fromBuffer(hash)
+        var eckey = new bitcoin.ECKey(d, false) // Uncompressed
+        var addr = eckey.pub.getAddress()
+
+        assert.equal(addr.toBase58Check(), '1HZwkjkeaoZfTSaJxDw6aKkxp45agDiEzN')
+        assert.equal(eckey.toWIF(), '5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss')
+        assert.equal(eckey.pub.toBuffer().toString('hex'), '04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235')
+        assert.equal(addr.hash.toString('hex'), 'b5bd079c4d57cc7fc28ecf8213a6b791625b8183')
+    })
 })


### PR DESCRIPTION
Expanding on @dcousens efforts in #302 to have useful and sensible integration tests
