### PR TITLE
Remove `const` and replace with `var`

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -13,7 +13,7 @@ var REVERSE_OPS = (function () {
   return result
 })()
 
-const OP_INT_BASE = OPS.OP_RESERVED // OP_1 - 1
+var OP_INT_BASE = OPS.OP_RESERVED // OP_1 - 1
 
 function toASM (chunks) {
   if (types.Buffer(chunks)) {


### PR DESCRIPTION
To keep the project consistenly ES5.

Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const