### PR TITLE
Updated address.js javascript styling - now uses semicolons

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -1,64 +1,64 @@
-var assert = require('assert')
-var base58check = require('bs58check')
-var typeForce = require('typeforce')
-var networks = require('./networks')
-var scripts = require('./scripts')
+var assert = require('assert');
+var base58check = require('bs58check');
+var typeForce = require('typeforce');
+var networks = require('./networks');
+var scripts = require('./scripts');
 
 function findScriptTypeByVersion(version) {
   for (var networkName in networks) {
-    var network = networks[networkName]
+    var network = networks[networkName];
 
-    if (version === network.pubKeyHash) return 'pubkeyhash'
-    if (version === network.scriptHash) return 'scripthash'
+    if (version === network.pubKeyHash) return 'pubkeyhash';
+    if (version === network.scriptHash) return 'scripthash';
   }
 }
 
 function Address(hash, version) {
-  typeForce('Buffer', hash)
+  typeForce('Buffer', hash);
 
-  assert.strictEqual(hash.length, 20, 'Invalid hash length')
-  assert.strictEqual(version & 0xff, version, 'Invalid version byte')
+  assert.strictEqual(hash.length, 20, 'Invalid hash length');
+  assert.strictEqual(version & 0xff, version, 'Invalid version byte');
 
-  this.hash = hash
-  this.version = version
+  this.hash = hash;
+  this.version = version;
 }
 
 // Import functions
 Address.fromBase58Check = function(string) {
-  var payload = base58check.decode(string)
-  var version = payload.readUInt8(0)
-  var hash = payload.slice(1)
+  var payload = base58check.decode(string);
+  var version = payload.readUInt8(0);
+  var hash = payload.slice(1);
 
-  return new Address(hash, version)
-}
+  return new Address(hash, version);
+};
 
 Address.fromOutputScript = function(script, network) {
-  network = network || networks.bitcoin
+  network = network || networks.bitcoin;
 
-  if (scripts.isPubKeyHashOutput(script)) return new Address(script.chunks[2], network.pubKeyHash)
-  if (scripts.isScriptHashOutput(script)) return new Address(script.chunks[1], network.scriptHash)
+  if (scripts.isPubKeyHashOutput(script)) return new Address(script.chunks[2], network.pubKeyHash);
+  if (scripts.isScriptHashOutput(script)) return new Address(script.chunks[1], network.scriptHash);
 
-  assert(false, script.toASM() + ' has no matching Address')
-}
+  assert(false, script.toASM() + ' has no matching Address');
+};
 
 // Export functions
 Address.prototype.toBase58Check = function () {
-  var payload = new Buffer(21)
-  payload.writeUInt8(this.version, 0)
-  this.hash.copy(payload, 1)
+  var payload = new Buffer(21);
+  payload.writeUInt8(this.version, 0);
+  this.hash.copy(payload, 1);
 
-  return base58check.encode(payload)
-}
+  return base58check.encode(payload);
+};
 
 Address.prototype.toOutputScript = function() {
-  var scriptType = findScriptTypeByVersion(this.version)
+  var scriptType = findScriptTypeByVersion(this.version);
 
-  if (scriptType === 'pubkeyhash') return scripts.pubKeyHashOutput(this.hash)
-  if (scriptType === 'scripthash') return scripts.scriptHashOutput(this.hash)
+  if (scriptType === 'pubkeyhash') return scripts.pubKeyHashOutput(this.hash);
+  if (scriptType === 'scripthash') return scripts.scriptHashOutput(this.hash);
 
-  assert(false, this.toString() + ' has no matching Script')
-}
+  assert(false, this.toString() + ' has no matching Script');
+};
 
-Address.prototype.toString = Address.prototype.toBase58Check
+Address.prototype.toString = Address.prototype.toBase58Check;
 
-module.exports = Address
+module.exports = Address;


### PR DESCRIPTION
I did not modify any logic, all I have done is update the javascript statements to use semicolons. Note, semicolons after function declarations like on lines 14 and 24 are not necessary, so I did not add them there. It seems as though this project places a lot of importance on code style, so I am just hoping to help out! Let me know if you agree with this change, and I will update all of your JS files. 

Also, semicolons are super important, see javascript example below.

>   var x = 3 + f
>  (a+b).toString()

By missing the semicolons, the interpreter may confuse f to be a function: 

> var x = 3 + f(a+b).toString()

The npm test commands you suggested were not working on my computer, I received this message: 

"Failed at the bitcoinjs-lib@1.4.4 coverage script. This is most likely a problem with the bitcoinjs-lib package, not with npm itself. Tell the author that this fails on your system: istanbul cover _mocha -- test/*.js"