### PR TITLE
use blanket over coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "0.11"
   - "0.10"
 env:
-  - TEST_SUITE=coveralls
+  - TEST_SUITE=coverage
   - TEST_SUITE=integration
   - TEST_SUITE=standard
   - TEST_SUITE=unit

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/bitcoinjs/bitcoinjs-lib.png?branch=master)](https://travis-ci.org/bitcoinjs/bitcoinjs-lib)
 [![NPM](http://img.shields.io/npm/v/bip66.svg)](https://www.npmjs.org/package/bip66)
-[![Coverage Status](https://coveralls.io/repos/bitcoinjs/bitcoinjs-lib/badge.png)](https://coveralls.io/r/bitcoinjs/bitcoinjs-lib)
 [![tip for next commit](http://tip4commit.com/projects/735.svg)](http://tip4commit.com/projects/735)
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)

--- a/package.json
+++ b/package.json
@@ -32,17 +32,31 @@
     }
   ],
   "scripts": {
-    "compile": "browserify ./src/index.js -s bitcoin > bitcoin.js",
-    "coverage": "istanbul cover _mocha -- test/*.js",
-    "coveralls": "npm run-script coverage && coveralls < coverage/lcov.info",
+    "coverage": "mocha --require blanket -R travis-cov",
+    "coverage-local": "mocha --require blanket -R html-cov",
     "integration": "mocha test/integration/",
+    "prepublish": "npm run test",
     "standard": "standard",
-    "test": "npm run-script unit && npm run standard",
+    "test": "npm run standard && npm run unit",
     "unit": "mocha"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/bitcoinjs/bitcoinjs-lib.git"
+  },
+  "config": {
+    "blanket": {
+      "pattern": [
+        ""
+      ],
+      "data-cover-never": [
+        "node_modules",
+        "test"
+      ]
+    },
+    "travis-cov": {
+      "threshold": 99
+    }
   },
   "dependencies": {
     "bigi": "^1.4.0",
@@ -57,15 +71,15 @@
   },
   "devDependencies": {
     "async": "^0.9.0",
+    "blanket": "^1.1.0",
     "browserify": "^10.0.0",
     "bs58": "^2.0.1",
     "cb-http-client": "^0.2.0",
-    "coveralls": "^2.11.2",
     "httpify": "^1.0.0",
-    "istanbul": "^0.3.5",
     "mocha": "^2.2.0",
     "proxyquire": "^1.4.0",
     "sinon": "^1.12.2",
-    "standard": "^5.0.0"
+    "standard": "^5.0.0",
+    "travis-cov": "^0.2.0"
   }
 }


### PR DESCRIPTION
Coveralls has just been a massive pain lately, always throwing false positives.
Using `blanket` means we don't allow our test coverage to drop below 99%,  **ever**.

You can still generate great coverage reports using `coverage-local`.