### PR TITLE
add `fixSignatureOrder` option to txb.sign

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -271,7 +271,7 @@ TransactionBuilder.prototype.__build = function (allowIncomplete) {
   return tx
 }
 
-TransactionBuilder.prototype.sign = function (index, privKey, redeemScript, hashType) {
+TransactionBuilder.prototype.sign = function (index, privKey, redeemScript, hashType, fixSignatureOrder) {
   assert(index in this.inputs, 'No input at index: ' + index)
   hashType = hashType || Transaction.SIGHASH_ALL
 
@@ -358,14 +358,33 @@ TransactionBuilder.prototype.sign = function (index, privKey, redeemScript, hash
     input.hashType = hashType
     input.signatures = input.signatures || []
   }
+  var signatureScript = input.redeemScript || input.prevOutScript
+  var signatureHash = this.tx.hashForSignature(index, signatureScript, hashType)
+
+  if (fixSignatureOrder) {
+    // store signatures locally
+    var signatures = input.signatures
+
+    // empty signatures so we can set them in the correct order
+    input.signatures = []
+
+    // loop over pubKeys to set their respective signature or leave it blank so it can be signed
+    input.pubKeys.forEach(function (pubKey, pubKeyIdx) {
+      signatures.forEach(function (signature, sigIdx) {
+        // check if the signature is not null / false / OP_0 and verify if it belongs to the pubKey
+        if (signature && pubKey.verify(signatureHash, signature)) {
+          // use .splice to remove the signature from the list, so we won't verify it again
+          input.signatures[pubKeyIdx] = signatures.splice(sigIdx, 1)[0]
+        }
+      })
+    })
+  }
 
   // enforce in order signing of public keys
   assert(input.pubKeys.some(function (pubKey, i) {
     if (!privKey.pub.Q.equals(pubKey.Q)) return false
 
     assert(!input.signatures[i], 'Signature already exists')
-    var signatureScript = input.redeemScript || input.prevOutScript
-    var signatureHash = this.tx.hashForSignature(index, signatureScript, hashType)
     var signature = privKey.sign(signatureHash)
     input.signatures[i] = signature
 

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -238,5 +238,41 @@ describe('TransactionBuilder', function () {
 
       assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd1c01004830450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a8014830450221009418caa5bc18da87b188a180125c0cf06dce6092f75b2d3c01a29493466800fd02206ead65e7ca6e0f17eefe6f78457c084eab59af7c9882be1437de2e7116358eb9014c8752410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
     })
+
+    /*
+     * test if it can also sign out-of-order P2SH multisig where there are no OP_0 in place of the signature
+     *  since a lot of other libraries don't follow the adding op OP_0
+     */
+    it('works for the out-of-order P2SH multisig without OP_0', function () {
+      var privKeys = [
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx'
+      ].map(ECKey.fromWIF)
+      var redeemScript = Script.fromASM('OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a OP_2 OP_CHECKMULTISIG')
+
+      txb.addInput('4971f016798a167331bcbc67248313fbc444c6e92e4416efd06964425588f5cf', 0)
+      txb.addOutput('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH', 10000)
+      txb.sign(0, privKeys[0], redeemScript)
+
+      var tx = txb.buildIncomplete()
+
+      // in another galaxy...
+      // ... far, far away
+      var txb2 = TransactionBuilder.fromTransaction(tx)
+
+      txb2.inputs[0].signatures = [txb2.inputs[0].signatures[1]]
+
+      // assert that without fixing the order it will throw
+      assert.throws(function () {
+        txb2.sign(0, privKeys[1], redeemScript)
+      })
+
+      // sign with fixSignatureOrder=true
+      txb2.sign(0, privKeys[1], redeemScript, null, true)
+
+      var tx2 = txb2.build()
+
+      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd1c01004830450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a8014830450221009418caa5bc18da87b188a180125c0cf06dce6092f75b2d3c01a29493466800fd02206ead65e7ca6e0f17eefe6f78457c084eab59af7c9882be1437de2e7116358eb9014c8752410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
+    })
   })
 })


### PR DESCRIPTION
add `fixSignatureOrder` option to `txb.sign` for when trying to sign transactions that don't have `OP_0` in place of missing signatures.

It's not doing this by default atm, but I think it would be a good idea to do this by default in `txb.sign` since asuming that partial transactions will always have `OP_0` to fill missing signatures is not very safe 
but if you guys prefer not doing this by default then at least having the option to do it in bitcoinjs-lib wouldn't hurt imo

this has also broken backward compatibily completely with being able to sign a partially signed transaction from a v1.4.4 bitcoinjs-lib with a v1.4.5+ bitcoinjs-lib.