### PR TITLE
scripts: add allowIncomplete for multisig scripts

### DIFF
--- a/test/fixtures/scripts.json
+++ b/test/fixtures/scripts.json
@@ -53,6 +53,51 @@
       "type": "nulldata",
       "data": "deadffffffffffffffffffffffffffffffffbeef",
       "scriptPubKey": "OP_RETURN deadffffffffffffffffffffffffffffffffbeef"
+    },
+    {
+      "type": "nonstandard",
+      "typeIncomplete": "multisig",
+      "pubKeys": [
+        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "02b80011a883a0fd621ad46dfc405df1e74bf075cbaf700fd4aebef6e96f848340",
+        "024289801366bcee6172b771cf5a7f13aaecd237a0b9a1ff9d769cabc2e6b70a34"
+      ],
+      "signatures": [
+        null,
+        "3044022001ab168e80b863fdec694350b587339bb72a37108ac3c989849251444d13ebba02201811272023e3c1038478eb972a82d3ad431bfc2408e88e4da990f1a7ecbb263901",
+        "3045022100aaeb7204c17eee2f2c4ff1c9f8b39b79e75e7fbf33e92cc67ac51be8f15b75f90220659eee314a4943a6384d2b154fa5821ef7a084814d7ee2c6f9f7f0ffb53be34b01"
+      ],
+      "scriptSig": "OP_0 OP_0 3044022001ab168e80b863fdec694350b587339bb72a37108ac3c989849251444d13ebba02201811272023e3c1038478eb972a82d3ad431bfc2408e88e4da990f1a7ecbb263901 3045022100aaeb7204c17eee2f2c4ff1c9f8b39b79e75e7fbf33e92cc67ac51be8f15b75f90220659eee314a4943a6384d2b154fa5821ef7a084814d7ee2c6f9f7f0ffb53be34b01"
+    },
+    {
+      "type": "nonstandard",
+      "typeIncomplete": "multisig",
+      "pubKeys": [
+        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "02b80011a883a0fd621ad46dfc405df1e74bf075cbaf700fd4aebef6e96f848340",
+        "024289801366bcee6172b771cf5a7f13aaecd237a0b9a1ff9d769cabc2e6b70a34"
+      ],
+      "signatures": [
+        null,
+        null,
+        null
+      ],
+      "scriptSig": "OP_0 OP_0 OP_0 OP_0"
+    },
+    {
+      "type": "nonstandard",
+      "typeIncomplete": "scripthash",
+      "pubKeys": [
+        "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+        "04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a"
+      ],
+      "signatures": [
+        null,
+        "30450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a801"
+      ],
+      "redeemScript": "OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a OP_2 OP_CHECKMULTISIG",
+      "redeemScriptSig": "OP_0 OP_0 30450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a801",
+      "scriptSig": "OP_0 OP_0 30450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a801 52410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52ae"
     }
   ],
   "invalid": {
@@ -121,6 +166,18 @@
       }
     ],
     "multisigInput": [
+      {
+        "description": "Not enough signatures provided",
+        "type": "multisig",
+        "pubKeys": [
+          "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+          "02b80011a883a0fd621ad46dfc405df1e74bf075cbaf700fd4aebef6e96f848340"
+        ],
+        "signatures": [
+          null,
+          null
+        ]
+      },
       {
         "exception": "Not enough signatures provided",
         "pubKeys": [


### PR DESCRIPTION
Thanks to @bpdavenport for the initial implementation of this, however there was some issues with the existing implementation in https://github.com/bitcoinjs/bitcoinjs-lib/commit/f7604b81035839153725815dbf19a54e48c5ca94 that meant all multisig signatures were considered complete even though they weren't. 

To allow for this without breaking backwards compatibility, I have added the `allowIncomplete` flag and appropriate tests.

@bpdavenport does this look good to you?

This should bode well with the `txbmerge` changes and ideally be merged in the next 24 hours.