### PR TITLE
address: fix compiled assumption for fromOutputScript

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -18,8 +18,8 @@ function fromBase58Check (address) {
 function fromOutputScript (scriptPubKey, network) {
   network = network || networks.bitcoin
 
-  if (bscript.isPubKeyHashOutput(scriptPubKey)) return toBase58Check(scriptPubKey.slice(3, 23), network.pubKeyHash)
-  if (bscript.isScriptHashOutput(scriptPubKey)) return toBase58Check(scriptPubKey.slice(2, 22), network.scriptHash)
+  if (bscript.isPubKeyHashOutput(scriptPubKey)) return toBase58Check(bscript.compile(scriptPubKey).slice(3, 23), network.pubKeyHash)
+  if (bscript.isScriptHashOutput(scriptPubKey)) return toBase58Check(bscript.compile(scriptPubKey).slice(2, 22), network.scriptHash)
 
   throw new Error(bscript.toASM(scriptPubKey) + ' has no matching Address')
 }

--- a/test/address.js
+++ b/test/address.js
@@ -36,6 +36,15 @@ describe('address', function () {
       })
     })
 
+    fixtures.valid.forEach(function (f) {
+      it('parses (as chunks) ' + f.script.slice(0, 30) + '... (' + f.network + ')', function () {
+        var chunks = bscript.decompile(bscript.fromASM(f.script))
+        var address = baddress.fromOutputScript(chunks, networks[f.network])
+
+        assert.strictEqual(address, f.base58check)
+      })
+    })
+
     fixtures.invalid.fromOutputScript.forEach(function (f) {
       it('throws when ' + f.script.slice(0, 30) + '... ' + f.exception, function () {
         var script = bscript.fromASM(f.script)


### PR DESCRIPTION
All of the `script.*` functions allow you to provide a compiled or uncompiled script,  and it will decide based on the input type whether to compile/decompile it.

This is actually a major optimization in many cases since you may be doing this many times over and the functions vary as to what state of script they prefer.

`fromOutputScript` actually already supports this,  but if a valid script is found,  then it fails with `toBase58Check` complaining about a non-buffer being given (confusing!).