### PR TITLE
README: `1.0.0` is now more popular

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 
 The pure JavaScript Bitcoin library for node.js and browsers.
-A continued implementation of the original `0.1.3` version used by over a million wallet users; the backbone for almost all Bitcoin web wallets in production today.
+Used by over a million wallet users and the backbone for almost all Bitcoin web wallets in production today.
 
 
 ## Features


### PR DESCRIPTION
This is somewhat hard to quantify,  so citations would be great.
But my general impression is that most people are using at least `1.0.0` (if not `2.0.0`) now,  and in fact even blockchain.info are using `2.0.0` AFAIK.