### PR TITLE
standard: remove padded Blocks

### DIFF
--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -28,7 +28,6 @@ function ECPair (d, Q, options) {
     if (Q) throw new TypeError('Unexpected publicKey parameter')
 
     this.d = d
-
   } else {
     typeforce(types.ECPoint, Q)
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -211,7 +211,6 @@ Transaction.prototype.hashForSignature = function (inIndex, prevOutScript, hashT
         input.sequence = 0
       }
     })
-
   } else if ((hashType & 0x1f) === Transaction.SIGHASH_SINGLE) {
     var nOut = inIndex
 

--- a/test/ecdsa.js
+++ b/test/ecdsa.js
@@ -174,7 +174,6 @@ describe('ecdsa', function () {
         var signature
         if (f.signature) {
           signature = ECSignature.fromDER(new Buffer(f.signature, 'hex'))
-
         } else if (f.signatureRaw) {
           signature = new ECSignature(new BigInteger(f.signatureRaw.r, 16), new BigInteger(f.signatureRaw.s, 16))
         }

--- a/test/script.js
+++ b/test/script.js
@@ -323,7 +323,6 @@ describe('script', function () {
 
         if (f.scriptSig) {
           assert.strictEqual(bscript.toASM(scriptSig), f.scriptSig)
-
         } else {
           assert.strictEqual(scriptSig.toString('hex'), f.scriptSigHex)
         }

--- a/test/transaction.js
+++ b/test/transaction.js
@@ -19,7 +19,6 @@ describe('Transaction', function () {
 
       if (txIn.data) {
         scriptSig = new Buffer(txIn.data, 'hex')
-
       } else if (txIn.script) {
         scriptSig = bscript.fromASM(txIn.script)
       }
@@ -31,9 +30,7 @@ describe('Transaction', function () {
       var script
 
       if (txOut.data) {
-        var data = new Buffer(txOut.data, 'hex')
-        script = data
-
+        script = new Buffer(txOut.data, 'hex')
       } else if (txOut.script) {
         script = bscript.fromASM(txOut.script)
       }

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -203,7 +203,6 @@ describe('TransactionBuilder', function () {
 
             if (!sign.throws) {
               txb.sign(index, keyPair, redeemScript, sign.hashType)
-
             } else {
               assert.throws(function () {
                 txb.sign(index, keyPair, redeemScript, sign.hashType)
@@ -229,9 +228,7 @@ describe('TransactionBuilder', function () {
       describe('for ' + (f.description || f.exception), function () {
         beforeEach(function () {
           if (f.txHex) {
-            var tx = Transaction.fromHex(f.txHex)
-            txb = TransactionBuilder.fromTransaction(tx)
-
+            txb = TransactionBuilder.fromTransaction(Transaction.fromHex(f.txHex))
           } else {
             txb = construct(f)
           }


### PR DESCRIPTION
Reference: https://github.com/feross/standard/issues/170

This was re-enabled in `5.0.0`,  its just that eslint wasn't picking it up properly.