### PR TITLE
TransactionBuilder P2SH Multisig order of signatures

### DIFF
--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -290,5 +290,32 @@ describe('TransactionBuilder', function() {
 
       assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd1c01004830450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a8014830450221009418caa5bc18da87b188a180125c0cf06dce6092f75b2d3c01a29493466800fd02206ead65e7ca6e0f17eefe6f78457c084eab59af7c9882be1437de2e7116358eb9014c8752410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
     })
+
+    it('works for the P2SH multisig case with signing out of order', function() {
+      // same test case as above but privKeys are in different order
+      var privKeys = [
+        "91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT",
+        "91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx"
+      ].map(ECKey.fromWIF)
+      // 2of2
+      var redeemScript = Script.fromASM("OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a OP_2 OP_CHECKMULTISIG")
+
+      txb.addInput("4971f016798a167331bcbc67248313fbc444c6e92e4416efd06964425588f5cf", 0)
+      txb.addOutput("1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH", 10000)
+      txb.sign(0, privKeys[0], redeemScript)
+
+      var tx = txb.buildIncomplete()
+
+      // in another galaxy...
+      // ... far, far away
+      var txb2 = TransactionBuilder.fromTransaction(tx)
+
+      // [you should] verify that Transaction is what you want...
+      // ... then sign it
+      txb2.sign(0, privKeys[1], redeemScript)
+      var tx2 = txb2.build()
+
+      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd1c01004830450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a8014830450221009418caa5bc18da87b188a180125c0cf06dce6092f75b2d3c01a29493466800fd02206ead65e7ca6e0f17eefe6f78457c084eab59af7c9882be1437de2e7116358eb9014c8752410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
+    })
   })
 })


### PR DESCRIPTION
When building a transaction the order of the signatures of a P2SH multisig should be the same as the order of their respective pubKey.

This PR fixes that by looping over the pubKeys in the `__build` and finding the signature that belongs to the pubKey (and 2 changes to make sure that the `input.pubKeys` is actually the correct list of pubKeys).

A problem however that I'm using  `pubKey.verify` calls to figure out which signature belongs to which pubKey, and the `pubKey.verify` calls are reletively heavy on performance, making the `__build` take ~0.12 instead of the old ~0.03 (testing with the 2of2 from the test case).

Alternatively I could move the resposibility to put the signatures in the right order to `txb.sign` and `TransactionBuilder.fromTransaction`, prefilling the `input.signatures` with NULL values for missing signatures, in which case `fromTransaction` would be doing the `pubKey.verify` calls instead of `__build`.  
To compare I did another PR with that version of the code; <gimme a sec to make the PR ;-)>  

The 2nd solution is probably better since it involves less `pubKey.verify` calls and they're only in `txb.sign`, which is where you would expect the 'heavy lifting' 