### PR TITLE
Bump typeforce to 1.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "create-hmac": "^1.1.3",
     "ecurve": "^1.0.0",
     "randombytes": "^2.0.1",
-    "typeforce": "^1.3.0",
+    "typeforce": "^1.5.5",
     "wif": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "wif": "^1.1.0"
   },
   "devDependencies": {
-    "async": "^0.9.0",
+    "async": "^1.5.0",
     "blanket": "^1.1.0",
     "browserify": "^10.0.0",
     "bs58": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "keywords": [

--- a/test/integration/_blockchain.js
+++ b/test/integration/_blockchain.js
@@ -1,3 +1,4 @@
+var async = require('async')
 var Blockchain = require('cb-http-client')
 var httpify = require('httpify')
 
@@ -5,16 +6,42 @@ var BLOCKTRAIL_API_KEY = process.env.BLOCKTRAIL_API_KEY || 'c0bd8155c66e3fb148bb
 
 var mainnet = new Blockchain('https://api.blocktrail.com/cb/v0.2.1/BTC', { api_key: BLOCKTRAIL_API_KEY })
 var testnet = new Blockchain('https://api.blocktrail.com/cb/v0.2.1/tBTC', { api_key: BLOCKTRAIL_API_KEY })
-testnet.faucet = function faucet (address, amount, callback) {
-  httpify({
-    method: 'POST',
-    url: 'https://api.blocktrail.com/v1/tBTC/faucet/withdrawl?api_key=' + BLOCKTRAIL_API_KEY,
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      address: address,
-      amount: amount
-    })
-  }, callback)
+
+testnet.faucet = function faucet (address, amount, done) {
+  var unspents = []
+
+  async.whilst(
+    function condition () { return unspents.length === 0 },
+    function f (callback) {
+      httpify({
+        method: 'POST',
+        url: 'https://api.blocktrail.com/v1/tBTC/faucet/withdrawl?api_key=' + BLOCKTRAIL_API_KEY,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          address: address,
+          amount: amount
+        })
+      }, function (err) {
+        if (err) return callback(err)
+
+        testnet.addresses.unspents(address, function (err, result) {
+          if (err) return callback(err)
+
+          // filter small unspents
+          unspents = result.filter(function (unspent) {
+            return unspent.value > 1e3
+          })
+
+          callback()
+        })
+      })
+    },
+    function (err) {
+      if (err) return done(err)
+
+      done(null, unspents)
+    }
+  )
 }
 
 module.exports = {

--- a/test/integration/advanced.js
+++ b/test/integration/advanced.js
@@ -22,53 +22,42 @@ describe('bitcoinjs-lib (advanced)', function () {
   })
 
   it('can create an OP_RETURN transaction', function (done) {
-    this.timeout(20000)
+    this.timeout(30000)
 
     var network = bitcoin.networks.testnet
     var keyPair = bitcoin.ECPair.makeRandom({ network: network })
     var address = keyPair.getAddress()
 
-    blockchain.t.faucet(address, 2e4, function (err) {
+    blockchain.t.faucet(address, 2e4, function (err, unspents) {
       if (err) return done(err)
 
-      blockchain.t.addresses.unspents(address, function (err, unspents) {
+      // use the oldest unspent
+      var unspent = unspents.pop()
+      var tx = new bitcoin.TransactionBuilder(network)
+      var data = new Buffer('bitcoinjs-lib')
+      var dataScript = bitcoin.script.nullDataOutput(data)
+
+      tx.addInput(unspent.txId, unspent.vout)
+      tx.addOutput(dataScript, 1000)
+      tx.sign(0, keyPair)
+
+      var txBuilt = tx.build()
+
+      blockchain.t.transactions.propagate(txBuilt.toHex(), function (err) {
         if (err) return done(err)
 
-        // filter small unspents
-        unspents = unspents.filter(function (unspent) {
-          return unspent.value > 1e4
-        })
-
-        // use the oldest unspent
-        var unspent = unspents.pop()
-        if (!unspent) throw new Error('Faucet didn\'t provide an unspent')
-
-        var tx = new bitcoin.TransactionBuilder(network)
-        var data = new Buffer('bitcoinjs-lib')
-        var dataScript = bitcoin.script.nullDataOutput(data)
-
-        tx.addInput(unspent.txId, unspent.vout)
-        tx.addOutput(dataScript, 1000)
-        tx.sign(0, keyPair)
-
-        var txBuilt = tx.build()
-
-        blockchain.t.transactions.propagate(txBuilt.toHex(), function (err) {
+        // check that the message was propagated
+        blockchain.t.transactions.get(txBuilt.getId(), function (err, transaction) {
           if (err) return done(err)
 
-          // check that the message was propagated
-          blockchain.t.transactions.get(txBuilt.getId(), function (err, transaction) {
-            if (err) return done(err)
+          var actual = bitcoin.Transaction.fromHex(transaction.txHex)
+          var dataScript2 = actual.outs[0].script
+          var data2 = bitcoin.script.decompile(dataScript2)[1]
 
-            var actual = bitcoin.Transaction.fromHex(transaction.txHex)
-            var dataScript2 = actual.outs[0].script
-            var data2 = bitcoin.script.decompile(dataScript2)[1]
+          assert.deepEqual(dataScript, dataScript2)
+          assert.deepEqual(data, data2)
 
-            assert.deepEqual(dataScript, dataScript2)
-            assert.deepEqual(data, data2)
-
-            done()
-          })
+          done()
         })
       })
     })

--- a/test/integration/multisig.js
+++ b/test/integration/multisig.js
@@ -37,53 +37,41 @@ describe('bitcoinjs-lib (multisig)', function () {
     var address = bitcoin.address.fromOutputScript(scriptPubKey, bitcoin.networks.testnet)
 
     // attempt to send funds to the source address
-    blockchain.t.faucet(address, 2e4, function (err) {
+    blockchain.t.faucet(address, 2e4, function (err, unspents) {
       if (err) return done(err)
 
-      // get latest unspents from the address
-      blockchain.t.addresses.unspents(address, function (err, unspents) {
+      // use the oldest unspent
+      var unspent = unspents.pop()
+
+      // make a random destination address
+      var targetAddress = bitcoin.ECPair.makeRandom({
+        network: bitcoin.networks.testnet
+      }).getAddress()
+
+      var txb = new bitcoin.TransactionBuilder(bitcoin.networks.testnet)
+      txb.addInput(unspent.txId, unspent.vout)
+      txb.addOutput(targetAddress, 1e4)
+
+      // sign with 1st and 3rd key
+      txb.sign(0, keyPairs[0], redeemScript)
+      txb.sign(0, keyPairs[2], redeemScript)
+
+      // broadcast our transaction
+      var tx = txb.build()
+      var txId = tx.getId()
+
+      blockchain.t.transactions.propagate(tx.toHex(), function (err) {
         if (err) return done(err)
 
-        // filter small unspents
-        unspents = unspents.filter(function (unspent) {
-          return unspent.value > 1e4
-        })
-
-        // use the oldest unspent
-        var unspent = unspents.pop()
-
-        if (!unspent) throw new Error('Faucet didn\'t provide an unspent')
-
-        // make a random destination address
-        var targetAddress = bitcoin.ECPair.makeRandom({
-          network: bitcoin.networks.testnet
-        }).getAddress()
-
-        var txb = new bitcoin.TransactionBuilder(bitcoin.networks.testnet)
-        txb.addInput(unspent.txId, unspent.vout)
-        txb.addOutput(targetAddress, 1e4)
-
-        // sign with 1st and 3rd key
-        txb.sign(0, keyPairs[0], redeemScript)
-        txb.sign(0, keyPairs[2], redeemScript)
-
-        // broadcast our transaction
-        var tx = txb.build()
-        var txId = tx.getId()
-
-        blockchain.t.transactions.propagate(tx.toHex(), function (err) {
+        // check that the above transaction included the intended address
+        blockchain.t.addresses.unspents(targetAddress, function (err, unspents) {
           if (err) return done(err)
 
-          // check that the above transaction included the intended address
-          blockchain.t.addresses.unspents(targetAddress, function (err, unspents) {
-            if (err) return done(err)
+          assert(unspents.some(function (unspent) {
+            return unspent.txId === txId && unspent.value === 1e4
+          }))
 
-            assert(unspents.some(function (unspent) {
-              return unspent.txId === txId && unspent.value === 1e4
-            }))
-
-            done()
-          })
+          done()
         })
       })
     })


### PR DESCRIPTION
This version of typeforce uses ES5 solely, and should force any users to update their dependencies if they installed the miscompiled version.