### PR TITLE
Segregated Witness Support - WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bitcoin.js
 coverage
 node_modules
+
+_dev.*.js

--- a/src/bufferwriter.js
+++ b/src/bufferwriter.js
@@ -1,0 +1,55 @@
+var bufferutils = require('./bufferutils')
+var typeforce = require('typeforce')
+var types = require('./types')
+
+var BufferWriter = function (length) {
+  typeforce(types.tuple(types.Number), arguments)
+  this.buffer = new Buffer(length)
+  this.offset = 0
+}
+
+BufferWriter.prototype.writeSlice = function (slice) {
+  slice.copy(this.buffer, this.offset)
+  this.offset += slice.length
+
+  return this
+}
+
+BufferWriter.prototype.writeSliceWithVarInt = function (script) {
+  this.writeVarInt(script.length)
+  this.writeSlice(script)
+
+  return this
+}
+
+BufferWriter.prototype.writeScript = BufferWriter.prototype.writeSliceWithVarInt
+
+BufferWriter.prototype.writeInt = function (i) {
+  this.buffer.writeUInt8(i, this.offset)
+  this.offset += 1
+
+  return this
+}
+
+BufferWriter.prototype.writeUInt64 = function (i) {
+  bufferutils.writeUInt64LE(this.buffer, i, this.offset)
+  this.offset += 8
+
+  return this
+}
+
+BufferWriter.prototype.writeUInt32 = function (i) {
+  this.buffer.writeUInt32LE(i, this.offset)
+  this.offset += 4
+
+  return this
+}
+
+BufferWriter.prototype.writeVarInt = function (i) {
+  var n = bufferutils.writeVarInt(this.buffer, i, this.offset)
+  this.offset += n
+
+  return this
+}
+
+module.exports = BufferWriter

--- a/src/networks.js
+++ b/src/networks.js
@@ -10,6 +10,8 @@ module.exports = {
     },
     pubKeyHash: 0x00,
     scriptHash: 0x05,
+    segWitPubKeyHash: 0x06,
+    segWitScriptHash: 0x0A,
     wif: 0x80,
     dustThreshold: 546 // https://github.com/bitcoin/bitcoin/blob/v0.9.2/src/core.h#L151-L162
   },
@@ -21,7 +23,22 @@ module.exports = {
     },
     pubKeyHash: 0x6f,
     scriptHash: 0xc4,
+    segWitPubKeyHash: 0x03,
+    segWitScriptHash: 0x28,
     wif: 0xef,
+    dustThreshold: 546
+  },
+  segnet: {
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
+    bip32: {
+      public: 0x053587CF,
+      private: 0x05358394
+    },
+    pubKeyHash: 0x1e,
+    scriptHash: 0x32,
+    segWitPubKeyHash: 0x03,
+    segWitScriptHash: 0x28,
+    wif: 0x9e,
     dustThreshold: 546
   },
   litecoin: {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -4,9 +4,15 @@ var bufferutils = require('./bufferutils')
 var opcodes = require('./opcodes')
 var typeforce = require('typeforce')
 var types = require('./types')
+var BufferWriter = require('./bufferwriter')
+
+var ADVANCED_TRANSACTION_MARKER = 0
+var ADVANCED_TRANSACTION_FLAG = 1
 
 function Transaction () {
   this.version = 1
+  this.marker = null
+  this.flag = null
   this.locktime = 0
   this.ins = []
   this.outs = []
@@ -37,6 +43,13 @@ Transaction.fromBuffer = function (buffer, __noStrict) {
     return i
   }
 
+  function readInt () {
+    var i = buffer.readUInt8(offset)
+    offset += 1
+
+    return i
+  }
+
   function readVarInt () {
     var vi = bufferutils.readVarInt(buffer, offset)
     offset += vi.size
@@ -47,8 +60,23 @@ Transaction.fromBuffer = function (buffer, __noStrict) {
     return readSlice(readVarInt())
   }
 
+  // console.log('fromBuffer')
+
   var tx = new Transaction()
   tx.version = readUInt32()
+
+  tx.marker = readInt()
+  tx.flag = readInt()
+
+  // check if transaction is advanced (segwit) format
+  if (tx.marker === ADVANCED_TRANSACTION_MARKER && tx.flag === ADVANCED_TRANSACTION_FLAG) {
+    // -
+  } else {
+    // undo the reading of the marker and flag byte
+    offset -= 2
+    tx.marker = null
+    tx.flag = null
+  }
 
   var vinLen = readVarInt()
   for (var i = 0; i < vinLen; ++i) {
@@ -56,7 +84,8 @@ Transaction.fromBuffer = function (buffer, __noStrict) {
       hash: readSlice(32),
       index: readUInt32(),
       script: readScript(),
-      sequence: readUInt32()
+      sequence: readUInt32(),
+      witness: undefined
     })
   }
 
@@ -66,6 +95,16 @@ Transaction.fromBuffer = function (buffer, __noStrict) {
       value: readUInt64(),
       script: readScript()
     })
+  }
+
+  if (tx.flag === ADVANCED_TRANSACTION_FLAG) {
+    for (i = 0; i < vinLen; ++i) {
+      tx.ins[i].witness = []
+      var witnessLen = readVarInt()
+      for (var x = 0; x < witnessLen; ++x) {
+        tx.ins[i].witness.push(readScript())
+      }
+    }
   }
 
   tx.locktime = readUInt32()
@@ -88,7 +127,7 @@ Transaction.isCoinbaseHash = function (buffer) {
 
 var EMPTY_SCRIPT = new Buffer(0)
 
-Transaction.prototype.addInput = function (hash, index, sequence, scriptSig) {
+Transaction.prototype.addInput = function (hash, index, sequence, scriptSig, witness) {
   typeforce(types.tuple(
     types.Hash256bit,
     types.UInt32,
@@ -105,7 +144,8 @@ Transaction.prototype.addInput = function (hash, index, sequence, scriptSig) {
     hash: hash,
     index: index,
     script: scriptSig || EMPTY_SCRIPT,
-    sequence: sequence
+    sequence: sequence,
+    witness: witness
   }) - 1)
 }
 
@@ -119,19 +159,35 @@ Transaction.prototype.addOutput = function (scriptPubKey, value) {
   }) - 1)
 }
 
-Transaction.prototype.byteLength = function () {
+Transaction.prototype.byteLength = function (withWitness) {
   function scriptSize (someScript) {
     var length = someScript.length
 
     return bufferutils.varIntSize(length) + length
   }
 
+  var witnessLength = 0
+  var advancedTxMarkerFlagLength = 0
+
+  if (this.flag === ADVANCED_TRANSACTION_FLAG && withWitness) {
+    advancedTxMarkerFlagLength = 2
+    witnessLength = this.ins.reduce(function (sum, txIn) {
+      var witness = txIn.witness || []
+
+      return sum + bufferutils.varIntSize(witness.length) + witness.reduce(function (sum, witnessChunk) {
+        return sum + scriptSize(witnessChunk)
+      }, 0)
+    }, 0)
+  }
+
   return (
     8 +
+    advancedTxMarkerFlagLength +
     bufferutils.varIntSize(this.ins.length) +
     bufferutils.varIntSize(this.outs.length) +
     this.ins.reduce(function (sum, input) { return sum + 40 + scriptSize(input.script) }, 0) +
-    this.outs.reduce(function (sum, output) { return sum + 8 + scriptSize(output.script) }, 0)
+    this.outs.reduce(function (sum, output) { return sum + 8 + scriptSize(output.script) }, 0) +
+    witnessLength
   )
 }
 
@@ -139,13 +195,16 @@ Transaction.prototype.clone = function () {
   var newTx = new Transaction()
   newTx.version = this.version
   newTx.locktime = this.locktime
+  newTx.marker = this.marker
+  newTx.flag = this.flag
 
   newTx.ins = this.ins.map(function (txIn) {
     return {
       hash: txIn.hash,
       index: txIn.index,
       script: txIn.script,
-      sequence: txIn.sequence
+      sequence: txIn.sequence,
+      witness: txIn.witness ? txIn.witness.slice() : txIn.witness
     }
   })
 
@@ -170,9 +229,100 @@ var VALUE_UINT64_MAX = new Buffer('ffffffffffffffff', 'hex')
  * hashType, and then hashes the result.
  * This hash can then be used to sign the provided transaction input.
  */
-Transaction.prototype.hashForSignature = function (inIndex, prevOutScript, hashType) {
-  typeforce(types.tuple(types.UInt32, types.Buffer, /* types.UInt8 */ types.Number), arguments)
+Transaction.prototype.hashForSignature = function (inIndex, prevOutScript, hashType, segWit, amount) {
+  typeforce(types.tuple(types.UInt32, types.Buffer, /* types.UInt8 */ types.Number, types.maybe(types.Boolean)), arguments)
 
+  if (segWit) {
+    return this.hashForSignatureV2(inIndex, prevOutScript, amount, hashType)
+  } else {
+    return this.hashForSignatureV1(inIndex, prevOutScript, hashType)
+  }
+}
+
+Transaction.prototype.hashForSignatureV2 = function (inIndex, prevOutScript, amount, hashType) {
+  var hashPrevouts = new Buffer(((new Array(32 + 1)).join('00')), 'hex')
+  var hashSequence = new Buffer(((new Array(32 + 1)).join('00')), 'hex')
+  var hashOutputs = new Buffer(((new Array(32 + 1)).join('00')), 'hex')
+
+  function txOutToBuffer (txOut) {
+    var bufferWriter = new BufferWriter(8 + bufferutils.varIntSize(txOut.script.length) + txOut.script.length)
+
+    bufferWriter.writeUInt64(txOut.value)
+    bufferWriter.writeScript(txOut.script)
+
+    return bufferWriter.buffer
+  }
+
+  if (!(hashType & Transaction.SIGHASH_ANYONECANPAY)) {
+    hashPrevouts = bcrypto.hash256(Buffer.concat(this.ins.map(function (txIn) {
+      var bufferWriter = new BufferWriter(36)
+
+      bufferWriter.writeSlice(txIn.hash)
+      bufferWriter.writeUInt32(txIn.index)
+
+      return bufferWriter.buffer
+    })))
+  }
+
+  if (!(hashType & Transaction.SIGHASH_ANYONECANPAY) && (hashType & 0x1f) !== Transaction.SIGHASH_SINGLE && (hashType & 0x1f) !== Transaction.SIGHASH_NONE) {
+    hashSequence = bcrypto.hash256(Buffer.concat(this.ins.map(function (txIn) {
+      var bufferWriter = new BufferWriter(4)
+
+      bufferWriter.writeUInt32(txIn.sequence)
+
+      // console.log(txIn.sequence, bufferWriter.buffer.toString('hex'))
+
+      return bufferWriter.buffer
+    })))
+  }
+
+  if ((hashType & 0x1f) !== Transaction.SIGHASH_SINGLE && (hashType & 0x1f) !== Transaction.SIGHASH_NONE) {
+    hashOutputs = bcrypto.hash256(Buffer.concat(this.outs.map(function (txOut) {
+      return txOutToBuffer(txOut)
+    })))
+  } else if ((hashType & 0x1f) === Transaction.SIGHASH_SINGLE && inIndex < this.outs.length) {
+    hashOutputs = bcrypto.hash256(txOutToBuffer(this.outs[inIndex]))
+  }
+
+  // console.log('hashPrevouts', hashPrevouts.toString('hex'))
+  // console.log('hashSequence', hashSequence.toString('hex'))
+  // console.log('hashOutputs', hashOutputs.toString('hex'))
+
+  // TODO: cache hashPrevouts, hashSequence and hashOutputs for all signatures in a transaction
+
+  var bufferWriter = new BufferWriter(4 + 32 + 32 + 32 + 4 + bufferutils.varIntSize(prevOutScript.length) + prevOutScript.length + 8 + 4 + 32 + 4 + 4)
+
+  bufferWriter.writeUInt32(this.version)
+
+  bufferWriter.writeSlice(hashPrevouts)
+  bufferWriter.writeSlice(hashSequence)
+
+  // console.log('prevOutScript', prevOutScript)
+  // console.log('prevOutScript', bscript.toASM(prevOutScript))
+
+  // console.log('amount', amount)
+
+  // The input being signed (replacing the scriptSig with scriptCode + amount)
+  // The prevout may already be contained in hashPrevout, and the nSequence
+  // may already be contain in hashSequence.
+  bufferWriter.writeSlice(this.ins[inIndex].hash)
+  bufferWriter.writeUInt32(this.ins[inIndex].index)
+  bufferWriter.writeScript(prevOutScript)
+  bufferWriter.writeUInt64(amount)
+  bufferWriter.writeUInt32(this.ins[inIndex].sequence)
+
+  bufferWriter.writeSlice(hashOutputs)
+
+  bufferWriter.writeUInt32(this.locktime)
+  bufferWriter.writeUInt32(hashType)
+
+  // console.log('SignatureHashPayload', bufferWriter.buffer.toString('hex'))
+  // console.log('SignatureHash', bcrypto.hash256(bufferWriter.buffer).toString('hex'))
+
+  return bcrypto.hash256(bufferWriter.buffer)
+}
+
+Transaction.prototype.hashForSignatureV1 = function (inIndex, prevOutScript, hashType) {
   // https://github.com/bitcoin/bitcoin/blob/master/src/test/sighash_tests.cpp#L29
   if (inIndex >= this.ins.length) return ONE
 
@@ -250,13 +400,34 @@ Transaction.prototype.getId = function () {
   return [].reverse.call(this.getHash()).toString('hex')
 }
 
-Transaction.prototype.toBuffer = function () {
-  var buffer = new Buffer(this.byteLength())
+Transaction.prototype.toBuffer = function (withWitness) {
+  // console.log('tx.Buffer')
+
+  // @TODO: it would be nicer if the marker/flag would be set when witness is set on one of the txIn...
+  var txInHaveWitness = this.ins.some(function (txIn) {
+    return typeof txIn.witness !== 'undefined'
+  })
+
+  // console.log('tx.Buffer::txInHaveWitness', txInHaveWitness)
+
+  if (txInHaveWitness) {
+    this.marker = ADVANCED_TRANSACTION_MARKER
+    this.flag = ADVANCED_TRANSACTION_FLAG
+  }
+
+  var buffer = new Buffer(this.byteLength(withWitness))
 
   var offset = 0
   function writeSlice (slice) {
     slice.copy(buffer, offset)
     offset += slice.length
+  }
+
+  function writeInt (i) {
+    buffer.writeUInt8(i, offset)
+    offset += 1
+
+    return i
   }
 
   function writeUInt32 (i) {
@@ -275,8 +446,13 @@ Transaction.prototype.toBuffer = function () {
   }
 
   writeUInt32(this.version)
-  writeVarInt(this.ins.length)
 
+  if (this.flag !== null && withWitness) {
+    writeInt(this.marker)
+    writeInt(this.flag)
+  }
+
+  writeVarInt(this.ins.length)
   this.ins.forEach(function (txIn) {
     writeSlice(txIn.hash)
     writeUInt32(txIn.index)
@@ -297,19 +473,33 @@ Transaction.prototype.toBuffer = function () {
     writeSlice(txOut.script)
   })
 
+  if (this.flag === ADVANCED_TRANSACTION_FLAG && withWitness) {
+    this.ins.forEach(function (txIn) {
+      var witness = txIn.witness || []
+
+      writeVarInt(witness.length)
+
+      witness.forEach(function (witnessChunk) {
+        writeVarInt(witnessChunk.length)
+        writeSlice(witnessChunk)
+      })
+    })
+  }
+
   writeUInt32(this.locktime)
 
   return buffer
 }
 
-Transaction.prototype.toHex = function () {
-  return this.toBuffer().toString('hex')
+Transaction.prototype.toHex = function (withWitness) {
+  return this.toBuffer(withWitness).toString('hex')
 }
 
-Transaction.prototype.setInputScript = function (index, scriptSig) {
-  typeforce(types.tuple(types.Number, types.Buffer), arguments)
+Transaction.prototype.setInputScript = function (index, scriptSig, witness) {
+  typeforce(types.tuple(types.Number, types.Buffer, types.maybe(types.Array)), arguments)
 
   this.ins[index].script = scriptSig
+  this.ins[index].witness = witness
 }
 
 module.exports = Transaction

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -46,17 +46,51 @@ function fixMSSignatures (transaction, vin, pubKeys, signatures, prevOutScript, 
 function extractInput (transaction, txIn, vin) {
   var scriptSigChunks = bscript.decompile(txIn.script)
   var prevOutType = bscript.classifyInput(scriptSigChunks, true)
+  var isSegWit = false
 
-  if (txIn.script.length === 0) {
+  if (txIn.witness && txIn.witness.length) {
+    // native segwit
+    if (scriptSigChunks.length === 0) {
+      prevOutType = bscript.classifyInput(txIn.witness, true)
+      isSegWit = true
+
+      switch (prevOutType) {
+        case 'pubkeyhash':
+          prevOutType = 'segwitpubkeyhash'
+          break
+
+        default:
+          throw new Error('segwit ' + prevOutType + ' not supported')
+      }
+    // segwit nested in P2SH
+    } else if (scriptSigChunks.length === 1) {
+      scriptSigChunks = txIn.witness.concat(scriptSigChunks)
+      prevOutType = bscript.classifyInput(scriptSigChunks, true)
+      isSegWit = true
+
+      if (prevOutType !== 'scripthash') throw new Error('segwit ' + prevOutType + ' not supported')
+    } else {
+      throw new Error('not supported')
+    }
+  // Ignore empty scripts
+  } else if (txIn.script.length === 0) {
     return {}
   }
 
-  var processScript = function (scriptType, scriptSigChunks, redeemScriptChunks) {
+  // console.log('extractInput::prevOutType', prevOutType)
+
+  var processScript = function (scriptType, scriptSigChunks, isSegWit, redeemScriptChunks) {
+    // console.log('extractInput::processScript')
+
     // ensure chunks are decompiled
     scriptSigChunks = bscript.decompile(scriptSigChunks)
     redeemScriptChunks = redeemScriptChunks ? bscript.decompile(redeemScriptChunks) : undefined
 
     var hashType, pubKeys, signatures, prevOutScript, redeemScript, redeemScriptType, result, parsed
+
+    // console.log('extractInput::processScript::scriptType', scriptType)
+    // console.log('extractInput::processScript::scriptSigChunks', scriptSigChunks)
+    // console.log('extractInput::processScript::redeemScriptChunks', redeemScriptChunks)
 
     switch (scriptType) {
       case 'scripthash':
@@ -66,7 +100,22 @@ function extractInput (transaction, txIn, vin) {
         redeemScriptType = bscript.classifyInput(scriptSigChunks, true)
         prevOutScript = bscript.scriptHashOutput(bcrypto.hash160(redeemScript))
 
-        result = processScript(redeemScriptType, scriptSigChunks, bscript.decompile(redeemScript))
+        // console.log('extractInput::processScript::scripthash::redeemScript', redeemScript)
+
+        result = processScript(redeemScriptType, scriptSigChunks, isSegWit, bscript.decompile(redeemScript))
+
+        // console.log('extractInput::processScript::scripthash::result', result)
+
+        if (isSegWit) {
+          switch (redeemScriptType) {
+            case 'pubkeyhash':
+              redeemScriptType = 'segwitpubkeyhash'
+              break
+
+            default:
+              throw new Error('segwit scripthash[ ' + redeemScriptType + ' ] not supported')
+          }
+        }
 
         result.prevOutScript = prevOutScript
         result.redeemScript = redeemScript
@@ -95,6 +144,7 @@ function extractInput (transaction, txIn, vin) {
         break
 
       case 'multisig':
+        // console.log('extractInput::multisig::scriptSigChunks', scriptSigChunks)
         signatures = scriptSigChunks.slice(1).map(function (chunk) {
           if (chunk === ops.OP_0) return undefined
 
@@ -104,6 +154,7 @@ function extractInput (transaction, txIn, vin) {
           return parsed.signature
         })
 
+        // console.log('extractInput::multisig::redeemScriptChunks', redeemScriptChunks)
         if (redeemScriptChunks) {
           pubKeys = redeemScriptChunks.slice(1, -2)
 
@@ -111,6 +162,17 @@ function extractInput (transaction, txIn, vin) {
             signatures = fixMSSignatures(transaction, vin, pubKeys, signatures, bscript.compile(redeemScriptChunks), hashType, redeemScript)
           }
         }
+
+        // console.log('extractInput::multisig::signatures', signatures.map(function (sig) { return sig && sig.toDER() }))
+
+        break
+
+      case 'segwitpubkeyhash':
+        parsed = ECSignature.parseScriptSignature(txIn.witness[0])
+        hashType = parsed.hashType
+        pubKeys = [txIn.witness[1]]
+        signatures = [parsed.signature]
+        prevOutScript = bscript.segWitPubKeyHashOutput(bcrypto.hash160(pubKeys[0]))
 
         break
     }
@@ -126,7 +188,7 @@ function extractInput (transaction, txIn, vin) {
   }
 
   // Extract hashType, pubKeys, signatures and prevOutScript
-  var result = processScript(prevOutType, scriptSigChunks)
+  var result = processScript(prevOutType, scriptSigChunks, isSegWit)
 
   return {
     hashType: result.hashType,
@@ -135,7 +197,10 @@ function extractInput (transaction, txIn, vin) {
     pubKeys: result.pubKeys,
     redeemScript: result.redeemScript,
     redeemScriptType: result.redeemScriptType,
-    signatures: result.signatures
+    segWitScript: result.segWitScript,
+    segWitScriptType: result.segWitScriptType,
+    signatures: result.signatures,
+    witness: txIn.witness || []
   }
 }
 
@@ -191,6 +256,9 @@ TransactionBuilder.fromTransaction = function (transaction, network) {
     return extractInput(transaction, txIn, vin)
   })
 
+  // console.log('txb.fromTransaction::inputs', txb.inputs[0])
+  // console.log('txb.fromTransaction::tx.ins', txb.tx.ins[0])
+
   return txb
 }
 
@@ -226,7 +294,7 @@ TransactionBuilder.prototype.addInput = function (txHash, vout, sequence, prevOu
         break
     }
 
-    if (prevOutType !== 'scripthash') {
+    if (prevOutType !== 'scripthash' && prevOutType !== 'segwitscripthash') {
       input.scriptType = prevOutType
     }
 
@@ -294,7 +362,9 @@ TransactionBuilder.prototype.buildIncomplete = function () {
 var canBuildTypes = {
   'multisig': true,
   'pubkey': true,
-  'pubkeyhash': true
+  'pubkeyhash': true,
+  'segwitpubkeyhash': true,
+  'segwitscripthash': true
 }
 
 TransactionBuilder.prototype.__build = function (allowIncomplete) {
@@ -309,6 +379,7 @@ TransactionBuilder.prototype.__build = function (allowIncomplete) {
   this.inputs.forEach(function (input, index) {
     var scriptType = input.redeemScriptType || input.prevOutType
     var scriptSig
+    var witness
 
     if (!allowIncomplete) {
       if (!scriptType) throw new Error('Transaction is not complete')
@@ -346,17 +417,36 @@ TransactionBuilder.prototype.__build = function (allowIncomplete) {
             }
 
             scriptSig = bscript.multisigInput(msSignatures, allowIncomplete ? undefined : redeemScript)
-
             break
 
           case 'pubkey':
             var pkSignature = input.signatures[0].toScriptSignature(input.hashType)
             scriptSig = bscript.pubKeyInput(pkSignature)
             break
+
+          case 'segwitpubkeyhash':
+            pkhSignature = input.signatures[0].toScriptSignature(input.hashType)
+            witness = input.witness
+            witness[0] = pkhSignature
+            scriptSig = new Buffer('')
+            break
+
+          case 'segwitscripthash':
+            witness = bscript.decompile(processScript(input.segWitScriptType, scriptType, input.segWitScript))
+
+            witness = witness.map(function (chunk) {
+              if (!(chunk instanceof Buffer)) {
+                return new Buffer(chunk)
+              }
+
+              return chunk
+            })
+
+            return input.redeemScript
         }
 
         // wrap as scriptHash if necessary
-        if (parentType === 'scripthash') {
+        if (parentType === 'scripthash' || parentType === 'segwitscripthash') {
           scriptSig = bscript.scriptHashInput(scriptSig, redeemScript)
         }
 
@@ -368,14 +458,14 @@ TransactionBuilder.prototype.__build = function (allowIncomplete) {
 
     // did we build a scriptSig? Buffer('') is allowed
     if (scriptSig) {
-      tx.setInputScript(index, scriptSig)
+      tx.setInputScript(index, scriptSig, witness)
     }
   })
 
   return tx
 }
 
-TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hashType) {
+TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hashType, segWit, amount, segWitScript) {
   if (keyPair.network !== this.network) throw new Error('Inconsistent network')
   if (!this.inputs[index]) throw new Error('No input at index: ' + index)
   hashType = hashType || Transaction.SIGHASH_ALL
@@ -388,6 +478,7 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
     input.redeemScriptType &&
     input.signatures &&
     input.signatures.length === input.pubKeys.length
+  // @TODO segWit
 
   var kpPubKey = keyPair.getPublicKeyBuffer()
   var signatureScript
@@ -404,7 +495,6 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
   // no? prepare
   } else {
     // must be pay-to-scriptHash?
-
     if (redeemScript) {
       // if we have a prevOutScript, enforce scriptHash equality to the redeemScript
       if (input.prevOutScript) {
@@ -417,6 +507,7 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
       var pubKeys, pkh1, pkh2
 
       var redeemScriptType
+      var segWitScriptType
 
       var processScript = function (redeemScript) {
         var scriptType = bscript.classifyOutput(redeemScript)
@@ -425,6 +516,12 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
         switch (scriptType) {
           case 'multisig':
             pubKeys = redeemScriptChunks.slice(1, -2)
+
+            if (segWit) {
+              input.witness = [new Buffer(''), undefined, redeemScript]
+
+              segWitScript = segWitScript || bscript.multisigOutput(1, pubKeys) // @TODO bufferEquals?
+            }
 
             break
 
@@ -435,10 +532,38 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
             if (!bufferEquals(pkh1, pkh2)) throw new Error('privateKey cannot sign for this input')
             pubKeys = [kpPubKey]
 
+            if (segWit) {
+              input.witness = [undefined, kpPubKey]
+              segWitScript = segWitScript || bscript.pubKeyHashOutput(pkh1)// @TODO bufferEquals?
+            }
+
             break
 
           case 'pubkey':
             pubKeys = redeemScriptChunks.slice(0, 1)
+
+            // @TODO: P2WSH(segWit)
+
+            break
+
+          case 'segwitpubkeyhash':
+            pkh1 = redeemScriptChunks.slice(1)[0]
+            pkh2 = bcrypto.hash160(keyPair.getPublicKeyBuffer())
+
+            if (!bufferEquals(pkh1, pkh2)) throw new Error('privateKey cannot sign for this input')
+            pubKeys = [kpPubKey]
+
+            input.witness = [undefined, kpPubKey]
+            segWitScript = bscript.pubKeyHashOutput(pkh1)
+
+            break
+
+          case 'segwitscripthash':
+            if (!segWitScript) {
+              throw new Error('Missing SegWitScript for segwitscripthash')
+            }
+
+            segWitScriptType = processScript(segWitScript)
 
             break
 
@@ -460,15 +585,28 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
       input.pubKeys = pubKeys
       input.redeemScript = redeemScript
       input.redeemScriptType = redeemScriptType
+      input.segWitScript = segWitScript
+      input.segWitScriptType = segWitScriptType
       input.signatures = pubKeys.map(function () { return undefined })
     } else {
       // pay-to-scriptHash is not possible without a redeemScript
       if (input.prevOutType === 'scripthash') throw new Error('PrevOutScript is P2SH, missing redeemScript')
 
+      // console.log('input.pubKeys', input.pubKeys)
+      // console.log('input.scriptType', input.scriptType)
+      // console.log('segWit', segWit)
+
       // if we don't have a scriptType, assume pubKeyHash otherwise
       if (!input.scriptType) {
-        input.prevOutScript = bscript.pubKeyHashOutput(bcrypto.hash160(keyPair.getPublicKeyBuffer()))
-        input.prevOutType = 'pubkeyhash'
+        if (segWit) {
+          input.prevOutScript = bscript.segWitPubKeyHashOutput(bcrypto.hash160(keyPair.getPublicKeyBuffer()))
+          input.prevOutType = 'segwitpubkeyhash'
+          input.witness = [undefined, kpPubKey]
+          signatureScript = bscript.pubKeyHashOutput(bcrypto.hash160(keyPair.getPublicKeyBuffer()))
+        } else {
+          input.prevOutScript = bscript.pubKeyHashOutput(bcrypto.hash160(keyPair.getPublicKeyBuffer()))
+          input.prevOutType = 'pubkeyhash'
+        }
 
         input.pubKeys = [kpPubKey]
         input.scriptType = input.prevOutType
@@ -482,12 +620,17 @@ TransactionBuilder.prototype.sign = function (index, keyPair, redeemScript, hash
     input.hashType = hashType
   }
 
+  // console.log('sign::input.segWitScript', input.segWitScript)
+  // console.log('sign::signatureScript', signatureScript)
+
   // ready to sign?
-  signatureScript = signatureScript || input.redeemScript || input.prevOutScript
-  var signatureHash = this.tx.hashForSignature(index, signatureScript, hashType)
+  signatureScript = signatureScript || input.segWitScript || input.redeemScript || input.prevOutScript
+  var signatureHash = this.tx.hashForSignature(index, signatureScript, hashType, segWit, amount)
 
   // enforce in order signing of public keys
   var valid = input.pubKeys.some(function (pubKey, i) {
+    // console.log('sign::sign', index, i)
+
     if (!bufferEquals(kpPubKey, pubKey)) return false
     if (input.signatures[i]) throw new Error('Signature already exists')
 

--- a/test/address.js
+++ b/test/address.js
@@ -14,11 +14,15 @@ describe('address', function () {
 
         assert.strictEqual(decode.version, f.version)
         assert.strictEqual(decode.hash.toString('hex'), f.hash)
+
+        if (typeof f.segWitVersion !== 'undefined') {
+          assert.strictEqual(decode.segWitVersion, f.segWitVersion)
+        }
       })
     })
 
     fixtures.invalid.fromBase58Check.forEach(function (f) {
-      it('throws on ' + f.exception, function () {
+      it('throws on ' + f.exception + ' (' + f.address + ')', function () {
         assert.throws(function () {
           baddress.fromBase58Check(f.address)
         }, new RegExp(f.address + ' ' + f.exception))
@@ -59,7 +63,7 @@ describe('address', function () {
   describe('toBase58Check', function () {
     fixtures.valid.forEach(function (f) {
       it('formats ' + f.hash + ' (' + f.network + ')', function () {
-        var address = baddress.toBase58Check(new Buffer(f.hash, 'hex'), f.version)
+        var address = baddress.toBase58Check(new Buffer(f.hash, 'hex'), f.version, f.segWitVersion)
 
         assert.strictEqual(address, f.base58check)
       })

--- a/test/fixtures/address.json
+++ b/test/fixtures/address.json
@@ -15,6 +15,22 @@
       "script": "OP_HASH160 cd7b44d0b03f2d026d1e586d7ae18903b0d385f6 OP_EQUAL"
     },
     {
+      "network": "bitcoin",
+      "version": 6,
+      "hash": "751e76e8199196d454941c45d1b3a323f1433bd6",
+      "segWitVersion": 0,
+      "base58check": "p2y59b9U5YTUAYEDBr5zwSHFoM8pn3ozAhRD",
+      "script": "OP_0 751e76e8199196d454941c45d1b3a323f1433bd6"
+    },
+    {
+      "network": "bitcoin",
+      "version": 10,
+      "hash": "b6148e3abb0116ef3bf752c4a0377cd35aa9b6c3db8073103472fc69f615318d",
+      "segWitVersion": 0,
+      "base58check": "7XhQas9H1tJ1e1QqgdoojWoBSrSGFZKPorV3eTcq5w15JeNTngReA",
+      "script": "OP_0 b6148e3abb0116ef3bf752c4a0377cd35aa9b6c3db8073103472fc69f615318d"
+    },
+    {
       "network": "testnet",
       "version": 111,
       "hash": "751e76e8199196d454941c45d1b3a323f1433bd6",
@@ -27,6 +43,60 @@
       "hash": "cd7b44d0b03f2d026d1e586d7ae18903b0d385f6",
       "base58check": "2NByiBUaEXrhmqAsg7BbLpcQSAQs1EDwt5w",
       "script": "OP_HASH160 cd7b44d0b03f2d026d1e586d7ae18903b0d385f6 OP_EQUAL"
+    },
+    {
+      "network": "testnet",
+      "version": 3,
+      "hash": "751e76e8199196d454941c45d1b3a323f1433bd6",
+      "segWitVersion": 0,
+      "base58check": "QWz8QvrJz5QmWegmBv9tXP447AdU7JQtyakg",
+      "script": "OP_0 751e76e8199196d454941c45d1b3a323f1433bd6"
+    },
+    {
+      "network": "testnet",
+      "version": 40,
+      "hash": "b6148e3abb0116ef3bf752c4a0377cd35aa9b6c3db8073103472fc69f615318d",
+      "segWitVersion": 0,
+      "base58check": "T7nZBtafiNv9ZhaZ7ujAFbTjzBPC6q9rk5KCdrFeAsy7Z6aDM1RPt",
+      "script": "OP_0 b6148e3abb0116ef3bf752c4a0377cd35aa9b6c3db8073103472fc69f615318d"
+    },
+    {
+      "network": "segnet",
+      "version": 30,
+      "hash": "751e76e8199196d454941c45d1b3a323f1433bd6",
+      "base58check": "DFpN6QqFfUm3gKNaxN6tNcab1FArL9cZLE",
+      "script": "OP_DUP OP_HASH160 751e76e8199196d454941c45d1b3a323f1433bd6 OP_EQUALVERIFY OP_CHECKSIG"
+    },
+    {
+      "network": "segnet",
+      "version": 50,
+      "hash": "cd7b44d0b03f2d026d1e586d7ae18903b0d385f6",
+      "base58check": "MSdeRd4AsX3rRtX2Xvxp2JfaGmFHUYVk9A",
+      "script": "OP_HASH160 cd7b44d0b03f2d026d1e586d7ae18903b0d385f6 OP_EQUAL"
+    },
+    {
+      "network": "segnet",
+      "version": 3,
+      "hash": "751e76e8199196d454941c45d1b3a323f1433bd6",
+      "segWitVersion": 0,
+      "base58check": "QWz8QvrJz5QmWegmBv9tXP447AdU7JQtyakg",
+      "script": "OP_0 751e76e8199196d454941c45d1b3a323f1433bd6"
+    },
+    {
+      "network": "segnet",
+      "version": 3,
+      "hash": "751e76e8199196d454941c45d1b3a323f1433bd6",
+      "segWitVersion": 0,
+      "base58check": "QWz8QvrJz5QmWegmBv9tXP447AdU7JQtyakg",
+      "script": "OP_0 751e76e8199196d454941c45d1b3a323f1433bd6"
+    },
+    {
+      "network": "segnet",
+      "version": 40,
+      "hash": "b6148e3abb0116ef3bf752c4a0377cd35aa9b6c3db8073103472fc69f615318d",
+      "segWitVersion": 0,
+      "base58check": "T7nZBtafiNv9ZhaZ7ujAFbTjzBPC6q9rk5KCdrFeAsy7Z6aDM1RPt",
+      "script": "OP_0 b6148e3abb0116ef3bf752c4a0377cd35aa9b6c3db8073103472fc69f615318d"
     }
   ],
   "invalid": {
@@ -36,7 +106,7 @@
         "exception": "is too short"
       },
       {
-        "address": "j9ywUkWg2fTQrouxxh5rSZhRvrjMkEUfuiKe",
+        "address": "4D4eKTV3yGLjaJr4mzovRDqKT2iVxZpCp4ALzk",
         "exception": "is too long"
       }
     ],

--- a/test/fixtures/script.json
+++ b/test/fixtures/script.json
@@ -60,6 +60,12 @@
       "scriptPubKeyHex": "a914722ff0bc2c3f47b35c20df646c395594da24e90e87"
     },
     {
+      "type": "segwitpubkeyhash",
+      "pubKey": "02359c6e3f04cefbf089cf1d6670dc47c3fb4df68e2bad1fa5a369f9ce4b42bbd1",
+      "scriptPubKey": "OP_0 aa4d7985c57e011a8b3dd8e0e5a73aaef41629c5",
+      "scriptPubKeyHex": "0014aa4d7985c57e011a8b3dd8e0e5a73aaef41629c5"
+    },
+    {
       "type": "nulldata",
       "data": "06deadbeef03f895a2ad89fb6d696497af486cb7c644a27aa568c7a18dd06113401115185474",
       "scriptPubKey": "OP_RETURN 06deadbeef03f895a2ad89fb6d696497af486cb7c644a27aa568c7a18dd06113401115185474",

--- a/test/fixtures/transaction.json
+++ b/test/fixtures/transaction.json
@@ -224,6 +224,146 @@
           }
         ]
       }
+    },
+    {
+      "description": "-> segWitPubKeyHash",
+      "id": "788e0fa2f54fa03eae137316bd1a5e5d3bec290591bdb2e9d1f730bcf27ee513",
+      "hash": "13e57ef2bc30f7d1e9b2bd910529ec3b5d5e1abd167313ae3ea04ff5a20f8e78",
+      "raw": {
+        "version": 1,
+        "ins": [
+          {
+            "hash": "f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe",
+            "index": 0,
+            "script": "30450221008732a460737d956fd94d49a31890b2908f7ed7025a9c1d0f25e43290f1841716022004fa7d608a291d44ebbbebbadaac18f943031e7de39ef3bf9920998c43e60c0401 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+          }
+        ],
+        "outs": [
+          {
+            "script": "OP_0 c42e7ef92fdb603af844d064faad95db9bcdfd3d",
+            "value": 100000
+          }
+        ],
+        "locktime": 0
+      },
+      "hex": "0100000001f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe000000006b4830450221008732a460737d956fd94d49a31890b2908f7ed7025a9c1d0f25e43290f1841716022004fa7d608a291d44ebbbebbadaac18f943031e7de39ef3bf9920998c43e60c0401210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ffffffff01a086010000000000160014c42e7ef92fdb603af844d064faad95db9bcdfd3d00000000"
+    },
+    {
+      "description": "-> segWitPubKeyHash as scriptHash",
+      "id": "1e0a96b96dc53369baec00ca3d667ff24168ba10022250bc76a29024ce42949f",
+      "hash": "9f9442ce2490a276bc50220210ba6841f27f663dca00ecba6933c56db9960a1e",
+      "raw": {
+        "version": 1,
+        "ins": [
+          {
+            "hash": "f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe",
+            "index": 0,
+            "script": "30450221008732a460737d956fd94d49a31890b2908f7ed7025a9c1d0f25e43290f1841716022004fa7d608a291d44ebbbebbadaac18f943031e7de39ef3bf9920998c43e60c0401 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+          }
+        ],
+        "outs": [
+          {
+            "script": "OP_HASH160 37c70b38661336f43b0ea798913860a89007e0d5 OP_EQUAL",
+            "value": 100000
+          }
+        ],
+        "locktime": 0
+      },
+      "hex": "0100000001f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe000000006b4830450221008732a460737d956fd94d49a31890b2908f7ed7025a9c1d0f25e43290f1841716022004fa7d608a291d44ebbbebbadaac18f943031e7de39ef3bf9920998c43e60c0401210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ffffffff01a08601000000000017a91437c70b38661336f43b0ea798913860a89007e0d58700000000"
+    },
+    {
+      "description": "segWitPubKeyHash -> segWitPubKeyHash",
+      "id": "9810b5aaaa7995c95cb07f0c3ba38424c7e910659fdb4c5eed87aed0be4d703d",
+      "hash": "3d704dbed0ae87ed5e4cdb9f6510e9c72484a33b0c7fb05cc99579aaaab51098",
+      "raw": {
+        "version": 1,
+        "ins": [
+          {
+            "hash": "f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe",
+            "index": 0,
+            "script": "",
+            "witness": [
+              "30450221008732a460737d956fd94d49a31890b2908f7ed7025a9c1d0f25e43290f1841716022004fa7d608a291d44ebbbebbadaac18f943031e7de39ef3bf9920998c43e60c0401",
+              "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            ]
+          }
+        ],
+        "outs": [
+          {
+            "script": "OP_0 c42e7ef92fdb603af844d064faad95db9bcdfd3d",
+            "value": 100000
+          }
+        ],
+        "locktime": 0
+      },
+      "hex": "0100000001f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0000000000ffffffff01a086010000000000160014c42e7ef92fdb603af844d064faad95db9bcdfd3d00000000",
+      "hexWithWitness": "01000000000101f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe0000000000ffffffff01a086010000000000160014c42e7ef92fdb603af844d064faad95db9bcdfd3d024830450221008732a460737d956fd94d49a31890b2908f7ed7025a9c1d0f25e43290f1841716022004fa7d608a291d44ebbbebbadaac18f943031e7de39ef3bf9920998c43e60c0401210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179800000000"
+    },
+    {
+      "description": "segWitPubKeyHash as scriptHash -> segWitPubKeyHash",
+      "id": "1aa3f6c3da44ae25db6603f5f8a85048a272af003728d30d892d43d7eb136e86",
+      "hash": "866e13ebd7432d890dd3283700af72a24850a8f8f50366db25ae44dac3f6a31a",
+      "raw": {
+        "version": 1,
+        "ins": [
+          {
+            "hash": "f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe",
+            "index": 0,
+            "script": "OP_0 c42e7ef92fdb603af844d064faad95db9bcdfd3d",
+            "witness": [
+              "30450221008732a460737d956fd94d49a31890b2908f7ed7025a9c1d0f25e43290f1841716022004fa7d608a291d44ebbbebbadaac18f943031e7de39ef3bf9920998c43e60c0401",
+              "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            ]
+          }
+        ],
+        "outs": [
+          {
+            "script": "OP_0 c42e7ef92fdb603af844d064faad95db9bcdfd3d",
+            "value": 100000
+          }
+        ],
+        "locktime": 0
+      },
+      "hex": "0100000001f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe00000000160014c42e7ef92fdb603af844d064faad95db9bcdfd3dffffffff01a086010000000000160014c42e7ef92fdb603af844d064faad95db9bcdfd3d00000000",
+      "hexWithWitness": "01000000000101f1fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe00000000160014c42e7ef92fdb603af844d064faad95db9bcdfd3dffffffff01a086010000000000160014c42e7ef92fdb603af844d064faad95db9bcdfd3d024830450221008732a460737d956fd94d49a31890b2908f7ed7025a9c1d0f25e43290f1841716022004fa7d608a291d44ebbbebbadaac18f943031e7de39ef3bf9920998c43e60c0401210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179800000000"
+    },
+    {
+      "description": "example",
+      "id": "e8151a2af31c368a35053ddd4bdb285a8595c769a3ad83e0fa02314a602d4609",
+      "hash": "09462d604a3102fae083ada369c795855a28db4bdd3d05358a361cf32a1a15e8",
+      "raw": {
+        "version": 1,
+        "ins": [
+          {
+            "txId": "9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff",
+            "index": 0,
+            "data": "4830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01",
+            "sequence": 4294967278
+          },
+          {
+            "txId": "8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef",
+            "index": 1,
+            "data": "",
+            "witness": [
+              "304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee01",
+              "025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357"
+            ]
+          }
+        ],
+        "outs": [
+          {
+            "script": "OP_DUP OP_HASH160 8280b37df378db99f66f85c95a783a76ac7a6d59 OP_EQUALVERIFY OP_CHECKSIG",
+            "value": 112340000
+          },
+          {
+            "script": "OP_DUP OP_HASH160 3bde42dbee7e4dbe6a21b2d50ce2f0167faa8159 OP_EQUALVERIFY OP_CHECKSIG",
+            "value": 223450000
+          }
+        ],
+        "locktime": 17
+      },
+      "hex": "0100000002fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac11000000",
+      "hexWithWitness": "01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000"
     }
   ],
   "invalid": {

--- a/test/fixtures/transaction_builder.json
+++ b/test/fixtures/transaction_builder.json
@@ -285,6 +285,97 @@
             "value": 10000
           }
         ]
+      },
+      {
+        "description": "Transaction w/ segWitPubKeyHash -> segWitPubKeyHash",
+        "txHex": "0100000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000ffffffff011027000000000000160014aa4d7985c57e011a8b3dd8e0e5a73aaef41629c500000000",
+        "txHexWithWitness": "01000000000101ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000ffffffff011027000000000000160014aa4d7985c57e011a8b3dd8e0e5a73aaef41629c502483045022100a8fc5e4c6d7073474eff2af5d756966e75be0cdfbba299518526080ce8b584be02200f26d41082764df89e3c815b8eaf51034a3b68a25f1be51208f54222c1bb6c1601210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179800000000",
+        "inputs": [
+          {
+            "txId": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "vout": 0,
+            "value": 10000,
+            "signs": [
+              {
+                "keyPair": "KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn",
+                "segWit": true
+              }
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "script": "OP_0 aa4d7985c57e011a8b3dd8e0e5a73aaef41629c5",
+            "value": 10000
+          }
+        ]
+      },
+      {
+        "description": "Transaction w/ segWitPubKeyHash as scriptHash -> segWitPubKeyHash",
+        "txHex": "0100000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000017160014751e76e8199196d454941c45d1b3a323f1433bd6ffffffff011027000000000000160014aa4d7985c57e011a8b3dd8e0e5a73aaef41629c500000000",
+        "txHexWithWitness": "01000000000101ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000017160014751e76e8199196d454941c45d1b3a323f1433bd6ffffffff011027000000000000160014aa4d7985c57e011a8b3dd8e0e5a73aaef41629c502483045022100a8fc5e4c6d7073474eff2af5d756966e75be0cdfbba299518526080ce8b584be02200f26d41082764df89e3c815b8eaf51034a3b68a25f1be51208f54222c1bb6c1601210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179800000000",
+        "inputs": [
+          {
+            "txId": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "vout": 0,
+            "value": 10000,
+            "signs": [
+              {
+                "keyPair": "KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn",
+                "segWit": true,
+                "redeemScript": "OP_0 751e76e8199196d454941c45d1b3a323f1433bd6"
+              }
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "script": "OP_0 aa4d7985c57e011a8b3dd8e0e5a73aaef41629c5",
+            "value": 10000
+          }
+        ]
+      },
+      {
+        "description": "example from; https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki",
+        "txHex": "0100000002fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac11000000",
+        "txHexWithWitness": "01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000",
+        "locktime": 17,
+        "inputs": [
+          {
+            "txId": "9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff",
+            "vout": 0,
+            "value": 626000000,
+            "sequence": 4294967278,
+            "prevTxScriptHex": "2103c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432ac",
+            "signs": [
+              {
+                "keyPair": "L3Wh2WPg21MWqzMFYsVC7PeBXcq1ow32KRccRihnTUnAhJaZUvg1"
+              }
+            ]
+          },
+          {
+            "txId": "8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef",
+            "vout": 1,
+            "value": 600000000,
+            "sequence": 4294967295,
+            "signs": [
+              {
+                "keyPair": "KzVTBhbMaKrAYagJ11VdTaBrb6yzLykLGyuMBkf9sCFPDxdT8shL",
+                "segWit": true
+              }
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "script": "OP_DUP OP_HASH160 8280b37df378db99f66f85c95a783a76ac7a6d59 OP_EQUALVERIFY OP_CHECKSIG",
+            "value": 112340000
+          },
+          {
+            "script": "OP_DUP OP_HASH160 3bde42dbee7e4dbe6a21b2d50ce2f0167faa8159 OP_EQUALVERIFY OP_CHECKSIG",
+            "value": 223450000
+          }
+        ]
       }
     ],
     "fromTransaction": [

--- a/test/script.js
+++ b/test/script.js
@@ -259,6 +259,21 @@ describe('script', function () {
     })
   })
 
+  describe('segWitPubKeyHashOutput', function () {
+    fixtures.valid.forEach(function (f) {
+      if (f.type !== 'segwitpubkeyhash') return
+
+      var pubKey = new Buffer(f.pubKey, 'hex')
+      var pubKeyHash = bcrypto.hash160(pubKey)
+
+      it('returns ' + f.scriptPubKey, function () {
+        var scriptPubKey = bscript.segWitPubKeyHashOutput(pubKeyHash)
+        assert.strictEqual(bscript.toASM(scriptPubKey), f.scriptPubKey)
+        assert.strictEqual(scriptPubKey.toString('hex'), f.scriptPubKeyHex)
+      })
+    })
+  })
+
   describe('multisigInput', function () {
     fixtures.valid.forEach(function (f) {
       if (f.type !== 'multisig') return

--- a/test/types.js
+++ b/test/types.js
@@ -40,5 +40,10 @@ describe('types', function () {
         types.Hash256bit(buffer20byte)
       }, /Expected 256-bit Buffer, got 160-bit Buffer/)
     })
+
+    it('return true for oneOf', function () {
+      assert(typeforce(types.oneOf(types.Hash256bit, types.Hash160bit), buffer32byte))
+      assert(typeforce(types.oneOf(types.Hash160bit, types.Hash256bit), buffer32byte))
+    })
   })
 })


### PR DESCRIPTION
# WORK IN PROGRESS

getting shit to work before making it pretty; almost done with getting shit to work!

depends on: https://github.com/bitcoinjs/bitcoinjs-lib/pull/540

first time spending a p2wpkh (6a539927494f3d6f07078dd1c70a28e0c4910662593072305529eaa66257f59d) and p2wpkh as p2sh (4704de796b8ea819f262eb3399fad85b838327497639da2ceafbd04a08a06be3) with bitcoinjs-lib :D
### ToDo
- [x] Output script creation for P2WPKH
- [x] Output script creation for P2WSH
- [x] Transaction encoding / decode
- [x] SignatureHash v2
- [x] Transaction signing of P2WPKH
- [x] Transaction signing of P2WPKH as P2SH
- [x] Transaction signing of P2WSH
- [x] `toBuffer` should be able to return both segwit and non-segwit TX
  - [x] fix `getTxId` using the segwit TX atm
- [x] BIP142 addresses for P2WPKH
- [ ] Add `value` arg to `addInput` and use it in `TransactionBuilder.sign` instead of `value` arg there?
- [x] Refactoring of changes made so far
- [ ] More tests
  - [x] Add tests for mix of non witness and witness (already manually tested and works)
  - [ ] Integration tests (and an API to already run them against segnet)
  - [ ] Check bitcoin core projects for any vectors that we can copy
- [ ] Review and discuss changes for BIP142 addresses
- [ ] Review and discuss changes to `TransactionBuilder.sign`
- [ ] Review and discuss changes to `TransactionBuilder.extractInput` / `script.classifyInput`
- [ ] Cache `hashPrevouts`, `hashSequence` and `hashOutputs` for all signatures in a transaction (since that was one of the main reasons for changing the signatureHash xD)
### Usage

**Signing Native P2WPKH**

``` js
transactionBuilder.sign(0, keyPair, null, null, /* segWit = */ true, /* txIn.value = */ parseInt(0.9998 * 1e8)))
```

**Signing P2WPKH nested in P2SH**

``` js
var pubKeyHash = bcrypto.hash160(keyPair.getPublicKeyBuffer())
var redeemScript = bscript.segWitPubKeyHashOutput(pubKeyHash)

transactionBuilder.sign(0, keyPair, redeemScript, null, /* segWit = */ true, /* txIn.value = */ parseInt(0.9998 * 1e8)))
```
### References
- BIP141 (general segwit) https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki
- BIP142 (segwit address) https://github.com/bitcoin/bips/blob/master/bip-0142.mediawiki
- BIP143 (signature verification with new signature hash) https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
- BIP144 (peer services) https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki
- Staging branch https://github.com/sipa/bitcoin/tree/segwit
