### PR TITLE
TransactionBuilder.sign signature re-ordering and verification optimization

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -371,22 +371,20 @@ TransactionBuilder.prototype.sign = function (index, privKey, redeemScript, hash
   var signatureScript = input.redeemScript || input.prevOutScript
   var signatureHash = this.tx.hashForSignature(index, signatureScript, hashType)
 
+  // enforce signature order matches public keys
   if (input.scriptType === 'multisig' && input.redeemScript && input.signatures.length !== input.pubKeys.length) {
-    // store signatures locally
-    var _signatures = input.signatures.slice()
-
-    // loop over pubKeys to set their respective signature or set it to OP_0
     input.signatures = input.pubKeys.map(function (pubKey) {
-      var signature = null
-      _signatures.forEach(function (_signature, _sigIdx) {
-        // check if the signature is not null / false / OP_0 and verify if it belongs to the pubKey
-        if (!signature && _signature && pubKey.verify(signatureHash, _signature)) {
-          // use .splice to remove the signature from the list, so we won't verify it again
-          signature = _signatures.splice(_sigIdx, 1)[0]
-        }
+      var match
+
+      // check for any matching signatures
+      input.signatures.some(function (signature) {
+        if (!pubKey.verify(signatureHash, signature)) return false
+        match = signature
+
+        return true
       })
 
-      return signature || ops.OP_0
+      return match || undefined
     })
   }
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -373,13 +373,19 @@ TransactionBuilder.prototype.sign = function (index, privKey, redeemScript, hash
 
   // enforce signature order matches public keys
   if (input.scriptType === 'multisig' && input.redeemScript && input.signatures.length !== input.pubKeys.length) {
+    // maintain a local copy of unmatched signatures
+    var unmatched = input.signatures.slice()
+
     input.signatures = input.pubKeys.map(function (pubKey) {
       var match
 
       // check for any matching signatures
-      input.signatures.some(function (signature) {
+      unmatched.some(function (signature, i) {
         if (!pubKey.verify(signatureHash, signature)) return false
         match = signature
+
+        // remove matched signature from unmatched
+        unmatched.splice(i, 1)
 
         return true
       })


### PR DESCRIPTION
Followup to #373 and #378, where @rubensayshi and I are discussing whether or not we should re-order signatures (and potentially verify more than is necessary) or opt for the fastest solution.

The case can be seen clearly in the following example by @rubensayshi:
If you have the following set of pubkeys and signatures:

```
pubKey1  |  pubKey2  |  pubKey3   |  pubKey4
sig1  |  sig3  |  sig4
```

That is, all but `pubKey2` has signed, and therefore their signature is missing.
If we allow re-ordering, the evaluation will be:

* `pubKey1` will match `sig1` and break,
* `pubKey2` will try to match `sig3` and `sig4` and fail
* `pubKey3` will match `sig3` and break
* `pubKey4` will match `sig4` and we're done

If we don't:

* `pubKey1` will match `sig1` and break,
* `pubKey2` will try to match `sig3`, and fail
* `pubKey3` will match `sig3` and break
* `pubKey4` will match `sig4` and we're done

This is only 1 less verification, but it could be substantial if there was more `pubKey`s and less signatures.

Any other feedback from any other onlookers is welcome :)