### PR TITLE
added a helloblock integration test for OP_RETURN

### DIFF
--- a/test/integration/helloblock.js
+++ b/test/integration/helloblock.js
@@ -15,6 +15,57 @@ var helloblock = require('helloblock-js')({
 describe('bitcoinjs-lib (helloblock)', function() {
   this.timeout(20000)
 
+  it('can create, propagate, retrieve and read a message with an OP_RETURN transaction', function(done) {
+
+    helloblock.faucet.get(1, function(err, res, body) {
+      if (err) return done(err)
+
+      var key = bitcoin.ECKey.fromWIF(body.privateKeyWIF)
+      var address = body.address
+      var unspent = body.unspents[0]
+
+      // generate a random string and encode as a data output
+      var message = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5)
+      var data = new Buffer(message)
+      var dataScript = bitcoin.scripts.dataOutput(data)
+
+      var txb = new TransactionBuilder()
+      txb.addInput(unspent.txHash, unspent.index)
+      txb.addOutput(address, unspent.value - 100)
+      txb.addOutput(dataScript, 100)
+      txb.sign(0, key)
+
+      helloblock.transactions.propagate(txb.build().toHex(), function(err) {
+        // no err means that the transaction has been successfully propagated
+        if (err) return done(err)
+
+        // Check that the message was propagated
+        helloblock.addresses.getTransactions(address, function(err, res, transactions) {
+          if (err) return done(err)
+
+          var transaction = transactions[0]
+
+          var messageCheck
+
+          // Loop through the outputs and decode the message
+          var outputs = transaction.outputs
+          for (var j = outputs.length - 1; j >= 0; j--) {
+            var output = outputs[j]
+            var scriptPubKey = output.scriptPubKey
+            var scriptPubKeyBuffer = new Buffer(scriptPubKey, 'hex')
+            if (scriptPubKeyBuffer[0] == 106) {
+              var messageBuffer = scriptPubKeyBuffer.slice(2,scriptPubKeyBuffer.length)
+              messageCheck = messageBuffer.toString()
+            }
+          }
+
+          assert.equal(message, messageCheck)
+          done()
+        })
+      })
+    })
+  })
+
   it('can spend from a 2-of-2 address', function(done) {
     var privKeys = [
       '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',


### PR DESCRIPTION
I've created an integration test that creates a random message in a OP_RETURN, propagates the transaction, and then checks to see that it went through and decodes properly.

It uses a random 5 character string for the test and you can see them here: http://testnet.coinsecrets.org/

Lemme know what you think! I've tried to adhere to the code style as close as possible.
