### PR TITLE
2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.2
+
+__fixed__
+- Add missing CHANGELOG entry for 2.1.1
+
 # 2.1.1
 
 __changed__

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "keywords": [


### PR DESCRIPTION
As mentioned in https://github.com/bitcoinjs/bitcoinjs-lib/issues/488#issuecomment-149505211,  https://github.com/bitcoinjs/bitcoinjs-lib/commit/8b882842dd5f43b07ef2eab2ad767cfb285ca5ab was not included in `2.1.1`,  which means the relevant CHANGELOG entry is missing from the published version.

This patch resolves that.