### PR TITLE
Magic constants

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -11,11 +11,11 @@ var ecurve = require('ecurve')
 var ecparams = ecurve.getCurveByName('secp256k1')
 
 function magicHash (message, network) {
-  var magicPrefix = new Buffer(network.magicPrefix)
+  var messagePrefix = new Buffer(network.messagePrefix)
   var messageBuffer = new Buffer(message)
   var lengthBuffer = bufferutils.varIntBuffer(messageBuffer.length)
 
-  var buffer = Buffer.concat([magicPrefix, lengthBuffer, messageBuffer])
+  var buffer = Buffer.concat([messagePrefix, lengthBuffer, messageBuffer])
   return crypto.hash256(buffer)
 }
 

--- a/src/networks.js
+++ b/src/networks.js
@@ -123,7 +123,7 @@ var networks = {
 
 function estimateFee (tx, network) {
   var baseFee = network.feePerKb
-  var byteSize = tx.toBuffer().length
+  var byteSize = tx.byteLength()
 
   var fee = baseFee * Math.ceil(byteSize / 1000)
   if (network.dustSoftThreshold === undefined) return fee

--- a/src/networks.js
+++ b/src/networks.js
@@ -13,8 +13,7 @@ var networks = {
     scriptHash: 0x05,
     wif: 0x80,
     dustThreshold: 546, // https://github.com/bitcoin/bitcoin/blob/v0.9.2/src/core.h#L151-L162
-    feePerKb: 10000, // https://github.com/bitcoin/bitcoin/blob/v0.9.2/src/main.cpp#L53
-    estimateFee: estimateFee('bitcoin')
+    feePerKb: 10000 // https://github.com/bitcoin/bitcoin/blob/v0.9.2/src/main.cpp#L53
   },
   testnet: {
     magic: 0xd9b4bef9,
@@ -27,8 +26,7 @@ var networks = {
     scriptHash: 0xc4,
     wif: 0xef,
     dustThreshold: 546,
-    feePerKb: 10000,
-    estimateFee: estimateFee('testnet')
+    feePerKb: 10000
   },
   litecoin: {
     magic: 0xd9b4bef9,
@@ -42,8 +40,7 @@ var networks = {
     wif: 0xb0,
     dustThreshold: 0, // https://github.com/litecoin-project/litecoin/blob/v0.8.7.2/src/main.cpp#L360-L365
     dustSoftThreshold: 100000, // https://github.com/litecoin-project/litecoin/blob/v0.8.7.2/src/main.h#L53
-    feePerKb: 100000, // https://github.com/litecoin-project/litecoin/blob/v0.8.7.2/src/main.cpp#L56
-    estimateFee: estimateFee('litecoin')
+    feePerKb: 100000 // https://github.com/litecoin-project/litecoin/blob/v0.8.7.2/src/main.cpp#L56
   },
   dogecoin: {
     messagePrefix: '\x19Dogecoin Signed Message:\n',
@@ -56,8 +53,7 @@ var networks = {
     wif: 0x9e,
     dustThreshold: 0, // https://github.com/dogecoin/dogecoin/blob/v1.7.1/src/core.h#L155-L160
     dustSoftThreshold: 100000000, // https://github.com/dogecoin/dogecoin/blob/v1.7.1/src/main.h#L62
-    feePerKb: 100000000, // https://github.com/dogecoin/dogecoin/blob/v1.7.1/src/main.cpp#L58
-    estimateFee: estimateFee('dogecoin')
+    feePerKb: 100000000 // https://github.com/dogecoin/dogecoin/blob/v1.7.1/src/main.cpp#L58
   },
   viacoin: {
     messagePrefix: '\x18Viacoin Signed Message:\n',
@@ -70,8 +66,7 @@ var networks = {
     wif: 0xc7,
     dustThreshold: 560,
     dustSoftThreshold: 100000,
-    feePerKb: 100000, //
-    estimateFee: estimateFee('viacoin')
+    feePerKb: 100000
   },
   viacointestnet: {
     messagePrefix: '\x18Viacoin Signed Message:\n',
@@ -84,8 +79,7 @@ var networks = {
     wif: 0xff,
     dustThreshold: 560,
     dustSoftThreshold: 100000,
-    feePerKb: 100000,
-    estimateFee: estimateFee('viacointestnet')
+    feePerKb: 100000
   },
   gamerscoin: {
     messagePrefix: '\x19Gamerscoin Signed Message:\n',
@@ -98,8 +92,7 @@ var networks = {
     wif: 0xA6,
     dustThreshold: 0, // https://github.com/gamers-coin/gamers-coinv3/blob/master/src/main.cpp#L358-L363
     dustSoftThreshold: 100000, // https://github.com/gamers-coin/gamers-coinv3/blob/master/src/main.cpp#L51
-    feePerKb: 100000, // https://github.com/gamers-coin/gamers-coinv3/blob/master/src/main.cpp#L54
-    estimateFee: estimateFee('gamerscoin')
+    feePerKb: 100000 // https://github.com/gamers-coin/gamers-coinv3/blob/master/src/main.cpp#L54
   },
   jumbucks: {
     messagePrefix: '\x19Jumbucks Signed Message:\n',
@@ -112,8 +105,7 @@ var networks = {
     wif: 0xab,
     dustThreshold: 0,
     dustSoftThreshold: 10000,
-    feePerKb: 10000,
-    estimateFee: estimateFee('jumbucks')
+    feePerKb: 10000
   },
   zetacoin: {
     messagePrefix: '\x18Zetacoin Signed Message:\n',
@@ -125,34 +117,35 @@ var networks = {
     scriptHash: 0x09,
     wif: 0xe0,
     dustThreshold: 546, // https://github.com/zetacoin/zetacoin/blob/master/src/core.h#L159
-    feePerKb: 10000, // https://github.com/zetacoin/zetacoin/blob/master/src/main.cpp#L54
-    estimateFee: estimateFee('zetacoin')
+    feePerKb: 10000 // https://github.com/zetacoin/zetacoin/blob/master/src/main.cpp#L54
   }
 }
 
-function estimateFee (type) {
-  return function (tx) {
-    var network = networks[type]
-    var baseFee = network.feePerKb
-    var byteSize = tx.toBuffer().length
+function estimateFee (tx, network) {
+  var baseFee = network.feePerKb
+  var byteSize = tx.toBuffer().length
 
-    var fee = baseFee * Math.ceil(byteSize / 1000)
-    if (network.dustSoftThreshold === undefined) return fee
+  var fee = baseFee * Math.ceil(byteSize / 1000)
+  if (network.dustSoftThreshold === undefined) return fee
 
-    tx.outs.forEach(function (e) {
-      if (e.value < network.dustSoftThreshold) {
-        fee += baseFee
-      }
-    })
+  tx.outs.forEach(function (e) {
+    if (e.value < network.dustSoftThreshold) {
+      fee += baseFee
+    }
+  })
 
-    return fee
-  }
+  return fee
 }
 
 // FIXME: 1.5.3 compatibility patch(s)
+function patchEstimateFee (network, tx) {
+  return estimateFee(tx, network)
+}
+
 for (var networkName in networks) {
   var network = networks[networkName]
 
+  network.estimateFee = patchEstimateFee.bind(null, network)
   network.magicPrefix = network.messagePrefix
 }
 

--- a/src/networks.js
+++ b/src/networks.js
@@ -146,7 +146,6 @@ for (var networkName in networks) {
   var network = networks[networkName]
 
   network.estimateFee = patchEstimateFee.bind(null, network)
-  network.magicPrefix = network.messagePrefix
 }
 
 module.exports = networks

--- a/src/networks.js
+++ b/src/networks.js
@@ -128,8 +128,8 @@ function estimateFee (tx, network) {
   var fee = baseFee * Math.ceil(byteSize / 1000)
   if (network.dustSoftThreshold === undefined) return fee
 
-  tx.outs.forEach(function (e) {
-    if (e.value < network.dustSoftThreshold) {
+  tx.outs.forEach(function (output) {
+    if (output.value < network.dustSoftThreshold) {
       fee += baseFee
     }
   })

--- a/src/networks.js
+++ b/src/networks.js
@@ -3,7 +3,8 @@
 
 var networks = {
   bitcoin: {
-    magicPrefix: '\x18Bitcoin Signed Message:\n',
+    magic: 0xd9b4bef9,
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
     bip32: {
       public: 0x0488b21e,
       private: 0x0488ade4
@@ -16,7 +17,8 @@ var networks = {
     estimateFee: estimateFee('bitcoin')
   },
   testnet: {
-    magicPrefix: '\x18Bitcoin Signed Message:\n',
+    magic: 0xd9b4bef9,
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
     bip32: {
       public: 0x043587cf,
       private: 0x04358394
@@ -29,7 +31,8 @@ var networks = {
     estimateFee: estimateFee('testnet')
   },
   litecoin: {
-    magicPrefix: '\x19Litecoin Signed Message:\n',
+    magic: 0xd9b4bef9,
+    messagePrefix: '\x19Litecoin Signed Message:\n',
     bip32: {
       public: 0x019da462,
       private: 0x019d9cfe
@@ -43,7 +46,7 @@ var networks = {
     estimateFee: estimateFee('litecoin')
   },
   dogecoin: {
-    magicPrefix: '\x19Dogecoin Signed Message:\n',
+    messagePrefix: '\x19Dogecoin Signed Message:\n',
     bip32: {
       public: 0x02facafd,
       private: 0x02fac398
@@ -57,7 +60,7 @@ var networks = {
     estimateFee: estimateFee('dogecoin')
   },
   viacoin: {
-    magicPrefix: '\x18Viacoin Signed Message:\n',
+    messagePrefix: '\x18Viacoin Signed Message:\n',
     bip32: {
       public: 0x0488b21e,
       private: 0x0488ade4
@@ -71,7 +74,7 @@ var networks = {
     estimateFee: estimateFee('viacoin')
   },
   viacointestnet: {
-    magicPrefix: '\x18Viacoin Signed Message:\n',
+    messagePrefix: '\x18Viacoin Signed Message:\n',
     bip32: {
       public: 0x043587cf,
       private: 0x04358394
@@ -85,7 +88,7 @@ var networks = {
     estimateFee: estimateFee('viacointestnet')
   },
   gamerscoin: {
-    magicPrefix: '\x19Gamerscoin Signed Message:\n',
+    messagePrefix: '\x19Gamerscoin Signed Message:\n',
     bip32: {
       public: 0x019da462,
       private: 0x019d9cfe
@@ -99,7 +102,7 @@ var networks = {
     estimateFee: estimateFee('gamerscoin')
   },
   jumbucks: {
-    magicPrefix: '\x19Jumbucks Signed Message:\n',
+    messagePrefix: '\x19Jumbucks Signed Message:\n',
     bip32: {
       public: 0x037a689a,
       private: 0x037a6460
@@ -113,7 +116,7 @@ var networks = {
     estimateFee: estimateFee('jumbucks')
   },
   zetacoin: {
-    magicPrefix: '\x18Zetacoin Signed Message:\n',
+    messagePrefix: '\x18Zetacoin Signed Message:\n',
     bip32: {
       public: 0x0488b21e,
       private: 0x0488ade4
@@ -144,6 +147,13 @@ function estimateFee (type) {
 
     return fee
   }
+}
+
+// FIXME: 1.5.3 compatibility patch(s)
+for (var networkName in networks) {
+  var network = networks[networkName]
+
+  network.magicPrefix = network.messagePrefix
 }
 
 module.exports = networks

--- a/test/networks.js
+++ b/test/networks.js
@@ -10,13 +10,13 @@ var Transaction = require('../src/transaction')
 var fixtures = require('./fixtures/network')
 
 describe('networks', function () {
-  var txToBuffer
+  var txByteLength
   before(function () {
-    txToBuffer = sinon.stub(Transaction.prototype, 'toBuffer')
+    txByteLength = sinon.stub(Transaction.prototype, 'byteLength')
   })
 
   after(function () {
-    Transaction.prototype.toBuffer.restore()
+    Transaction.prototype.byteLength.restore()
   })
 
   describe('constants', function () {
@@ -39,8 +39,7 @@ describe('networks', function () {
         var network = networks[f.network]
 
         it('calculates the fee correctly for ' + f.description, function () {
-          var buffer = new Buffer(f.txSize)
-          txToBuffer.returns(buffer)
+          txByteLength.returns(f.txSize)
 
           var estimateFee = network.estimateFee
           var tx = new Transaction()


### PR DESCRIPTION
This pull request does two things.

* It adds the `magic` [protocol](https://en.bitcoin.it/wiki/Protocol_specification#Message_structure) constant to the `networks` object, renaming `magicPrefix` to `messagePrefix` (with `1.5.x` compatibility added for now)

* It changes `estimateFee` to use a new function `Transaction.prototype.byteLength` which is the size calculation functionality extracted out of `Transaction.prototype.toBuffer`, this saves unnecessary building of a `Buffer` in `estimateFee`.

All changes are backwards compatible (excepting 5b4e762d2aa3fa3412d8dc9e9e4d511445584242), and could be directly applied to `1.5.x` via cherry pick.