### PR TITLE
isScriptHashInput logic fix

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -29,7 +29,6 @@ Script.fromASM = function(asm) {
 
 Script.fromBuffer = function(buffer) {
   var chunks = []
-
   var i = 0
 
   while (i < buffer.length) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -70,7 +70,13 @@ function isScriptHashInput(script, allowIncomplete) {
   if (!Buffer.isBuffer(lastChunk)) return false
 
   var scriptSig = Script.fromChunks(script.chunks.slice(0, -1))
-  var scriptPubKey = Script.fromBuffer(lastChunk)
+  var scriptPubKey
+
+  try {
+    scriptPubKey = Script.fromBuffer(lastChunk)
+  } catch (e) {
+    return false
+  }
 
   return classifyInput(scriptSig, allowIncomplete) === classifyOutput(scriptPubKey)
 }

--- a/test/fixtures/scripts.json
+++ b/test/fixtures/scripts.json
@@ -111,6 +111,10 @@
       {
         "description": "redeemScript not data",
         "scriptSig": "OP_0 304402207515cf147d201f411092e6be5a64a6006f9308fad7b2a8fdaab22cd86ce764c202200974b8aca7bf51dbf54150d3884e1ae04f675637b926ec33bf75939446f6ca2801 3045022100ef253c1faa39e65115872519e5f0a33bbecf430c0f35cf562beabbad4da24d8d02201742be8ee49812a73adea3007c9641ce6725c32cd44ddb8e3a3af460015d140501 OP_RESERVED"
+      },
+      {
+        "description": "signature forms invalid script",
+        "scriptSig": "OP_0 3045022100e12b17b3a4c80c401a1687487bd2bafee9e5f1f8f1ffc6180ce186672ad7b43a02205e316d1e5e71822f5ef301b694e578fa9c94af4f5f098c952c833f4691307f4e01"
       }
     ],
     "isPubKeyInput": [

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -51,8 +51,11 @@ describe('Scripts', function() {
   })
 
   ;['PubKey', 'PubKeyHash', 'ScriptHash', 'Multisig', 'NullData'].forEach(function(type) {
-    var inputFn = scripts['is' + type + 'Input']
-    var outputFn= scripts['is' + type + 'Output']
+    var inputFnName = 'is' + type + 'Input'
+    var outputFnName = 'is' + type + 'Output'
+
+    var inputFn = scripts[inputFnName]
+    var outputFn= scripts[outputFnName]
 
     describe('is' + type + 'Input', function() {
       fixtures.valid.forEach(function(f) {
@@ -76,6 +79,18 @@ describe('Scripts', function() {
           }
         }
       })
+
+      if (!(inputFnName in fixtures.invalid)) return
+
+      fixtures.invalid[inputFnName].forEach(function(f) {
+        if (inputFn && f.scriptSig) {
+          it('returns false for ' + f.scriptSig, function() {
+            var script = Script.fromASM(f.scriptSig)
+
+            assert.equal(inputFn(script), false)
+          })
+        }
+      })
     })
 
     describe('is' + type + 'Output', function() {
@@ -87,6 +102,18 @@ describe('Scripts', function() {
             var script = Script.fromASM(f.scriptPubKey)
 
             assert.equal(outputFn(script), expected)
+          })
+        }
+      })
+
+      if (!(outputFnName in fixtures.invalid)) return
+
+      fixtures.invalid[outputFnName].forEach(function(f) {
+        if (outputFn && f.scriptPubKey) {
+          it('returns false for ' + f.scriptPubKey, function() {
+            var script = Script.fromASM(f.scriptPubKey)
+
+            assert.equal(outputFn(script), false)
           })
         }
       })


### PR DESCRIPTION
This PR fixes a small mistake in `isScriptHashInput` which meant a script would throw during classification of a `Script` rather than return false.

It fixes #344 properly, despite the original test case being fixed by #354. 