### PR TITLE
Extract BIP66 module

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "bigi": "^1.4.0",
-    "bip66": "^1.0.8",
+    "bip66": "^1.1.0",
     "bs58check": "^1.0.5",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "bigi": "^1.4.0",
+    "bip66": "^1.0.2",
     "bs58check": "^1.0.5",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "bigi": "^1.4.0",
-    "bip66": "^1.0.2",
+    "bip66": "^1.0.8",
     "bs58check": "^1.0.5",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.3",

--- a/src/script.js
+++ b/src/script.js
@@ -134,8 +134,16 @@ function isCanonicalPubKey (buffer) {
 
 function isCanonicalSignature (buffer) {
   if (!Buffer.isBuffer(buffer)) return false
+  if (!isDefinedHashType(buffer[buffer.length - 1])) return false
 
   return bip66.check(buffer.slice(0, -1))
+}
+
+function isDefinedHashType (hashType) {
+  var hashTypeMod = hashType & ~0x80
+
+// return hashTypeMod > SIGHASH_ALL && hashTypeMod < SIGHASH_SINGLE
+  return hashTypeMod > 0x00 && hashTypeMod < 0x04
 }
 
 function isPubKeyHashInput (script) {
@@ -369,6 +377,7 @@ module.exports = {
 
   isCanonicalPubKey: isCanonicalPubKey,
   isCanonicalSignature: isCanonicalSignature,
+  isDefinedHashType: isDefinedHashType,
   isPubKeyHashInput: isPubKeyHashInput,
   isPubKeyHashOutput: isPubKeyHashOutput,
   isPubKeyInput: isPubKeyInput,

--- a/src/script.js
+++ b/src/script.js
@@ -3,9 +3,6 @@ var bufferutils = require('./bufferutils')
 var typeforce = require('typeforce')
 var types = require('./types')
 
-var ecurve = require('ecurve')
-var curve = ecurve.getCurveByName('secp256k1')
-
 var OPS = require('./opcodes')
 var REVERSE_OPS = []
 for (var op in OPS) {

--- a/src/script.js
+++ b/src/script.js
@@ -1,8 +1,8 @@
+var bip66 = require('bip66')
 var bufferutils = require('./bufferutils')
 var typeforce = require('typeforce')
 var types = require('./types')
 
-var ECSignature = require('./ecsignature')
 var ecurve = require('ecurve')
 var curve = ecurve.getCurveByName('secp256k1')
 
@@ -135,17 +135,7 @@ function isCanonicalPubKey (buffer) {
 function isCanonicalSignature (buffer) {
   if (!Buffer.isBuffer(buffer)) return false
 
-  try {
-    ECSignature.parseScriptSignature(buffer)
-  } catch (e) {
-    if (!(e.message.match(/Not a DER sequence|Invalid sequence length|Expected a DER integer|R length is zero|S length is zero|R value excessively padded|S value excessively padded|R value is negative|S value is negative|Invalid hashType/))) {
-      throw e
-    }
-
-    return false
-  }
-
-  return true
+  return bip66.check(buffer.slice(0, -1))
 }
 
 function isPubKeyHashInput (script) {

--- a/src/script.js
+++ b/src/script.js
@@ -118,18 +118,17 @@ function decompile (buffer) {
 
 function isCanonicalPubKey (buffer) {
   if (!Buffer.isBuffer(buffer)) return false
+  if (buffer.length < 33) return false
 
-  try {
-    ecurve.Point.decodeFrom(curve, buffer)
-  } catch (e) {
-    if (!(e.message.match(/Invalid sequence (length|tag)/))) {
-      throw e
-    }
-
-    return false
+  switch (buffer[0]) {
+    case 0x02:
+    case 0x03:
+      return buffer.length === 33
+    case 0x04:
+      return buffer.length === 65
   }
 
-  return true
+  return false
 }
 
 function isCanonicalSignature (buffer) {

--- a/test/bitcoin.core.js
+++ b/test/bitcoin.core.js
@@ -243,14 +243,12 @@ describe('Bitcoin-core', function () {
       if (i % 2 !== 0) return
 
       var description = sig_noncanonical[i - 1].slice(0, -1)
-      if (description === 'too long') return // we support non secp256k1 signatures
-
       var buffer = new Buffer(hex, 'hex')
 
       it('throws on ' + description, function () {
         assert.throws(function () {
           bitcoin.ECSignature.parseScriptSignature(buffer)
-        })
+        }, /Expected DER (integer|sequence)|(R|S) value (excessively padded|is negative)|(R|S|DER sequence) length is (zero|too short|too long|invalid)|Invalid hashType/)
       })
     })
   })

--- a/test/fixtures/ecsignature.json
+++ b/test/fixtures/ecsignature.json
@@ -130,36 +130,32 @@
     ],
     "DER": [
       {
-        "exception": "DER sequence too short",
+        "exception": "DER sequence length is too short",
         "hex": "ffffffffffffff"
       },
       {
-        "exception": "DER sequence too long",
+        "exception": "DER sequence length is too long",
         "hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
       },
       {
-        "exception": "Invalid sequence length",
+        "exception": "Expected DER sequence",
+        "hex": "00ffff0400ffffff020400ffffff"
+      },
+      {
+        "exception": "DER sequence length is invalid",
         "hex": "30ff020400ffffff020400ffffff"
       },
       {
-        "exception": "Invalid sequence length",
+        "exception": "DER sequence length is invalid",
         "hex": "300c030400ffffff030400ffffff0000"
       },
       {
-        "exception": "Expected a DER integer",
+        "exception": "Expected DER integer",
         "hex": "300cff0400ffffff020400ffffff"
       },
       {
-        "exception": "Expected a DER integer \\(2\\)",
+        "exception": "Expected DER integer \\(2\\)",
         "hex": "300c020200ffffff020400ffffff"
-      },
-      {
-        "exception": "Invalid DER encoding",
-        "hex": "300c0204ddffffff020200ffffff"
-      },
-      {
-        "exception": "Invalid DER encoding \\(2\\)",
-        "hex": "300c020400ffffff02dd00ffffff"
       },
       {
         "exception": "R length is zero",
@@ -170,12 +166,20 @@
         "hex": "3008020400ffffff0200"
       },
       {
+        "exception": "R length is too long",
+        "hex": "300c02dd00ffffff020400ffffff"
+      },
+      {
+        "exception": "S length is invalid",
+        "hex": "300c020400ffffff02dd00ffffff"
+      },
+      {
         "exception": "R value is negative",
-        "hex": "300c0204ffffffff020400ffffff"
+        "hex": "300c020480000000020400ffffff"
       },
       {
         "exception": "S value is negative",
-        "hex": "300c020400ffffff0204ffffffff"
+        "hex": "300c020400ffffff020480000000"
       },
       {
         "exception": "R value excessively padded",

--- a/test/fixtures/script.json
+++ b/test/fixtures/script.json
@@ -178,8 +178,16 @@
     ],
     "isPubKeyInput": [
       {
+        "description": "non-canonical signature (too short)",
+        "scriptSig": "304402207515cf147d201f411092e6be5a64a6006f9308fad7b2a8fdaab22cd86ce764c202200974b8aca7bf51dbf54150d3884e1ae04f675637b926ec33bf7593"
+      },
+      {
         "description": "non-canonical signature (too long)",
-        "scriptSig": "304402207515cf147d201f411092e6be5a64a6006f9308fad7b2a8fdaab22cd86ce764c202200974b8aca7bf51dbf54150d3884e1ae04f675637b926ec33bf7593ffffffffffffffff"
+        "scriptSig": "304402207515cf147d201f411092e6be5a64a6006f9308fad7b2a8fdaab22cd86ce764c202200974b8aca7bf51dbf54150d3884e1ae04f675637b926ec33bf75939446f6ca28ffffffff01"
+      },
+      {
+        "description": "non-canonical signature (invalid hashType)",
+        "scriptSig": "304402207515cf147d201f411092e6be5a64a6006f9308fad7b2a8fdaab22cd86ce764c202200974b8aca7bf51dbf54150d3884e1ae04f675637b926ec33bf75939446f6ca28ff"
       }
     ],
     "isPubKeyOutput": [

--- a/test/fixtures/script.json
+++ b/test/fixtures/script.json
@@ -178,8 +178,18 @@
     ],
     "isPubKeyInput": [
       {
-        "description": "non-canonical signature",
+        "description": "non-canonical signature (too long)",
         "scriptSig": "304402207515cf147d201f411092e6be5a64a6006f9308fad7b2a8fdaab22cd86ce764c202200974b8aca7bf51dbf54150d3884e1ae04f675637b926ec33bf7593ffffffffffffffff"
+      }
+    ],
+    "isPubKeyOutput": [
+      {
+        "description": "non-canonical pubkey (too short)",
+        "scriptPubKey": "02359c6e3f04cefbf089cf1d6670dc47c3fb4df68e2bad1fa5a369f9ce OP_CHECKSIG"
+      },
+      {
+        "description": "non-canonical pubkey (too long)",
+        "scriptPubKey": "02359c6e3f04cefbf089cf1d6670dc47c3fb4df68e2bad1fa5a369f9ce4b42bbd1ffffff OP_CHECKSIG"
       }
     ],
     "isMultisigOutput": [


### PR DESCRIPTION
**Only breaking change in terms of exact exception messages**.

The messages are now consistent in the https://github.com/bitcoinjs/bip66 module,  and adhering to SEMVER.

The fact I can now test for all of them using:
``` javascript
/Expected DER (integer|sequence)|(R|S) value (excessively padded|is negative)|(R|S|DER sequence) length is (zero|too short|too long|invalid)/
```

Is a huge bonus compared to the huge regex that was necessary prior.