### PR TITLE
crypto: use packages directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.5",
     "mocha": "^2.2.0",
+    "proxyquire": "^1.4.0",
     "sinon": "^1.12.2",
     "standard": "^2.11.0"
   }

--- a/package.json
+++ b/package.json
@@ -46,8 +46,11 @@
   },
   "dependencies": {
     "bigi": "^1.4.0",
-    "bs58check": "^1.0.4",
+    "bs58check": "^1.0.5",
+    "create-hash": "^1.1.0",
+    "create-hmac": "^1.1.3",
     "ecurve": "^1.0.0",
+    "randombytes": "^2.0.1",
     "typeforce": "^1.0.0"
   },
   "devDependencies": {

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,4 +1,4 @@
-var crypto = require('crypto')
+var createHash = require('create-hash')
 
 function hash160 (buffer) {
   return ripemd160(sha256(buffer))
@@ -9,15 +9,15 @@ function hash256 (buffer) {
 }
 
 function ripemd160 (buffer) {
-  return crypto.createHash('rmd160').update(buffer).digest()
+  return createHash('rmd160').update(buffer).digest()
 }
 
 function sha1 (buffer) {
-  return crypto.createHash('sha1').update(buffer).digest()
+  return createHash('sha1').update(buffer).digest()
 }
 
 function sha256 (buffer) {
-  return crypto.createHash('sha256').update(buffer).digest()
+  return createHash('sha256').update(buffer).digest()
 }
 
 module.exports = {

--- a/src/ecdsa.js
+++ b/src/ecdsa.js
@@ -1,5 +1,5 @@
 var assert = require('assert')
-var crypto = require('crypto')
+var createHmac = require('create-hmac')
 var typeForce = require('typeforce')
 
 var BigInteger = require('bigi')
@@ -29,7 +29,7 @@ function deterministicGenerateK (curve, hash, d, checkSig) {
   k.fill(0)
 
   // Step D
-  k = crypto.createHmac('sha256', k)
+  k = createHmac('sha256', k)
     .update(v)
     .update(ZERO)
     .update(x)
@@ -37,10 +37,10 @@ function deterministicGenerateK (curve, hash, d, checkSig) {
     .digest()
 
   // Step E
-  v = crypto.createHmac('sha256', k).update(v).digest()
+  v = createHmac('sha256', k).update(v).digest()
 
   // Step F
-  k = crypto.createHmac('sha256', k)
+  k = createHmac('sha256', k)
     .update(v)
     .update(ONE)
     .update(x)
@@ -48,26 +48,26 @@ function deterministicGenerateK (curve, hash, d, checkSig) {
     .digest()
 
   // Step G
-  v = crypto.createHmac('sha256', k).update(v).digest()
+  v = createHmac('sha256', k).update(v).digest()
 
   // Step H1/H2a, ignored as tlen === qlen (256 bit)
   // Step H2b
-  v = crypto.createHmac('sha256', k).update(v).digest()
+  v = createHmac('sha256', k).update(v).digest()
 
   var T = BigInteger.fromBuffer(v)
 
   // Step H3, repeat until T is within the interval [1, n - 1] and is suitable for ECDSA
   while ((T.signum() <= 0) || (T.compareTo(curve.n) >= 0) || !checkSig(T)) {
-    k = crypto.createHmac('sha256', k)
+    k = createHmac('sha256', k)
       .update(v)
       .update(ZERO)
       .digest()
 
-    v = crypto.createHmac('sha256', k).update(v).digest()
+    v = createHmac('sha256', k).update(v).digest()
 
     // Step H1/H2a, again, ignored as tlen === qlen (256 bit)
     // Step H2b again
-    v = crypto.createHmac('sha256', k).update(v).digest()
+    v = createHmac('sha256', k).update(v).digest()
     T = BigInteger.fromBuffer(v)
   }
 

--- a/src/eckey.js
+++ b/src/eckey.js
@@ -1,9 +1,9 @@
 var assert = require('assert')
 var base58check = require('bs58check')
-var crypto = require('crypto')
 var ecdsa = require('./ecdsa')
-var typeForce = require('typeforce')
 var networks = require('./networks')
+var randomBytes = require('randombytes')
+var typeForce = require('typeforce')
 
 var BigInteger = require('bigi')
 var ECPubKey = require('./ecpubkey')
@@ -47,7 +47,7 @@ ECKey.fromWIF = function (string) {
 }
 
 ECKey.makeRandom = function (compressed, rng) {
-  rng = rng || crypto.randomBytes
+  rng = rng || randomBytes
 
   var buffer = rng(32)
   typeForce('Buffer', buffer)

--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -1,7 +1,7 @@
 var assert = require('assert')
 var base58check = require('bs58check')
 var bcrypto = require('./crypto')
-var crypto = require('crypto')
+var createHmac = require('create-hmac')
 var typeForce = require('typeforce')
 var networks = require('./networks')
 
@@ -62,7 +62,7 @@ HDNode.fromSeedBuffer = function (seed, network) {
   assert(seed.length >= 16, 'Seed should be at least 128 bits')
   assert(seed.length <= 64, 'Seed should be at most 512 bits')
 
-  var I = crypto.createHmac('sha512', HDNode.MASTER_SECRET).update(seed).digest()
+  var I = createHmac('sha512', HDNode.MASTER_SECRET).update(seed).digest()
   var IL = I.slice(0, 32)
   var IR = I.slice(32)
 
@@ -225,7 +225,7 @@ HDNode.prototype.derive = function (index) {
     ])
   }
 
-  var I = crypto.createHmac('sha512', this.chainCode).update(data).digest()
+  var I = createHmac('sha512', this.chainCode).update(data).digest()
   var IL = I.slice(0, 32)
   var IR = I.slice(32)
 

--- a/test/eckey.js
+++ b/test/eckey.js
@@ -1,10 +1,10 @@
-/* global describe, it, beforeEach, afterEach */
+/* global describe, it */
 /* eslint-disable no-new */
 
 var assert = require('assert')
 var ecurve = require('ecurve')
 var networks = require('../src/networks')
-var proxyquire =  require('proxyquire')
+var proxyquire = require('proxyquire')
 var randomBytes = require('randombytes')
 
 var BigInteger = require('bigi')
@@ -102,7 +102,7 @@ describe('ECKey', function () {
     var exBuffer = exPrivKey.d.toBuffer(32)
 
     it("uses the RNG provided by the 'randombytes' module by default", function () {
-      var stub = { randombytes: function() { return exBuffer } }
+      var stub = { randombytes: function () { return exBuffer } }
       var ProxiedECKey = proxyquire('../src/eckey', stub)
 
       var privKey = ProxiedECKey.makeRandom()

--- a/test/integration/basic.js
+++ b/test/integration/basic.js
@@ -3,21 +3,18 @@
 var assert = require('assert')
 var bigi = require('bigi')
 var bitcoin = require('../../')
-var crypto = require('crypto')
-var sinon = require('sinon')
 
 describe('bitcoinjs-lib (basic)', function () {
-  it('can generate a random bitcoin address', sinon.test(function () {
+  it('can generate a random bitcoin address', function () {
     // for testing only
-    this.mock(crypto).expects('randomBytes')
-      .onCall(0).returns(new Buffer('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'))
+    function rng () { return new Buffer('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz') }
 
-    // generate random key
-    var key = bitcoin.ECKey.makeRandom()
+    // generate random key (custom rng for testing only)
+    var key = bitcoin.ECKey.makeRandom(undefined, rng)
     var address = key.pub.getAddress().toString()
 
     assert.equal(address, '1F5VhMHukdnUES9kfXqzPzMeF1GPHKiF64')
-  }))
+  })
 
   it('can generate an address from a SHA256 hash', function () {
     var hash = bitcoin.crypto.sha256('correct horse battery staple')


### PR DESCRIPTION
This reduces the browserify build size from 600k to ~300k.   While most apps may include `crypto` anyway, they all fall back to the same modules as this is what `crypto` uses in browserify.

Not indifferent to using `require('inherits')` vs `require('events').inherit`