### PR TITLE
scripts: rename compile to compileToBuffer (bikeshed)

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -18,7 +18,7 @@ function fromBase58Check (address) {
 function fromOutputScript (script, network) {
   network = network || networks.bitcoin
 
-  var chunks = scripts.decompile(script)
+  var chunks = scripts.decompileToChunks(script)
   if (scripts.isPubKeyHashOutput(chunks)) return toBase58Check(chunks[2], network.pubKeyHash)
   if (scripts.isScriptHashOutput(chunks)) return toBase58Check(chunks[1], network.scriptHash)
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -193,7 +193,7 @@ Transaction.prototype.hashForSignature = function (inIndex, prevOutScript, hashT
 
   // in case concatenating two scripts ends up with two codeseparators,
   // or an extra one at the end, this prevents all those possible incompatibilities.
-  var hashScript = scripts.compile(scripts.decompile(prevOutScript).filter(function (x) {
+  var hashScript = scripts.compileToBuffer(scripts.decompileToChunks(prevOutScript).filter(function (x) {
     return x !== opcodes.OP_CODESEPARATOR
   }))
   var i

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -12,7 +12,7 @@ var Transaction = require('./transaction')
 function extractInput (txIn) {
   var redeemScript
   var scriptSig = txIn.script
-  var scriptSigChunks = scripts.decompile(scriptSig)
+  var scriptSigChunks = scripts.decompileToChunks(scriptSig)
 
   var prevOutScript
   var prevOutType = scripts.classifyInput(scriptSig, true)
@@ -23,7 +23,7 @@ function extractInput (txIn) {
     redeemScript = scriptSigChunks.slice(-1)[0]
     prevOutScript = scripts.scriptHashOutput(bcrypto.hash160(redeemScript))
 
-    scriptSig = scripts.compile(scriptSigChunks.slice(0, -1))
+    scriptSig = scripts.compileToBuffer(scriptSigChunks.slice(0, -1))
     scriptSigChunks = scriptSigChunks.slice(0, -1)
 
     scriptType = scripts.classifyInput(scriptSig, true)
@@ -34,7 +34,7 @@ function extractInput (txIn) {
   // pre-empt redeemScript decompilation
   var redeemScriptChunks
   if (redeemScript) {
-    redeemScriptChunks = scripts.decompile(redeemScript)
+    redeemScriptChunks = scripts.decompileToChunks(redeemScript)
   }
 
   // Extract hashType, pubKeys and signatures
@@ -147,7 +147,7 @@ TransactionBuilder.prototype.addInput = function (txHash, vout, sequence, prevOu
 
   var input = {}
   if (prevOutScript) {
-    var prevOutScriptChunks = scripts.decompile(prevOutScript)
+    var prevOutScriptChunks = scripts.decompileToChunks(prevOutScript)
     var prevOutType = scripts.classifyOutput(prevOutScriptChunks)
 
     // if we can, extract pubKey information
@@ -318,14 +318,14 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
       if (input.prevOutScript) {
         if (input.prevOutType !== 'scripthash') throw new Error('PrevOutScript must be P2SH')
 
-        var scriptHash = scripts.decompile(input.prevOutScript)[1]
+        var scriptHash = scripts.decompileToChunks(input.prevOutScript)[1]
         if (!bufferutils.equal(scriptHash, bcrypto.hash160(redeemScript))) throw new Error('RedeemScript does not match ' + scriptHash.toString('hex'))
       }
 
       var scriptType = scripts.classifyOutput(redeemScript)
       if (!canSignTypes[scriptType]) throw new Error('RedeemScript not supported (' + scriptType + ')')
 
-      var redeemScriptChunks = scripts.decompile(redeemScript)
+      var redeemScriptChunks = scripts.decompileToChunks(redeemScript)
       var pubKeys = []
       switch (scriptType) {
         case 'multisig':

--- a/test/bitcoin.core.js
+++ b/test/bitcoin.core.js
@@ -228,8 +228,8 @@ describe('Bitcoin-core', function () {
         assert.strictEqual(transaction.toHex(), txHex)
 
         var script = new Buffer(scriptHex, 'hex')
-        var scriptChunks = scripts.decompile(script)
-        assert.strictEqual(scripts.compile(scriptChunks).toString('hex'), scriptHex)
+        var scriptChunks = scripts.decompileToChunks(script)
+        assert.strictEqual(scripts.compileToBuffer(scriptChunks).toString('hex'), scriptHex)
 
         var hash = transaction.hashForSignature(inIndex, script, hashType)
         assert.deepEqual(hash, expectedHash)

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -32,13 +32,13 @@ describe('scripts', function () {
     })
   })
 
-  describe('compile', function () {
+  describe('compileToBuffer', function () {
     fixtures.valid.forEach(function (f) {
       if (f.scriptSig) {
         it('compiles ' + f.scriptSig, function () {
           var script = scripts.fromASM(f.scriptSig)
 
-          assert.strictEqual(scripts.compile(script).toString('hex'), f.scriptSigHex)
+          assert.strictEqual(scripts.compileToBuffer(script).toString('hex'), f.scriptSigHex)
         })
       }
 
@@ -46,17 +46,17 @@ describe('scripts', function () {
         it('compiles ' + f.scriptPubKey, function () {
           var script = scripts.fromASM(f.scriptPubKey)
 
-          assert.strictEqual(scripts.compile(script).toString('hex'), f.scriptPubKeyHex)
+          assert.strictEqual(scripts.compileToBuffer(script).toString('hex'), f.scriptPubKeyHex)
         })
       }
     })
   })
 
-  describe('decompile', function () {
+  describe('decompileToChunks', function () {
     fixtures.valid.forEach(function (f) {
       if (f.scriptSigHex) {
         it('decompiles ' + f.scriptSig, function () {
-          var chunks = scripts.decompile(new Buffer(f.scriptSigHex, 'hex'))
+          var chunks = scripts.decompileToChunks(new Buffer(f.scriptSigHex, 'hex'))
 
           assert.strictEqual(scripts.toASM(chunks), f.scriptSig)
         })
@@ -64,7 +64,7 @@ describe('scripts', function () {
 
       if (f.scriptPubKeyHex) {
         it('decompiles ' + f.scriptPubKey, function () {
-          var chunks = scripts.decompile(new Buffer(f.scriptPubKeyHex, 'hex'))
+          var chunks = scripts.decompileToChunks(new Buffer(f.scriptPubKeyHex, 'hex'))
 
           assert.strictEqual(scripts.toASM(chunks), f.scriptPubKey)
         })
@@ -73,7 +73,7 @@ describe('scripts', function () {
 
     fixtures.invalid.decompile.forEach(function (f) {
       it('decompiles ' + f.hex + ' to [] because of "' + f.description + '"', function () {
-        var chunks = scripts.decompile(new Buffer(f.hex, 'hex'))
+        var chunks = scripts.decompileToChunks(new Buffer(f.hex, 'hex'))
 
         assert.strictEqual(chunks.length, 0)
       })

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -271,7 +271,7 @@ describe('TransactionBuilder', function () {
                 var scriptSig = tx.ins[i].script
 
                 // ignore OP_0 on the front, ignore redeemScript
-                var signatures = scripts.decompile(scriptSig).slice(1, -1).filter(function (x) { return x !== ops.OP_0 })
+                var signatures = scripts.decompileToChunks(scriptSig).slice(1, -1).filter(function (x) { return x !== ops.OP_0 })
 
                 // rebuild/replace the scriptSig without them
                 var replacement = scripts.scriptHashInput(scripts.multisigInput(signatures), redeemScript)


### PR DESCRIPTION
Still not sure about this,  so I figured I'd put it on its own.
`decompileToChunks` seems very context specific. 

I feel like these names could be resolved by just basic documentation?