### PR TITLE
README: remove IRC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ Daniel Cousens, Wei Lu, JP Richardson and Kyle Drake lead the major refactor of 
 
 ## Contributing
 
-Join the ongoing IRC development channel at `#bitcoinjs-dev` on Freenode.
-We are always accepting of Pull requests, but we do adhere to specific standards in regards to coding style, test driven development and commit messages.
+We are always accepting of pull requests, but we do adhere to specific standards in regards to coding style, test driven development and commit messages.
 
 Please make your best effort to adhere to these when contributing to save on trivial corrections.
 


### PR DESCRIPTION
The channel is rarely used, and it seems most discussion happens in the pull requests here.
I've been contacted more by email for this library than I have on IRC over the last 6 months.

If anyone wants it to remain in the README, please feel free to comment here.