### PR TITLE
Exposing Buffer into the browser build

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   Address: require('./address'),
   base58check: require('./base58check'),
+  Buffer: require('buffer').Buffer,
   bufferutils: require('./bufferutils'),
   crypto: require('./crypto'),
   ecdsa: require('./ecdsa'),


### PR DESCRIPTION
We're implementing multisig scripts, the logic is split between our backend and frontend. In the frontend, we need to use the `Buffer` to pass a `sighash` to `privKey.sign()` directly, and not via `transaction.sign()`. We don't have the whole transaction, just the `sighash` that needs to be signed, and sent back to the backend.

What do you think of exposing the Buffer like this?

Thanks
