### PR TITLE
isStandard compliance [for pubKeyHash / scriptHash outputs]

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -18,11 +18,10 @@ function fromBase58Check (address) {
 function fromOutputScript (scriptPubKey, network) {
   network = network || networks.bitcoin
 
-  var chunks = bscript.decompile(scriptPubKey)
-  if (bscript.isPubKeyHashOutput(chunks)) return toBase58Check(chunks[2], network.pubKeyHash)
-  if (bscript.isScriptHashOutput(chunks)) return toBase58Check(chunks[1], network.scriptHash)
+  if (bscript.isPubKeyHashOutput(scriptPubKey)) return toBase58Check(scriptPubKey.slice(3, 23), network.pubKeyHash)
+  if (bscript.isScriptHashOutput(scriptPubKey)) return toBase58Check(scriptPubKey.slice(2, 22), network.scriptHash)
 
-  throw new Error(bscript.toASM(chunks) + ' has no matching Address')
+  throw new Error(bscript.toASM(scriptPubKey) + ' has no matching Address')
 }
 
 function toBase58Check (hash, version) {

--- a/src/script.js
+++ b/src/script.js
@@ -156,15 +156,14 @@ function isPubKeyHashInput (script) {
 }
 
 function isPubKeyHashOutput (script) {
-  var chunks = decompile(script)
+  var buffer = compile(script)
 
-  return chunks.length === 5 &&
-    chunks[0] === OPS.OP_DUP &&
-    chunks[1] === OPS.OP_HASH160 &&
-    Buffer.isBuffer(chunks[2]) &&
-    chunks[2].length === 20 &&
-    chunks[3] === OPS.OP_EQUALVERIFY &&
-    chunks[4] === OPS.OP_CHECKSIG
+  return buffer.length === 25 &&
+    buffer[0] === OPS.OP_DUP &&
+    buffer[1] === OPS.OP_HASH160 &&
+    buffer[2] === 0x14 &&
+    buffer[23] === OPS.OP_EQUALVERIFY &&
+    buffer[24] === OPS.OP_CHECKSIG
 }
 
 function isPubKeyInput (script) {
@@ -199,13 +198,12 @@ function isScriptHashInput (script, allowIncomplete) {
 }
 
 function isScriptHashOutput (script) {
-  var chunks = decompile(script)
+  var buffer = compile(script)
 
-  return chunks.length === 3 &&
-    chunks[0] === OPS.OP_HASH160 &&
-    Buffer.isBuffer(chunks[1]) &&
-    chunks[1].length === 20 &&
-    chunks[2] === OPS.OP_EQUAL
+  return buffer.length === 23 &&
+    buffer[0] === OPS.OP_HASH160 &&
+    buffer[1] === 0x14 &&
+    buffer[22] === OPS.OP_EQUAL
 }
 
 // allowIncomplete is to account for combining signatures

--- a/test/fixtures/script.json
+++ b/test/fixtures/script.json
@@ -200,6 +200,18 @@
         "scriptPubKey": "02359c6e3f04cefbf089cf1d6670dc47c3fb4df68e2bad1fa5a369f9ce4b42bbd1ffffff OP_CHECKSIG"
       }
     ],
+    "isPubKeyHashOutput": [
+      {
+        "description": "non-minimal encoded isPubKeyHashOutput (non BIP62 compliant)",
+        "scriptPubKeyHex": "76a94c14aa4d7985c57e011a8b3dd8e0e5a73aaef41629c588ac"
+      }
+    ],
+    "isScriptHashOutput": [
+      {
+        "description": "non-minimal encoded isScriptHashOutput (non BIP62 compliant)",
+        "scriptPubKeyHex": "a94c14c286a1af0947f58d1ad787385b1c2c4a976f9e7187"
+      }
+    ],
     "isMultisigOutput": [
       {
         "description": "OP_CHECKMULTISIG not found",

--- a/test/script.js
+++ b/test/script.js
@@ -149,19 +149,17 @@ describe('script', function () {
       if (!(inputFnName in fixtures.invalid)) return
 
       fixtures.invalid[inputFnName].forEach(function (f) {
-        if (inputFn && (f.scriptSig || f.scriptSigHex)) {
-          it('returns false for ' + f.description + ' (' + (f.scriptSig || f.scriptSigHex) + ')', function () {
-            var scriptSig
+        it('returns false for ' + f.description + ' (' + (f.scriptSig || f.scriptSigHex) + ')', function () {
+          var scriptSig
 
-            if (f.scriptSig) {
-              scriptSig = bscript.fromASM(f.scriptSig)
-            } else {
-              scriptSig = bscript.fromHex(f.scriptSigHex)
-            }
+          if (f.scriptSig) {
+            scriptSig = bscript.fromASM(f.scriptSig)
+          } else {
+            scriptSig = new Buffer(f.scriptSigHex, 'hex')
+          }
 
-            assert.strictEqual(inputFn(scriptSig), false)
-          })
-        }
+          assert.strictEqual(inputFn(scriptSig), false)
+        })
       })
     })
 
@@ -181,13 +179,17 @@ describe('script', function () {
       if (!(outputFnName in fixtures.invalid)) return
 
       fixtures.invalid[outputFnName].forEach(function (f) {
-        if (outputFn && f.scriptPubKey) {
-          it('returns false for ' + f.description + ' (' + f.scriptPubKey + ')', function () {
-            var scriptPubKey = bscript.fromASM(f.scriptPubKey)
+        it('returns false for ' + f.description + ' (' + (f.scriptPubKey || f.scriptPubKeyHex) + ')', function () {
+          var scriptPubKey
 
-            assert.strictEqual(outputFn(scriptPubKey), false)
-          })
-        }
+          if (f.scriptPubKey) {
+            scriptPubKey = bscript.fromASM(f.scriptPubKey)
+          } else {
+            scriptPubKey = new Buffer(f.scriptPubKeyHex, 'hex')
+          }
+
+          assert.strictEqual(outputFn(scriptPubKey), false)
+        })
       })
     })
   })


### PR DESCRIPTION
As pointed out [here](https://github.com/bitcoinjs/bitcoinjs-lib/issues/480),  this is an interesting issue.

`script.decompile` will allow for non-minimal `OP_PUSHDATA`s (that is,  you can specify a larger `OP_PUSHDATAx` than needed),  meaning extra data can be added into the script.

In some cases (as pointed out in https://github.com/bitcoinjs/bitcoinjs-lib/issues/480),  this can be confusing because [bitcoin/bitcoin](https://github.com/bitcoin/bitcoin/blob/2b0567b00291205731cbb910fb3cf33359a046ee/src/script/standard.cpp#L61) doesn't consider these transactions standard.

So far, bitcoinjs-lib hasn't cared either way, and has allowed the construction of non-standard transactions.

Perhaps an `IsStandard` flag that is enabled by default on these scripts?
Thoughts?

**Or,  better yet,  perhaps our `is*` functions are assumed to be adhering to `IsStandard`, so naturally all we have to do is amend the functions as per this PR?**

@fanatid curious on your opinion here.