### PR TITLE
Add Example on Generating a Random Address and WIF for Alternative Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ The below examples are implemented as integration tests, they should be very eas
 
 - [Generate a random address](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/basic.js#L8)
 - [Generate a address from a SHA256 hash](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/basic.js#L20)
-- [Import an address via WIF](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/basic.js#L29)
-- [Create a Transaction](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/basic.js#L36)
+- [Generate a address and WIF for Litecoin](https://github.com/bitcoin/bitcoinjs-lib/blob/master/test/integration/basic.js#L29)
+- [Import an address via WIF](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/basic.js#L43)
+- [Create a Transaction](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/basic.js#L50)
 - [Sign a Bitcoin message](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/advanced.js#L9)
 - [Verify a Bitcoin message](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/advanced.js#L17)
 - [Create an OP RETURN transaction](https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/integration/advanced.js#L24)

--- a/test/integration/basic.js
+++ b/test/integration/basic.js
@@ -26,6 +26,20 @@ describe('bitcoinjs-lib (basic)', function () {
     assert.equal(address, '1C7zdTfnkzmr13HfA2vNm5SJYRK6nEKyq8')
   })
 
+  it('can generate a random keypair for alternative networks', function () {
+    // for testing only
+    function rng () { return new Buffer('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz') }
+
+    var litecoin = bitcoin.networks.litecoin
+
+    var keyPair = bitcoin.ECPair.makeRandom({ network: litecoin, rng: rng })
+    var wif = keyPair.toWIF()
+    var address = keyPair.getAddress().toString()
+
+    assert.equal(address, 'LZJSxZbjqJ2XVEquqfqHg1RQTDdfST5PTn')
+    assert.equal(wif, 'T7A4PUSgTDHecBxW1ZiYFrDNRih2o7M8Gf9xpoCgudPF9gDiNvuS')
+  })
+
   it('can import an address via WIF', function () {
     var keyPair = bitcoin.ECPair.fromWIF('Kxr9tQED9H44gCmp6HAdmemAzU3n84H3dGkuWTKvE23JgHMW8gct')
     var address = keyPair.getAddress().toString()


### PR DESCRIPTION
This PR adds an example on how to create a random keypair (address and WIF) for alternative networks such as Litecoin. 