### PR TITLE
revert 4b825bf

### DIFF
--- a/test/hdnode.js
+++ b/test/hdnode.js
@@ -193,7 +193,7 @@ describe('HDNode', function () {
       assert.strictEqual(hd.depth, depth || 0)
 
       if (v.hardened) {
-        assert.strictEqual(hd.index, v.m + 0x80000000)
+        assert.strictEqual(hd.index, v.m + HDNode.HIGHEST_BIT)
       } else {
         assert.strictEqual(hd.index, v.m)
       }

--- a/test/integration/crypto.js
+++ b/test/integration/crypto.js
@@ -67,7 +67,7 @@ describe('bitcoinjs-lib (crypto)', function () {
       serQP.copy(data, 0)
 
       // search index space until we find it
-      for (var i = 0; i < 0x80000000; ++i) {
+      for (var i = 0; i < bitcoin.HDNode.HIGHEST_BIT; ++i) {
         data.writeUInt32BE(i, 33)
 
         // calculate I


### PR DESCRIPTION
Un-breaking change.

@weilu I think 4b825bf was a mistake.
We need to rethink how we want to expose these constants.
See https://github.com/bitcoinjs/bitcoinjs-lib/issues/464 for discussion of that.