### PR TITLE
whitelist of files for npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-.gitignore
-.travis.yml
-jshint.json
-test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
+sudo: false
 language: node_js
 before_install:
   - npm install npm -g
 node_js:
-  - 5
-  - 4
-  - io.js
-  - 0.12
-  - 0.10
+  - "0.10"
+  - "0.12"
+  - "io.js"
+  - "4"
+  - "5"
 matrix:
   include:
-    - node_js: 4
+    - node_js: "4"
       env: TEST_SUITE=standard
 env:
   - TEST_SUITE=coverage
   - TEST_SUITE=integration
   - TEST_SUITE=unit
 script: npm run-script $TEST_SUITE
-sudo: false

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "type": "git",
     "url": "https://github.com/bitcoinjs/bitcoinjs-lib.git"
   },
+  "files": [
+    "src"
+  ],
   "config": {
     "blanket": {
       "pattern": [


### PR DESCRIPTION
Only src, because (from docs):

>
Certain files are always included, regardless of settings:
  * package.json
  * README (and its variants)
  * CHANGELOG (and its variants)
  * LICENSE / LICENCE
