### PR TITLE
fixed another test where TX was signed before locktime was set

### DIFF
--- a/test/fixtures/transaction_builder.json
+++ b/test/fixtures/transaction_builder.json
@@ -266,7 +266,7 @@
       },
       {
         "description": "Transaction w/ nLockTime, pubKeyHash -> pubKeyHash",
-        "txHex": "0100000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000006b483045022100a3b254e1c10b5d039f36c05f323995d6e5a367d98dd78a13d5bbc3991b35720e022022fccea3897d594de0689601fbd486588d5bfa6915be2386db0397ee9a6e80b601210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ffffffff0110270000000000001976a914aa4d7985c57e011a8b3dd8e0e5a73aaef41629c588acffff0000",
+        "txHex": "0100000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000006b483045022100e31ef1bcc6f060cb6a53675a11606b9180f4f8b1ec823113fb4c0bf1c5b99b8e02204234690c19cd89e544002d26dbcbd49bf9d1b4cfc5a617fd8ab2607acfd869b001210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ffffffff0110270000000000001976a914aa4d7985c57e011a8b3dd8e0e5a73aaef41629c588acffff0000",
         "locktime": 65535,
         "inputs": [
           {


### PR DESCRIPTION
From https://github.com/bitcoinjs/bitcoinjs-lib/pull/529,  doesn't fix the integration tests,  but it does resolve an issue that came from https://github.com/bitcoinjs/bitcoinjs-lib/pull/507.

Can't wait for #527 to be resolved.