### PR TITLE
docs: remove inline endian-ness notes, no endianness

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -246,7 +246,7 @@ Transaction.prototype.getHash = function () {
 }
 
 Transaction.prototype.getId = function () {
-  // TxHash is little-endian, we need big-endian
+  // transaction hash's are displayed in reverse order
   return bufferutils.reverse(this.getHash()).toString('hex')
 }
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -169,13 +169,13 @@ TransactionBuilder.fromTransaction = function (transaction, network) {
 }
 
 TransactionBuilder.prototype.addInput = function (txHash, vout, sequence, prevOutScript) {
-  // is it a txId?
+  // is it a hex string?
   if (typeof txHash === 'string') {
-    // a txId is big-endian hex, we want a little-endian Buffer
+    // transaction hashs's are displayed in reverse order, un-reverse it
     txHash = new Buffer(txHash, 'hex')
     Array.prototype.reverse.call(txHash)
 
-  // is it a Transaction?
+  // is it a Transaction object?
   } else if (txHash instanceof Transaction) {
     prevOutScript = txHash.outs[vout].script
     txHash = txHash.getHash()

--- a/test/bitcoin.core.js
+++ b/test/bitcoin.core.js
@@ -149,7 +149,7 @@ describe('Bitcoin-core', function () {
         transaction.ins.forEach(function (txIn, i) {
           var input = inputs[i]
 
-          // reverse because test data is big-endian
+          // reverse because test data is reversed
           var prevOutHash = bitcoin.bufferutils.reverse(new Buffer(input[0], 'hex'))
           var prevOutIndex = input[1]
 
@@ -202,7 +202,7 @@ describe('Bitcoin-core', function () {
       var inIndex = f[2]
       var hashType = f[3]
 
-      // reverse because test data is big-endian
+      // reverse because test data is reversed
       var expectedHash = bitcoin.bufferutils.reverse(new Buffer(f[4], 'hex'))
 
       var hashTypes = []


### PR DESCRIPTION
SHA256 output is not classified as big-endian or little-endian.
SHA256 **does** writes out big-endian 4 byte integers in its finalization step,  but this is for byte order consistency between platforms.
It is **not** a actual formalized *endianness* of the its output.

In https://github.com/bitcoin/bitcoin,  the hash output is reversed when displayed in hex.
This is because a pre-existing 256-bit integer data structure (`uint256`) was used for the hash output.
`uint256` when converted to a hex string, is converted to big-endian for human readability.
This created a situation where the original hash is reversed by convention.

This PR just corrects the inline documentation to avoid more questions regarding this.