### PR TITLE
integration: fix HDNode search space

### DIFF
--- a/test/integration/crypto.js
+++ b/test/integration/crypto.js
@@ -67,7 +67,7 @@ describe('bitcoinjs-lib (crypto)', function () {
       serQP.copy(data, 0)
 
       // search index space until we find it
-      for (var i = 0; i < bitcoin.HDNode.HIGHEST_BIT; ++i) {
+      for (var i = 0; i < 0x80000000; ++i) {
         data.writeUInt32BE(i, 33)
 
         // calculate I


### PR DESCRIPTION
This should have been caught by https://github.com/bitcoinjs/bitcoinjs-lib/issues/452,  but I've since resolved that with https://github.com/bitcoinjs/bitcoinjs-lib/issues/452#issuecomment-138449399.

Perhaps https://github.com/bitcoinjs/bitcoinjs-lib/commit/4b825bf2a84a7cfad979251c4cf6572e5c6c50b1#diff-5c6e94af0cfc148a8156e71ac23eb5fbL24 isn't worth it?

@weilu POST-merge thoughts?
I don't like the idea of setting them as variables,  as that implies they aren't constants.
Thoughts?

Maybe `HDNode.constants.*`?