### PR TITLE
tests: add HDNode fromSeed throwing tests

### DIFF
--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -124,16 +124,16 @@ HDNode.fromBase58 = function (string, networks) {
   return hd
 }
 
+HDNode.prototype.getAddress = function () {
+  return this.keyPair.getAddress()
+}
+
 HDNode.prototype.getIdentifier = function () {
   return bcrypto.hash160(this.keyPair.getPublicKeyBuffer())
 }
 
 HDNode.prototype.getFingerprint = function () {
   return this.getIdentifier().slice(0, 4)
-}
-
-HDNode.prototype.getAddress = function () {
-  return this.keyPair.getAddress()
 }
 
 HDNode.prototype.neutered = function () {

--- a/test/hdnode.js
+++ b/test/hdnode.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-new */
 
 var assert = require('assert')
+var ecdsa = require('../src/ecdsa')
 var sinon = require('sinon')
 
 var BigInteger = require('bigi')
@@ -9,6 +10,7 @@ var ECPair = require('../src/ecpair')
 var HDNode = require('../src/hdnode')
 
 var fixtures = require('./fixtures/hdnode.json')
+var curve = ecdsa.__curve
 
 var NETWORKS = require('../src/networks')
 var NETWORKS_LIST = [] // Object.values(NETWORKS)
@@ -67,6 +69,24 @@ describe('HDNode', function () {
         assert.strictEqual(hd.chainCode.toString('hex'), f.master.chainCode)
       })
     })
+
+    it('throws if IL is not within interval [1, n - 1] | IL === 0', sinon.test(function () {
+      this.mock(BigInteger).expects('fromBuffer')
+        .once().returns(BigInteger.ZERO)
+
+      assert.throws(function () {
+        HDNode.fromSeedHex('ffffffffffffffffffffffffffffffff')
+      }, /Private key must be greater than 0/)
+    }))
+
+    it('throws if IL is not within interval [1, n - 1] | IL === n', sinon.test(function () {
+      this.mock(BigInteger).expects('fromBuffer')
+        .once().returns(curve.n)
+
+      assert.throws(function () {
+        HDNode.fromSeedHex('ffffffffffffffffffffffffffffffff')
+      }, /Private key must be less than the curve order/)
+    }))
 
     it('throws on low entropy seed', function () {
       assert.throws(function () {


### PR DESCRIPTION
This path wasn't really covered properly before.  Now it is :+1: 
The constructor exceptions were tested, but the fact `fromSeed` can throw was probably not known to many.
The chance of this happening is `2^256 - 2^128`, that is, low. 