### PR TITLE
use buffer-equals / buffer-reverse

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "bigi": "^1.4.0",
     "bip66": "^1.1.0",
     "bs58check": "^1.0.5",
+    "buffer-equals": "^1.0.3",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.3",
     "ecurve": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "bip66": "^1.1.0",
     "bs58check": "^1.0.5",
     "buffer-equals": "^1.0.3",
+    "buffer-reverse": "^1.0.0",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.3",
     "ecurve": "^1.0.0",

--- a/src/block.js
+++ b/src/block.js
@@ -1,5 +1,6 @@
 var bufferutils = require('./bufferutils')
 var bcrypto = require('./crypto')
+var bufferReverse = require('buffer-reverse')
 
 var Transaction = require('./transaction')
 
@@ -70,7 +71,7 @@ Block.prototype.getHash = function () {
 }
 
 Block.prototype.getId = function () {
-  return bufferutils.reverse(this.getHash()).toString('hex')
+  return bufferReverse(this.getHash()).toString('hex')
 }
 
 Block.prototype.getUTCDate = function () {

--- a/src/bufferutils.js
+++ b/src/bufferutils.js
@@ -167,19 +167,13 @@ function varIntBuffer (i) {
   return buffer
 }
 
-function reverse (buffer) {
-  var buffer2 = new Buffer(buffer)
-  Array.prototype.reverse.call(buffer2)
-  return buffer2
-}
-
 module.exports = {
   equal: require('buffer-equals'),
   pushDataSize: pushDataSize,
   readPushDataInt: readPushDataInt,
   readUInt64LE: readUInt64LE,
   readVarInt: readVarInt,
-  reverse: reverse,
+  reverse: require('buffer-reverse'),
   varIntBuffer: varIntBuffer,
   varIntSize: varIntSize,
   writePushDataInt: writePushDataInt,

--- a/src/bufferutils.js
+++ b/src/bufferutils.js
@@ -167,16 +167,6 @@ function varIntBuffer (i) {
   return buffer
 }
 
-function equal (a, b) {
-  if (a.length !== b.length) return false
-
-  for (var i = 0; i < a.length; ++i) {
-    if (a[i] !== b[i]) return false
-  }
-
-  return true
-}
-
 function reverse (buffer) {
   var buffer2 = new Buffer(buffer)
   Array.prototype.reverse.call(buffer2)
@@ -184,7 +174,7 @@ function reverse (buffer) {
 }
 
 module.exports = {
-  equal: equal,
+  equal: require('buffer-equals'),
   pushDataSize: pushDataSize,
   readPushDataInt: readPushDataInt,
   readUInt64LE: readUInt64LE,

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -1,7 +1,8 @@
-var bufferutils = require('./bufferutils')
 var bcrypto = require('./crypto')
-var opcodes = require('./opcodes')
 var bscript = require('./script')
+var bufferReverse = require('buffer-reverse')
+var bufferutils = require('./bufferutils')
+var opcodes = require('./opcodes')
 var typeforce = require('typeforce')
 var types = require('./types')
 
@@ -247,7 +248,7 @@ Transaction.prototype.getHash = function () {
 
 Transaction.prototype.getId = function () {
   // transaction hash's are displayed in reverse order
-  return bufferutils.reverse(this.getHash()).toString('hex')
+  return bufferReverse(this.getHash()).toString('hex')
 }
 
 Transaction.prototype.toBuffer = function () {

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -1,7 +1,7 @@
 var baddress = require('./address')
 var bcrypto = require('./crypto')
 var bscript = require('./script')
-var bufferutils = require('./bufferutils')
+var bufferEquals = require('buffer-equals')
 var networks = require('./networks')
 var ops = require('./opcodes')
 
@@ -17,7 +17,7 @@ function fixMSSignatures (transaction, vin, pubKeys, signatures, prevOutScript, 
 
   return pubKeys.map(function (pubKey) {
     // skip optionally provided pubKey
-    if (skipPubKey && bufferutils.equal(skipPubKey, pubKey)) return undefined
+    if (skipPubKey && bufferEquals(skipPubKey, pubKey)) return undefined
 
     var matched
     var keyPair2 = ECPair.fromPublicKeyBuffer(pubKey)
@@ -346,7 +346,7 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
   if (canSign) {
     // if redeemScript was provided, enforce consistency
     if (redeemScript) {
-      if (!bufferutils.equal(input.redeemScript, redeemScript)) throw new Error('Inconsistent redeemScript')
+      if (!bufferEquals(input.redeemScript, redeemScript)) throw new Error('Inconsistent redeemScript')
     }
 
     if (input.hashType !== hashType) throw new Error('Inconsistent hashType')
@@ -360,7 +360,7 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
         if (input.prevOutType !== 'scripthash') throw new Error('PrevOutScript must be P2SH')
 
         var scriptHash = bscript.decompile(input.prevOutScript)[1]
-        if (!bufferutils.equal(scriptHash, bcrypto.hash160(redeemScript))) throw new Error('RedeemScript does not match ' + scriptHash.toString('hex'))
+        if (!bufferEquals(scriptHash, bcrypto.hash160(redeemScript))) throw new Error('RedeemScript does not match ' + scriptHash.toString('hex'))
       }
 
       var scriptType = bscript.classifyOutput(redeemScript)
@@ -377,7 +377,7 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
           var pkh1 = redeemScriptChunks[2]
           var pkh2 = bcrypto.hash160(keyPair.getPublicKeyBuffer())
 
-          if (!bufferutils.equal(pkh1, pkh2)) throw new Error('privateKey cannot sign for this input')
+          if (!bufferEquals(pkh1, pkh2)) throw new Error('privateKey cannot sign for this input')
           pubKeys = [kpPubKey]
 
           break
@@ -427,7 +427,7 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
 
   // enforce in order signing of public keys
   var valid = input.pubKeys.some(function (pubKey, i) {
-    if (!bufferutils.equal(kpPubKey, pubKey)) return false
+    if (!bufferEquals(kpPubKey, pubKey)) return false
     if (input.signatures[i]) throw new Error('Signature already exists')
 
     var signature = keyPair.sign(signatureHash)

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -2,6 +2,7 @@ var baddress = require('./address')
 var bcrypto = require('./crypto')
 var bscript = require('./script')
 var bufferEquals = require('buffer-equals')
+var bufferReverse = require('buffer-reverse/inplace')
 var networks = require('./networks')
 var ops = require('./opcodes')
 
@@ -173,7 +174,7 @@ TransactionBuilder.prototype.addInput = function (txHash, vout, sequence, prevOu
   if (typeof txHash === 'string') {
     // transaction hashs's are displayed in reverse order, un-reverse it
     txHash = new Buffer(txHash, 'hex')
-    Array.prototype.reverse.call(txHash)
+    bufferReverse(txHash)
 
   // is it a Transaction object?
   } else if (txHash instanceof Transaction) {

--- a/test/bitcoin.core.js
+++ b/test/bitcoin.core.js
@@ -3,6 +3,7 @@
 var assert = require('assert')
 var base58 = require('bs58')
 var bitcoin = require('../')
+var bufferReverse = require('buffer-reverse')
 
 var base58_encode_decode = require('./fixtures/core/base58_encode_decode.json')
 var base58_keys_invalid = require('./fixtures/core/base58_keys_invalid.json')
@@ -150,7 +151,7 @@ describe('Bitcoin-core', function () {
           var input = inputs[i]
 
           // reverse because test data is reversed
-          var prevOutHash = bitcoin.bufferutils.reverse(new Buffer(input[0], 'hex'))
+          var prevOutHash = bufferReverse(new Buffer(input[0], 'hex'))
           var prevOutIndex = input[1]
 
           assert.deepEqual(txIn.hash, prevOutHash)
@@ -203,7 +204,7 @@ describe('Bitcoin-core', function () {
       var hashType = f[3]
 
       // reverse because test data is reversed
-      var expectedHash = bitcoin.bufferutils.reverse(new Buffer(f[4], 'hex'))
+      var expectedHash = bufferReverse(new Buffer(f[4], 'hex'))
 
       var hashTypes = []
       if ((hashType & 0x1f) === bitcoin.Transaction.SIGHASH_NONE) hashTypes.push('SIGHASH_NONE')

--- a/test/bufferutils.js
+++ b/test/bufferutils.js
@@ -88,19 +88,6 @@ describe('bufferutils', function () {
     })
   })
 
-  describe('reverse', function () {
-    fixtures.valid.forEach(function (f) {
-      it('reverses ' + f.hex64 + ' correctly', function () {
-        var buffer = new Buffer(f.hex64, 'hex')
-        var buffer2 = bufferutils.reverse(buffer)
-
-        Array.prototype.reverse.call(buffer)
-
-        assert.deepEqual(buffer, buffer2)
-      })
-    })
-  })
-
   describe('varIntBuffer', function () {
     fixtures.valid.forEach(function (f) {
       it('encodes ' + f.dec + ' correctly', function () {

--- a/test/integration/crypto.js
+++ b/test/integration/crypto.js
@@ -5,6 +5,7 @@ var async = require('async')
 var bigi = require('bigi')
 var bitcoin = require('../../')
 var blockchain = require('./_blockchain')
+var bufferReverse = require('buffer-reverse')
 var crypto = require('crypto')
 
 var ecurve = require('ecurve')
@@ -134,7 +135,7 @@ describe('bitcoinjs-lib (crypto)', function () {
 
         assert(bitcoin.script.isPubKeyHashInput(scriptChunks), 'Expected pubKeyHash script')
 
-        var prevOutTxId = bitcoin.bufferutils.reverse(transaction.ins[input.vout].hash).toString('hex')
+        var prevOutTxId = bufferReverse(transaction.ins[input.vout].hash).toString('hex')
         var prevVout = transaction.ins[input.vout].index
 
         tasks.push(function (callback) {

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -3,7 +3,7 @@
 var assert = require('assert')
 var baddress = require('../src/address')
 var bscript = require('../src/script')
-var bufferutils = require('../src/bufferutils')
+var bufferReverse = require('buffer-reverse')
 var ops = require('../src/opcodes')
 
 var BigInteger = require('bigi')
@@ -92,7 +92,7 @@ describe('TransactionBuilder', function () {
         var tx = new Transaction()
 
         f.inputs.forEach(function (input) {
-          var txHash = bufferutils.reverse(new Buffer(input.txId, 'hex'))
+          var txHash = bufferReverse(new Buffer(input.txId, 'hex'))
 
           tx.addInput(txHash, input.vout, undefined, bscript.fromASM(input.scriptSig))
         })


### PR DESCRIPTION
Cons: 
* Added dependencies (`buffer-reverse`, `buffer-equals`)

Pros
* Actually tested (in the case of `buffer-equals`)
* Falls back to `Buffer.prototype.equals`,  inherent performance gain
* Less code to maintain
* Type checked