### PR TITLE
typeforce for hash160/256 throws hard error

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "create-hmac": "^1.1.3",
     "ecurve": "^1.0.0",
     "randombytes": "^2.0.1",
-    "typeforce": "^1.5.5",
+    "typeforce": "^1.6.2",
     "wif": "^1.1.0"
   },
   "devDependencies": {

--- a/src/types.js
+++ b/src/types.js
@@ -2,7 +2,8 @@ var typeforce = require('typeforce')
 
 function nBuffer (value, n) {
   typeforce(types.Buffer, value)
-  if (value.length !== n) throw new Error('Expected ' + (n * 8) + '-bit Buffer, got ' + (value.length * 8) + '-bit Buffer')
+  if (value.length !== n) throw new typeforce.TfTypeError('Expected ' + (n * 8) + '-bit Buffer, got ' + (value.length * 8) + '-bit Buffer')
+
   return true
 }
 

--- a/test/types.js
+++ b/test/types.js
@@ -26,14 +26,14 @@ describe('types', function () {
       assert(types.Hash256bit(buffer32byte))
     })
 
-    it('return false for incorrect size', function () {
+    it('throws for incorrect size', function () {
       assert.throws(function () {
         types.Hash160bit(buffer32byte)
-      }, 'Expected 160-bit Buffer, got Number 256')
+      }, /Expected 160-bit Buffer, got 256-bit Buffer/)
 
       assert.throws(function () {
         types.Hash256bit(buffer20byte)
-      }, 'Expected 256-bit Buffer, got Number 160')
+      }, /Expected 256-bit Buffer, got 160-bit Buffer/)
     })
 
     it('return true for oneOf', function () {

--- a/test/types.js
+++ b/test/types.js
@@ -21,12 +21,17 @@ describe('types', function () {
     var buffer20byte = new Buffer((new Array(20 + 1)).join('00'), 'hex')
     var buffer32byte = new Buffer((new Array(32 + 1)).join('00'), 'hex')
 
-    it('return true for correct size', function () {
+    it('return true for valid size', function () {
       assert(types.Hash160bit(buffer20byte))
       assert(types.Hash256bit(buffer32byte))
     })
 
-    it('throws for incorrect size', function () {
+    it('return true for oneOf', function () {
+      assert(typeforce(types.oneOf(types.Hash160bit, types.Hash256bit), buffer32byte))
+      assert(typeforce(types.oneOf(types.Hash256bit, types.Hash160bit), buffer32byte))
+    })
+
+    it('throws for invalid size', function () {
       assert.throws(function () {
         types.Hash160bit(buffer32byte)
       }, /Expected 160-bit Buffer, got 256-bit Buffer/)
@@ -34,11 +39,6 @@ describe('types', function () {
       assert.throws(function () {
         types.Hash256bit(buffer20byte)
       }, /Expected 256-bit Buffer, got 160-bit Buffer/)
-    })
-
-    it('return true for oneOf', function () {
-      assert(typeforce(types.oneOf(types.Hash256bit, types.Hash160bit), buffer32byte), "Hash256 first")
-      assert(typeforce(types.oneOf(types.Hash160bit, types.Hash256bit), buffer32byte), "Hash160 first")
     })
   })
 })

--- a/test/types.js
+++ b/test/types.js
@@ -2,6 +2,7 @@
 
 var assert = require('assert')
 var types = require('../src/types')
+var typeforce = require('typeforce')
 
 describe('types', function () {
   describe('BigInt/ECPoint', function () {
@@ -13,6 +14,31 @@ describe('types', function () {
     it('return false for bad types', function () {
       assert(!types.BigInt(new function NotABigInteger () {}))
       assert(!types.ECPoint(new function NotAPoint () {}))
+    })
+  })
+
+  describe('Buffer Hash160/Hash256', function () {
+    var buffer20byte = new Buffer((new Array(20 + 1)).join('00'), 'hex')
+    var buffer32byte = new Buffer((new Array(32 + 1)).join('00'), 'hex')
+
+    it('return true for correct size', function () {
+      assert(types.Hash160bit(buffer20byte))
+      assert(types.Hash256bit(buffer32byte))
+    })
+
+    it('return false for incorrect size', function () {
+      assert.throws(function () {
+        types.Hash160bit(buffer32byte)
+      }, 'Expected 160-bit Buffer, got Number 256')
+
+      assert.throws(function () {
+        types.Hash256bit(buffer20byte)
+      }, 'Expected 256-bit Buffer, got Number 160')
+    })
+
+    it('return true for oneOf', function () {
+      assert(typeforce(types.oneOf(types.Hash256bit, types.Hash160bit), buffer32byte), "Hash256 first")
+      assert(typeforce(types.oneOf(types.Hash160bit, types.Hash256bit), buffer32byte), "Hash160 first")
     })
   })
 })


### PR DESCRIPTION
Based on #532.

Fixed standard errors.