### PR TITLE
Allow constructing HDNode from an ECPubKey.

### DIFF
--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -43,6 +43,8 @@ function HDNode(K, chainCode, network) {
   if (K instanceof BigInteger) {
     this.privKey = new ECKey(K, true)
     this.pubKey = this.privKey.pub
+  } else if (K instanceof ECPubKey) {
+    this.pubKey = K
   } else {
     this.pubKey = new ECPubKey(K, true)
   }


### PR DESCRIPTION
Currently you can only construct an HD node using either a private key or an ECPoint. When using an ECPoint it is turned into an ECPubKey. This pull request makes it possible to use an ECPubKey directly.