### PR TITLE
Update 1.5.x hdnode.js

### DIFF
--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -44,6 +44,7 @@ function HDNode (K, chainCode, network) {
   } else if (K instanceof ECKey) {
     assert(K.pub.compressed, 'ECKey must be compressed')
     this.privKey = K
+    this.pubKey = K.pub
   } else if (K instanceof ECPubKey) {
     assert(K.compressed, 'ECPubKey must be compressed')
     this.pubKey = K


### PR DESCRIPTION
Informed the pubkey when building an HDNode from an ECKey (otherwise, derivation would fail on "this.pubKey.toBuffer()")