### PR TITLE
integration: avoid excessive blockchain requests

### DIFF
--- a/test/integration/advanced.js
+++ b/test/integration/advanced.js
@@ -32,7 +32,7 @@ describe('bitcoinjs-lib (advanced)', function() {
         if (err) return done(err)
 
         var tx = new bitcoin.TransactionBuilder()
-        var data = new Buffer('cafedeadbeef', 'hex')
+        var data = new Buffer('bitcoinjs-lib')
         var dataScript = bitcoin.scripts.nullDataOutput(data)
 
         var unspent = unspents.pop()


### PR DESCRIPTION
This should fix the related integration test occasionally failing due to a timeout.
Currently 900+ transactions are returned unnecessarily.