### PR TITLE
added usage of node-secp256k1 bindings module as optional module

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "mocha-lcov-reporter": "0.0.1",
     "sinon": "^1.12.2",
     "standard": "^2.7.3"
+  },
+  "optionalDependencies": {
+    "secp256k1": "~0.0.15"
   }
 }


### PR DESCRIPTION
https://github.com/wanderer/secp256k1-node provides nodejs bindings for https://github.com/bitcoin/secp256k1

it's a pretty decent performance gain using this module instead of the current js implementation.  

in this PR it will switch to using it if it's installed, because I couldn't really think of a nice way to 'configure' bitcoinjs-lib to enable / disable it...  
just putting this 'out there' to see what you think of it
