### PR TITLE
ECPair: fix modulo bias in makeRandom

### DIFF
--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -105,11 +105,14 @@ ECPair.makeRandom = function (options) {
   options = options || {}
 
   var rng = options.rng || randomBytes
-  var buffer = rng(32)
-  typeforce(types.Buffer256bit, buffer)
 
-  var d = BigInteger.fromBuffer(buffer)
-  d = d.mod(secp256k1.n)
+  var d
+  do {
+    var buffer = rng(32)
+    typeforce(types.Buffer256bit, buffer)
+
+    d = BigInteger.fromBuffer(buffer)
+  } while (d.compareTo(secp256k1.n) > 0)
 
   return new ECPair(d, null, options)
 }


### PR DESCRIPTION
See https://stackoverflow.com/questions/10984974/why-do-people-say-there-is-modulo-bias-when-using-a-random-number-generator for a good explanation.

`secp256k1.n` is approximately `2^256 - 2^128`, so the bias is negligible,  but it does exist.
No security notice needed.

Will back port.