### PR TITLE
stop filling P2SH multisig with OP_0 when there's no signature.

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -239,14 +239,7 @@ TransactionBuilder.prototype.__build = function (allowIncomplete) {
           // Array.prototype.map is sparse-compatible
           var msSignatures = input.signatures.map(function (signature) {
             return signature.toScriptSignature(input.hashType)
-          })
-
-          // fill in blanks with OP_0
-          for (var i = 0; i < msSignatures.length; ++i) {
-            if (msSignatures[i]) continue
-
-            msSignatures[i] = ops.OP_0
-          }
+          }).filter(function(signature) { return !!signature })
 
           var redeemScript = allowIncomplete ? undefined : input.redeemScript
           scriptSig = scripts.multisigInput(msSignatures, redeemScript)
@@ -362,14 +355,30 @@ TransactionBuilder.prototype.sign = function (index, privKey, redeemScript, hash
     input.hashType = hashType
     input.signatures = input.signatures || []
   }
+  var signatureScript = input.redeemScript || input.prevOutScript
+  var signatureHash = this.tx.hashForSignature(index, signatureScript, hashType)
+
+  // fix the order of the signatures
+  // store signatures locally
+  var signatures = input.signatures
+  // empty signatures so we can set them in the correct order
+  input.signatures = []
+  // loop over pubKeys to set their respective signature or leave it blank so it can be signed
+  input.pubKeys.forEach(function (pubKey, pubKeyIdx) {
+    signatures.forEach(function (signature, sigIdx) {
+      // check if the signature is not null / false / OP_0 and verify if it belongs to the pubKey
+      if (signature && pubKey.verify(signatureHash, signature)) {
+        // use .splice to remove the signature from the list, so we won't verify it again
+        input.signatures[pubKeyIdx] = signatures.splice(sigIdx, 1)[0]
+      }
+    })
+  })
 
   // enforce in order signing of public keys
   assert(input.pubKeys.some(function (pubKey, i) {
     if (!privKey.pub.Q.equals(pubKey.Q)) return false
 
     assert(!input.signatures[i], 'Signature already exists')
-    var signatureScript = input.redeemScript || input.prevOutScript
-    var signatureHash = this.tx.hashForSignature(index, signatureScript, hashType)
     var signature = privKey.sign(signatureHash)
     input.signatures[i] = signature
 

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -242,10 +242,10 @@ describe('TransactionBuilder', function () {
       })
     })
 
-    it('works for the out-of-order P2SH multisig case', function () {
+    it('works for in-order P2SH 2of2 multisig', function () {
       var privKeys = [
-        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
-        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx'
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT'
       ].map(ECKey.fromWIF)
       var redeemScript = Script.fromASM('OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a OP_2 OP_CHECKMULTISIG')
 
@@ -254,6 +254,9 @@ describe('TransactionBuilder', function () {
       txb.sign(0, privKeys[0], redeemScript)
 
       var tx = txb.buildIncomplete()
+
+      assert(bitcoin.scripts.isCanonicalSignature(tx.ins[0].script.chunks[1]))
+      assert.equal(tx.ins[0].script.chunks[2], bitcoin.opcodes.OP_0)
 
       // in another galaxy...
       // ... far, far away
@@ -264,17 +267,47 @@ describe('TransactionBuilder', function () {
       txb2.sign(0, privKeys[1], redeemScript)
       var tx2 = txb2.build()
 
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[1]))
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[2]))
+
       assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd1c01004830450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a8014830450221009418caa5bc18da87b188a180125c0cf06dce6092f75b2d3c01a29493466800fd02206ead65e7ca6e0f17eefe6f78457c084eab59af7c9882be1437de2e7116358eb9014c8752410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
     })
 
-    /*
-     * test if it can also sign out-of-order P2SH multisig where there are no OP_0 in place of the signature
-     *  since a lot of other libraries don't follow the adding op OP_0
-     */
-    it('works for the out-of-order P2SH multisig with OP_0', function () {
+    it('works for out-of-order P2SH 2of2 multisig', function () {
       var privKeys = [
-        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
-        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx'
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT'
+      ].map(ECKey.fromWIF)
+      var redeemScript = Script.fromASM('OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a OP_2 OP_CHECKMULTISIG')
+
+      txb.addInput('4971f016798a167331bcbc67248313fbc444c6e92e4416efd06964425588f5cf', 0)
+      txb.addOutput('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH', 10000)
+      txb.sign(0, privKeys[1], redeemScript)
+
+      var tx = txb.buildIncomplete()
+
+      assert.equal(tx.ins[0].script.chunks[1], bitcoin.opcodes.OP_0)
+      assert(bitcoin.scripts.isCanonicalSignature(tx.ins[0].script.chunks[2]))
+
+      // in another galaxy...
+      // ... far, far away
+      var txb2 = TransactionBuilder.fromTransaction(tx)
+
+      // [you should] verify that Transaction is what you want...
+      // ... then sign it
+      txb2.sign(0, privKeys[0], redeemScript)
+      var tx2 = txb2.build()
+
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[1]))
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[2]))
+
+      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd1c01004830450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a8014830450221009418caa5bc18da87b188a180125c0cf06dce6092f75b2d3c01a29493466800fd02206ead65e7ca6e0f17eefe6f78457c084eab59af7c9882be1437de2e7116358eb9014c8752410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
+    })
+
+    it('can fix signature order for messed up P2SH 2of2 multisig', function () {
+      var privKeys = [
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT'
       ].map(ECKey.fromWIF)
       var redeemScript = Script.fromASM('OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a OP_2 OP_CHECKMULTISIG')
 
@@ -284,34 +317,44 @@ describe('TransactionBuilder', function () {
 
       var tx = txb.buildIncomplete()
 
+      assert(bitcoin.scripts.isCanonicalSignature(tx.ins[0].script.chunks[1]))
+      assert.equal(tx.ins[0].script.chunks[2], bitcoin.opcodes.OP_0)
+
+      // 'manually' messing up the order
+      tx.ins[0].script.chunks.splice(1, 2,
+        tx.ins[0].script.chunks[2],
+        tx.ins[0].script.chunks[1]
+      )
+
       // in another galaxy...
       // ... far, far away
       var txb2 = TransactionBuilder.fromTransaction(tx)
 
-      // mess up the order of the signatures and add an OP_0
-      txb2.inputs[0].signatures = [bitcoin.opcodes.OP_0, txb2.inputs[0].signatures[0]]
+      // without forcing fixSignatureOrder it should fail
+      assert.throws(function () {
+        txb2.sign(0, privKeys[1], redeemScript)
+      })
 
-      txb2.sign(0, privKeys[1], redeemScript)
-
+      // with forcing fixSignatureOrder it should succeed
+      txb2.sign(0, privKeys[1], redeemScript, null, true)
       var tx2 = txb2.build()
+
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[1]))
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[2]))
 
       assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd1c01004830450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a8014830450221009418caa5bc18da87b188a180125c0cf06dce6092f75b2d3c01a29493466800fd02206ead65e7ca6e0f17eefe6f78457c084eab59af7c9882be1437de2e7116358eb9014c8752410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
     })
 
-    /*
-     * test if it can also sign out-of-order P2SH multisig where there are no OP_0 in place of the signature
-     *  since a lot of other libraries don't follow the adding op OP_0
-     */
     it('works for in-order P2SH 2of3 multisig', function () {
       var privKeys = [
-        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
         '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
         '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgx3cTMqe'
       ].map(ECKey.fromWIF)
 
-      var redeemScript = bitcoin.scripts.multisigOutput(2, privKeys.map(function(privKey) { return privKey.pub }))
+      var redeemScript = bitcoin.scripts.multisigOutput(2, privKeys.map(function (privKey) { return privKey.pub }))
 
-      assert.equal(redeemScript.toASM(), 'OP_2 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672 OP_3 OP_CHECKMULTISIG');
+      assert.equal(redeemScript.toASM(), 'OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a 04f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672 OP_3 OP_CHECKMULTISIG')
 
       txb.addInput('4971f016798a167331bcbc67248313fbc444c6e92e4416efd06964425588f5cf', 0)
       txb.addOutput('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH', 10000)
@@ -325,33 +368,35 @@ describe('TransactionBuilder', function () {
 
       txb2.sign(0, privKeys[1], redeemScript)
 
-      var tx2 = txb2.build()
+      var tx2 = txb2.buildIncomplete()
 
-      assert(tx2.ins[0].script.chunks.slice(1, -1).every(function(signature) {
-        return bitcoin.scripts.isCanonicalSignature(signature);
-      }));
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[1]))
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[2]))
+      assert.equal(tx2.ins[0].script.chunks[3], bitcoin.opcodes.OP_0)
 
-      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd5d01004730440220345b5ec8451d2fd904d3e67411eaf43f540b9d87ed279a9e447602f5f15897f00220701678df40957a978dd9e3b20009ac4cb97ef73e931efe655629f55a6cfbec2f01483045022100def7a0f4849acaea79a0d6213591b484e10d91829cb63c07b7a7ef5c871e4edd022039830420e4e36256201057807f90c950836a0f93c3465a9a8d2660ba738f726d014cc9524104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e67253aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
+      var tx3 = txb2.build()
+
+      assert(tx3.ins[0].script.chunks.slice(1, -1).every(function (signature) {
+        return bitcoin.scripts.isCanonicalSignature(signature)
+      }))
+
+      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd5e0100483045022100b160c1556add6314f106b23bdc539630797ace9c7a574b51bb80e46891cda5e9022077e95273a509f5dd83dad1fa6736ca1e2b87272b53c2323b6dc65297eb8ea798014730440221008aa2f7357350a5e13a619f32bfadb0b3d2f9fc23dd18c089e88c2c789c91a710021f65f6704372438b82ef31e1251e905626a65fee320196d9aa4da5f790ea93a301004cc952410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a4104f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e67253aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
     })
 
-    /*
-     * test if it can also sign out-of-order P2SH multisig where there are no OP_0 in place of the signature
-     *  since a lot of other libraries don't follow the adding op OP_0
-     */
-    it('works for out-of-order P2SH 2of3 multisig', function () {
+    it('works for gapped, out-of-order P2SH 2of3 multisig', function () {
       var privKeys = [
-        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
         '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
         '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgx3cTMqe'
       ].map(ECKey.fromWIF)
 
-      var redeemScript = bitcoin.scripts.multisigOutput(2, privKeys.map(function(privKey) { return privKey.pub }))
+      var redeemScript = bitcoin.scripts.multisigOutput(2, privKeys.map(function (privKey) { return privKey.pub }))
 
-      assert.equal(redeemScript.toASM(), 'OP_2 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672 OP_3 OP_CHECKMULTISIG');
+      assert.equal(redeemScript.toASM(), 'OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a 04f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672 OP_3 OP_CHECKMULTISIG')
 
       txb.addInput('4971f016798a167331bcbc67248313fbc444c6e92e4416efd06964425588f5cf', 0)
       txb.addOutput('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH', 10000)
-      txb.sign(0, privKeys[0], redeemScript)
+      txb.sign(0, privKeys[2], redeemScript)
 
       var tx = txb.buildIncomplete()
 
@@ -359,16 +404,62 @@ describe('TransactionBuilder', function () {
       // ... far, far away
       var txb2 = TransactionBuilder.fromTransaction(tx)
 
-      // sign with the THIRD key
-      txb2.sign(0, privKeys[2], redeemScript)
+      txb2.sign(0, privKeys[0], redeemScript)
 
-      var tx2 = txb2.build()
+      var tx2 = txb2.buildIncomplete()
 
-      assert(tx2.ins[0].script.chunks.slice(1, -1).every(function(signature) {
-        return bitcoin.scripts.isCanonicalSignature(signature);
-      }));
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[1]))
+      assert.equal(tx2.ins[0].script.chunks[2], bitcoin.opcodes.OP_0)
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[3]))
 
-      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd5d01004730440220345b5ec8451d2fd904d3e67411eaf43f540b9d87ed279a9e447602f5f15897f00220701678df40957a978dd9e3b20009ac4cb97ef73e931efe655629f55a6cfbec2f014830450221009717e0d01216deaab7ee4caf3bdf8dedbd67f8329fe2c65381d07284393b6d2302201b34241c632cdfeb71bdc142b6d7fc1302a01da14bccccd03e123427c7ba00fc014cc9524104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e67253aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
+      var tx3 = txb2.build()
+
+      assert(tx3.ins[0].script.chunks.slice(1, -1).every(function (signature) {
+        return bitcoin.scripts.isCanonicalSignature(signature)
+      }))
+
+      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd5f0100483045022100b160c1556add6314f106b23bdc539630797ace9c7a574b51bb80e46891cda5e9022077e95273a509f5dd83dad1fa6736ca1e2b87272b53c2323b6dc65297eb8ea7980100483045022100aa15c49494d2102237bfaa1d5ce1a5475a1d5c10cd42fb62181761575ae20a6802206186bd667c1b5a283d09a1f35da3b6cbc1f2b4d7739626b0c9c92761edea1196014cc952410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a4104f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e67253aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
+    })
+
+    it('works for gapped, out-of-order P2SH 2of3 multisig without OP_0', function () {
+      var privKeys = [
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgx3cTMqe'
+      ].map(ECKey.fromWIF)
+
+      var redeemScript = bitcoin.scripts.multisigOutput(2, privKeys.map(function (privKey) { return privKey.pub }))
+
+      assert.equal(redeemScript.toASM(), 'OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a 04f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672 OP_3 OP_CHECKMULTISIG')
+
+      txb.addInput('4971f016798a167331bcbc67248313fbc444c6e92e4416efd06964425588f5cf', 0)
+      txb.addOutput('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH', 10000)
+      txb.sign(0, privKeys[2], redeemScript)
+
+      var tx = txb.buildIncomplete()
+
+      // 'manually' removing the OP_0s to simulate other libraries being the source of the incomplete TX
+      tx.ins[0].script.chunks.splice(0, 2)
+
+      // in another galaxy...
+      // ... far, far away
+      var txb2 = TransactionBuilder.fromTransaction(tx)
+
+      txb2.sign(0, privKeys[0], redeemScript)
+
+      var tx2 = txb2.buildIncomplete()
+
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[1]))
+      assert.equal(tx2.ins[0].script.chunks[2], bitcoin.opcodes.OP_0)
+      assert(bitcoin.scripts.isCanonicalSignature(tx2.ins[0].script.chunks[3]))
+
+      var tx3 = txb2.build()
+
+      assert(tx3.ins[0].script.chunks.slice(1, -1).every(function (signature) {
+        return bitcoin.scripts.isCanonicalSignature(signature)
+      }))
+
+      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd5f0100483045022100b160c1556add6314f106b23bdc539630797ace9c7a574b51bb80e46891cda5e9022077e95273a509f5dd83dad1fa6736ca1e2b87272b53c2323b6dc65297eb8ea7980100483045022100aa15c49494d2102237bfaa1d5ce1a5475a1d5c10cd42fb62181761575ae20a6802206186bd667c1b5a283d09a1f35da3b6cbc1f2b4d7739626b0c9c92761edea1196014cc952410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a4104f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e67253aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
     })
   })
 })

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -1,9 +1,9 @@
 /* global describe, it, beforeEach */
 
 var assert = require('assert')
-
 var Address = require('../src/address')
 var BigInteger = require('bigi')
+var bitcoin = require('../src')
 var ECKey = require('../src/eckey')
 var Script = require('../src/script')
 var Transaction = require('../src/transaction')
@@ -265,6 +265,110 @@ describe('TransactionBuilder', function () {
       var tx2 = txb2.build()
 
       assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd1c01004830450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a8014830450221009418caa5bc18da87b188a180125c0cf06dce6092f75b2d3c01a29493466800fd02206ead65e7ca6e0f17eefe6f78457c084eab59af7c9882be1437de2e7116358eb9014c8752410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
+    })
+
+    /*
+     * test if it can also sign out-of-order P2SH multisig where there are no OP_0 in place of the signature
+     *  since a lot of other libraries don't follow the adding op OP_0
+     */
+    it('works for the out-of-order P2SH multisig with OP_0', function () {
+      var privKeys = [
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx'
+      ].map(ECKey.fromWIF)
+      var redeemScript = Script.fromASM('OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a OP_2 OP_CHECKMULTISIG')
+
+      txb.addInput('4971f016798a167331bcbc67248313fbc444c6e92e4416efd06964425588f5cf', 0)
+      txb.addOutput('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH', 10000)
+      txb.sign(0, privKeys[0], redeemScript)
+
+      var tx = txb.buildIncomplete()
+
+      // in another galaxy...
+      // ... far, far away
+      var txb2 = TransactionBuilder.fromTransaction(tx)
+
+      // mess up the order of the signatures and add an OP_0
+      txb2.inputs[0].signatures = [bitcoin.opcodes.OP_0, txb2.inputs[0].signatures[0]]
+
+      txb2.sign(0, privKeys[1], redeemScript)
+
+      var tx2 = txb2.build()
+
+      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd1c01004830450221009c92c1ae1767ac04e424da7f6db045d979b08cde86b1ddba48621d59a109d818022004f5bb21ad72255177270abaeb2d7940ac18f1e5ca1f53db4f3fd1045647a8a8014830450221009418caa5bc18da87b188a180125c0cf06dce6092f75b2d3c01a29493466800fd02206ead65e7ca6e0f17eefe6f78457c084eab59af7c9882be1437de2e7116358eb9014c8752410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
+    })
+
+    /*
+     * test if it can also sign out-of-order P2SH multisig where there are no OP_0 in place of the signature
+     *  since a lot of other libraries don't follow the adding op OP_0
+     */
+    it('works for in-order P2SH 2of3 multisig', function () {
+      var privKeys = [
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgx3cTMqe'
+      ].map(ECKey.fromWIF)
+
+      var redeemScript = bitcoin.scripts.multisigOutput(2, privKeys.map(function(privKey) { return privKey.pub }))
+
+      assert.equal(redeemScript.toASM(), 'OP_2 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672 OP_3 OP_CHECKMULTISIG');
+
+      txb.addInput('4971f016798a167331bcbc67248313fbc444c6e92e4416efd06964425588f5cf', 0)
+      txb.addOutput('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH', 10000)
+      txb.sign(0, privKeys[0], redeemScript)
+
+      var tx = txb.buildIncomplete()
+
+      // in another galaxy...
+      // ... far, far away
+      var txb2 = TransactionBuilder.fromTransaction(tx)
+
+      txb2.sign(0, privKeys[1], redeemScript)
+
+      var tx2 = txb2.build()
+
+      assert(tx2.ins[0].script.chunks.slice(1, -1).every(function(signature) {
+        return bitcoin.scripts.isCanonicalSignature(signature);
+      }));
+
+      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd5d01004730440220345b5ec8451d2fd904d3e67411eaf43f540b9d87ed279a9e447602f5f15897f00220701678df40957a978dd9e3b20009ac4cb97ef73e931efe655629f55a6cfbec2f01483045022100def7a0f4849acaea79a0d6213591b484e10d91829cb63c07b7a7ef5c871e4edd022039830420e4e36256201057807f90c950836a0f93c3465a9a8d2660ba738f726d014cc9524104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e67253aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
+    })
+
+    /*
+     * test if it can also sign out-of-order P2SH multisig where there are no OP_0 in place of the signature
+     *  since a lot of other libraries don't follow the adding op OP_0
+     */
+    it('works for out-of-order P2SH 2of3 multisig', function () {
+      var privKeys = [
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx',
+        '91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgx3cTMqe'
+      ].map(ECKey.fromWIF)
+
+      var redeemScript = bitcoin.scripts.multisigOutput(2, privKeys.map(function(privKey) { return privKey.pub }))
+
+      assert.equal(redeemScript.toASM(), 'OP_2 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672 OP_3 OP_CHECKMULTISIG');
+
+      txb.addInput('4971f016798a167331bcbc67248313fbc444c6e92e4416efd06964425588f5cf', 0)
+      txb.addOutput('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH', 10000)
+      txb.sign(0, privKeys[0], redeemScript)
+
+      var tx = txb.buildIncomplete()
+
+      // in another galaxy...
+      // ... far, far away
+      var txb2 = TransactionBuilder.fromTransaction(tx)
+
+      // sign with the THIRD key
+      txb2.sign(0, privKeys[2], redeemScript)
+
+      var tx2 = txb2.build()
+
+      assert(tx2.ins[0].script.chunks.slice(1, -1).every(function(signature) {
+        return bitcoin.scripts.isCanonicalSignature(signature);
+      }));
+
+      assert.equal(tx2.toHex(), '0100000001cff58855426469d0ef16442ee9c644c4fb13832467bcbc3173168a7916f0714900000000fd5d01004730440220345b5ec8451d2fd904d3e67411eaf43f540b9d87ed279a9e447602f5f15897f00220701678df40957a978dd9e3b20009ac4cb97ef73e931efe655629f55a6cfbec2f014830450221009717e0d01216deaab7ee4caf3bdf8dedbd67f8329fe2c65381d07284393b6d2302201b34241c632cdfeb71bdc142b6d7fc1302a01da14bccccd03e123427c7ba00fc014cc9524104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e67253aeffffffff0110270000000000001976a914751e76e8199196d454941c45d1b3a323f1433bd688ac00000000')
     })
   })
 })


### PR DESCRIPTION
better alternative to https://github.com/bitcoinjs/bitcoinjs-lib/pull/368
 - only fill P2SH multisig with `OP_0` in `txb.Incomplete`. 
 - fix the order of the signature in `txb.sign` if there's not enough `OP_0`s.

we can't leave the `OP_0`s in the transaction when trying to broadcast it, `bitcoin-cli sendrawtransaction` gives `6: mandatory-script-verify-flag-failed (Dummy CHECKMULTISIG argument must be zero)` when this happens.

no tests were failing because there are only 2of2 tests, they never have this issue and most likely noone noticed in production because if it's the 3rd key that is missing a signature it's also trimmed off (by coincidence) 