### PR TITLE
Add network list tests for ECPair/HDNode

### DIFF
--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -58,7 +58,6 @@ ECPair.fromPublicKeyBuffer = function (buffer, network) {
 }
 
 ECPair.fromWIF = function (string, network) {
-  network = network || NETWORKS.bitcoin
   var buffer = bs58check.decode(string)
 
   if (types.Array(network)) {
@@ -67,9 +66,9 @@ ECPair.fromWIF = function (string, network) {
     network = network.filter(function (network) {
       return version === network.wif
     }).pop()
-    if (!network) throw new Error('Invalid network version')
   }
 
+  network = network || NETWORKS.bitcoin
   var decoded = wif.decodeRaw(buffer, network.wif)
   var d = BigInteger.fromBuffer(decoded.privateKey)
 

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -66,6 +66,8 @@ ECPair.fromWIF = function (string, network) {
     network = network.filter(function (network) {
       return version === network.wif
     }).pop()
+
+    if (!network) throw new Error('Unknown network version')
   }
 
   network = network || NETWORKS.bitcoin

--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -66,7 +66,7 @@ HDNode.fromBase58 = function (string, networks) {
              version === network.bip32.public
     }).pop()
 
-    if (!network) throw new Error('Invalid network version')
+    if (!network) throw new Error('Unknown network version')
 
   // otherwise, assume a network object (or default to bitcoin)
   } else {

--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -64,7 +64,9 @@ HDNode.fromBase58 = function (string, networks) {
     network = networks.filter(function (network) {
       return version === network.bip32.private ||
              version === network.bip32.public
-    }).pop() || {}
+    }).pop()
+
+    if (!network) throw new Error('Invalid network version')
 
   // otherwise, assume a network object (or default to bitcoin)
   } else {
@@ -72,7 +74,7 @@ HDNode.fromBase58 = function (string, networks) {
   }
 
   if (version !== network.bip32.private &&
-    version !== network.bip32.public) throw new Error('Invalid network')
+    version !== network.bip32.public) throw new Error('Invalid network version')
 
   // 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 descendants, ...
   var depth = buffer[4]

--- a/test/ecpair.js
+++ b/test/ecpair.js
@@ -107,7 +107,9 @@ describe('ECPair', function () {
     fixtures.invalid.fromWIF.forEach(function (f) {
       it('throws on ' + f.WIF, function () {
         assert.throws(function () {
-          ECPair.fromWIF(f.WIF)
+          var networks = f.network ? NETWORKS[f.network] : NETWORKS_LIST
+
+          ECPair.fromWIF(f.WIF, networks)
         }, new RegExp(f.exception))
       })
     })

--- a/test/fixtures/ecpair.json
+++ b/test/fixtures/ecpair.json
@@ -107,7 +107,12 @@
     "fromWIF": [
       {
         "exception": "Invalid network version",
+        "network": "bitcoin",
         "WIF": "92Qba5hnyWSn5Ffcka56yMQauaWY6ZLd91Vzxbi4a9CCetaHtYj"
+      },
+      {
+        "exception": "Invalid network version",
+        "WIF": "brQnSed3Fia1w9VcbbS6ZGDgJ6ENkgwuQY2LS7pEC5bKHD1fMF"
       },
       {
         "exception": "Invalid compression flag",

--- a/test/fixtures/ecpair.json
+++ b/test/fixtures/ecpair.json
@@ -111,7 +111,7 @@
         "WIF": "92Qba5hnyWSn5Ffcka56yMQauaWY6ZLd91Vzxbi4a9CCetaHtYj"
       },
       {
-        "exception": "Invalid network version",
+        "exception": "Unknown network version",
         "WIF": "brQnSed3Fia1w9VcbbS6ZGDgJ6ENkgwuQY2LS7pEC5bKHD1fMF"
       },
       {

--- a/test/fixtures/hdnode.json
+++ b/test/fixtures/hdnode.json
@@ -199,11 +199,12 @@
         "string": "xprvQQQQQQQQQQQQQQQQCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334"
       },
       {
-        "exception": "Invalid network",
+        "exception": "Invalid network version",
         "string": "1111111111111adADjFaSNPxwXqLjHLj4mBfYxuewDPbw9hEj1uaXCzMxRPXDFF3cUoezTFYom4sEmEVSQmENPPR315cFk9YUFVek73wE9"
       },
       {
-        "exception": "Invalid network",
+        "exception": "Invalid network version",
+        "network": "bitcoin",
         "string": "Ltpv73XYpw28ZyVe2zEVyiFnxUZxoKLGQNdZ8NxUi1WcqjNmMBgtLbh3KimGSnPHCoLv1RmvxHs4dnKmo1oXQ8dXuDu8uroxrbVxZPA1gXboYvx"
       }
     ],

--- a/test/fixtures/hdnode.json
+++ b/test/fixtures/hdnode.json
@@ -199,7 +199,7 @@
         "string": "xprvQQQQQQQQQQQQQQQQCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334"
       },
       {
-        "exception": "Invalid network version",
+        "exception": "Unknown network version",
         "string": "1111111111111adADjFaSNPxwXqLjHLj4mBfYxuewDPbw9hEj1uaXCzMxRPXDFF3cUoezTFYom4sEmEVSQmENPPR315cFk9YUFVek73wE9"
       },
       {

--- a/test/hdnode.js
+++ b/test/hdnode.js
@@ -210,9 +210,9 @@ describe('HDNode', function () {
     fixtures.invalid.fromBase58.forEach(function (f) {
       it('throws on ' + f.string, function () {
         assert.throws(function () {
-          var network = NETWORKS[f.network]
+          var networks = f.network ? NETWORKS[f.network] : NETWORKS_LIST
 
-          HDNode.fromBase58(f.string, network)
+          HDNode.fromBase58(f.string, networks)
         }, new RegExp(f.exception))
       })
     })


### PR DESCRIPTION
This actually fixes a bug `bip32 is undefined` when a networks list was passed and no valid version was found in `HDNode`.