### PR TITLE
types: restore quacking behaviour

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -1,5 +1,3 @@
-var bigi = require('bigi')
-var ecurve = require('ecurve')
 var typeforce = require('typeforce')
 
 function nBuffer (value, n) {
@@ -24,9 +22,9 @@ function UInt53 (value) {
 }
 
 // external dependent types
-function BigInt (value) { return !typeforce.Null(value) && value.constructor === bigi }
-function ECCurve (value) { return !typeforce.Null(value) && value.constructor === ecurve.Curve }
-function ECPoint (value) { return !typeforce.Null(value) && value.constructor === ecurve.Point }
+var BigInt = typeforce.quacksLike('BigInteger')
+var ECCurve = typeforce.quacksLike('Curve')
+var ECPoint = typeforce.quacksLike('Point')
 
 // exposed, external API
 var ECSignature = typeforce.compile({ r: BigInt, s: BigInt })

--- a/test/types.js
+++ b/test/types.js
@@ -1,0 +1,14 @@
+/* global describe, it */
+
+var assert = require('assert')
+var types = require('../src/types')
+
+describe('types', function () {
+  describe('ECCurve/ECPoint/BigInt', function () {
+    it('return true for duck types', function () {
+      assert(types.quacksLike('BigInteger', function BigInteger () {}))
+      assert(types.quacksLike('Curve', function Curve () {}))
+      assert(types.quacksLike('Point', function Point () {}))
+    })
+  })
+})


### PR DESCRIPTION
@weilu right as always.
Found this is still an issue while doing some local testing.

Can't wait to be rid of these types.