### PR TITLE
Adding flow exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+test/flow/result

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: node_js
 before_install:
   - npm install npm -g
+  - npm install flow-bin
 node_js:
   - "0.10"
   - "0.12"
@@ -16,4 +17,5 @@ env:
   - TEST_SUITE=coverage
   - TEST_SUITE=integration
   - TEST_SUITE=unit
+  - TEST_SUITE=flowtest
 script: npm run-script $TEST_SUITE

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "prepublish": "npm run test",
     "standard": "standard",
     "test": "npm run standard && npm run unit",
-    "unit": "mocha"
+    "unit": "mocha",
+    "flowtest": "bash ./test/flow/run-test.sh"
   },
   "repository": {
     "type": "git",

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,0 +1,85 @@
+/* @flow */
+export type Network = {
+  messagePrefix: string;
+  bip32: {
+    public: number;
+    private: number;
+  };
+  pubKeyHash: number;
+  scriptHash: number;
+  wif: number;
+  dustThreshold: number;
+  feePerKB: number;
+}
+
+export type Output = {
+  script: Buffer;
+  value: number;
+}
+
+export type Input = {
+  script: Buffer;
+  hash: Buffer;
+  index: number;
+  sequence: number;
+}
+
+declare export var address: {
+  fromBase58Check(address: string): {hash: Buffer, version: number};
+  fromOutputScript(script: Buffer, network?: Network): string;
+}
+
+declare export var script: {
+  fromAddress(address: string, network?: Network): Buffer;
+  pubKeyHashOutput(pkh: Buffer): Buffer;
+  scriptHashOutput(sho: Buffer): Buffer;
+}
+
+declare export var crypto: {
+  hash256(buffer: Buffer): Buffer;
+  hash160(buffer: Buffer): Buffer;
+}
+
+declare export class ECPair {
+  d: ?Buffer;
+  Q: ?Buffer;
+  constructor(d: ?Buffer, Q: ?Buffer): void;
+  getPublicKeyBuffer(): Buffer;
+}
+
+declare export class HDNode {
+  depth: number;
+  parentFingerprint: number;
+  index: number;
+  keyPair: ECPair;
+  chainCode: Buffer;
+  static fromBase58(
+    str: string,
+    networks: Array<Network> | Network
+  ): HDNode;
+  derive(index: number): HDNode;
+  toBase58(): string;
+  getAddress(): string;
+  getIdentifier(): Buffer;
+  constructor(keyPair: ECPair, chainCode: Buffer): void;
+}
+
+declare export class Transaction {
+  version: number;
+  locktime: number;
+
+  constructor(): void;
+  static fromHex(hex: string): Transaction;
+  ins: Array<Input>;
+  outs: Array<Output>;
+  toHex(): string;
+  addInput(hash: Buffer, index: number, sequence?: ?number, scriptSig?: Buffer): void;
+  addOutput(scriptPubKey: Buffer, value: number): void;
+  getHash(): Buffer;
+  toBuffer(): Buffer;
+  getId(): string;
+
+  static isCoinbaseHash(buffer: Buffer): boolean;
+}
+
+declare export var networks: {[key: string]: Network}

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,4 +1,6 @@
 /* @flow */
+import * as BigInteger from 'bigi';
+
 export type Network = {
   messagePrefix: string;
   bip32: {
@@ -40,11 +42,22 @@ declare export var crypto: {
   hash160(buffer: Buffer): Buffer;
 }
 
+type ECurvePoint = any; // FIXME
+
 declare export class ECPair {
   d: ?Buffer;
-  Q: ?Buffer;
-  constructor(d: ?Buffer, Q: ?Buffer): void;
+  Q: ?ECurvePoint;
+  compressed: boolean;
+  network: Network;
+  constructor(d: ?Buffer, Q: ?ECurvePoint): void;
   getPublicKeyBuffer(): Buffer;
+  toWIF(): string;
+  static makeRandom(): ECPair;
+}
+
+declare export class ECSignature {
+  r: BigInteger;
+  s: BigInteger;
 }
 
 declare export class HDNode {
@@ -55,13 +68,25 @@ declare export class HDNode {
   chainCode: Buffer;
   static fromBase58(
     str: string,
-    networks: Array<Network> | Network
+    networks?: ?(Array<Network> | Network)
   ): HDNode;
+  static fromSeedHex(seed: string, network?: ?Network): HDNode;
+  static fromSeedBuffer(seed: Buffer, network?: ?Network): HDNode;
   derive(index: number): HDNode;
   toBase58(): string;
   getAddress(): string;
+  getFingerprint(): Buffer;
   getIdentifier(): Buffer;
+  getNetwork(): Network;
+  getPublicKeyBuffer(): Buffer;
+  sign(): ECSignature;
+  verify(hash: Buffer, signature: ECSignature): Buffer;
+  neutered(): HDNode;
+  isNeutered(): boolean;
+  deriveHardened(index: number): HDNode;
+  derivePath(path: string): HDNode;
   constructor(keyPair: ECPair, chainCode: Buffer): void;
+  static HIGHEST_BIT: number;
 }
 
 declare export class Transaction {

--- a/test/.flowconfig
+++ b/test/.flowconfig
@@ -1,0 +1,13 @@
+[ignore]
+
+[include]
+../node_modules/assert
+../node_modules/bigi
+../node_modules/sinon
+../src
+
+[libs]
+./flow/mocha.js.flow
+./flow/fixtures.js.flow
+
+[options]

--- a/test/flow/expected
+++ b/test/flow/expected
@@ -1,0 +1,26 @@
+hdnode.js:373
+373:       fixtures.invalid.derive.forEach(function (fx) {
+           ^ call of method `forEach`
+375:           master.derive(fx)
+                             ^^ mixed. This type is incompatible with
+ 75:   derive(index: number): HDNode;
+                     ^^^^^^ number. See: ../src/index.js.flow:75
+
+hdnode.js:379
+379:       fixtures.invalid.deriveHardened.forEach(function (fx) {
+           ^ call of method `forEach`
+381:           master.deriveHardened(fx)
+                                     ^^ mixed. This type is incompatible with
+ 86:   deriveHardened(index: number): HDNode;
+                             ^^^^^^ number. See: ../src/index.js.flow:86
+
+hdnode.js:385
+385:       fixtures.invalid.derivePath.forEach(function (fx) {
+           ^ call of method `forEach`
+387:           master.derivePath(fx)
+                                 ^^ mixed. This type is incompatible with
+ 87:   derivePath(path: string): HDNode;
+                        ^^^^^^ string. See: ../src/index.js.flow:87
+
+
+Found 3 errors

--- a/test/flow/fixtures.js.flow
+++ b/test/flow/fixtures.js.flow
@@ -1,0 +1,44 @@
+declare module './fixtures/hdnode.json' {
+  declare var valid: Array<{
+    network: string;
+    master: {
+      seed: string;
+      wif: string;
+      pubKey: string;
+      chainCode: string;
+      hex: string;
+      hexPriv: string;
+      base58: string;
+      base58Priv: string;
+      identifier: string;
+      fingerprint: string;
+      address: string;
+    };
+    children: Array<{
+      description: string;
+      m: number;
+      wif: string;
+      pubKey: string;
+      chainCode: string;
+      base58: string;
+      base58Priv: string;
+      identifier: string;
+      fingerprint: string;
+      address: string;
+    }>;
+  }>;
+  declare var invalid: {
+    fromBase58: Array<{
+      exception: string;
+      string: string;
+      network: ?string;
+    }>;
+    fromBuffer: Array<{
+      exception: string;
+      hex: string;
+    }>;
+    deriveHardened: Array<mixed>;
+    derive: Array<mixed>;
+    derivePath: Array<mixed>;
+  };
+}

--- a/test/flow/mocha.js.flow
+++ b/test/flow/mocha.js.flow
@@ -1,0 +1,11 @@
+declare class describe {
+  static (description: string, spec: () => void): void;
+  static only(description: string, spec: () => void): void;
+  static skip(description: string, spec: () => void): void;
+  static timeout(ms: number): void;
+}
+
+declare function beforeEach(action: () => void): void;
+declare function it(expectation: string, assertion: () => void): void;
+
+

--- a/test/flow/run-test.sh
+++ b/test/flow/run-test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -x
+cd "$(dirname "$0")"/..
+$(npm bin)/flow check > flow/result
+
+# diff returns >0 on difference
+diff flow/result flow/expected > flow/diff

--- a/test/hdnode.js
+++ b/test/hdnode.js
@@ -1,3 +1,4 @@
+/* @flow */
 /* global describe, it, beforeEach */
 /* eslint-disable no-new */
 
@@ -6,13 +7,13 @@ var ecdsa = require('../src/ecdsa')
 var sinon = require('sinon')
 
 var BigInteger = require('bigi')
-var ECPair = require('../src/ecpair')
-var HDNode = require('../src/hdnode')
+var ECPair = require('../src').ECPair
+var HDNode = require('../src').HDNode
 
 var fixtures = require('./fixtures/hdnode.json')
 var curve = ecdsa.__curve
 
-var NETWORKS = require('../src/networks')
+var NETWORKS = require('../src').networks
 var NETWORKS_LIST = [] // Object.values(NETWORKS)
 for (var networkName in NETWORKS) {
   NETWORKS_LIST.push(NETWORKS[networkName])


### PR DESCRIPTION
We are using [Facebook Flow](https://github.com/facebook/flow) for static typechecking of our code.

It's super useful, and we wrote our interface file for Flow, for the things we use the most. It isn't complete at all - it really just have things that we use.

Anyway, I thought it will be useful to put it upstream, even when it's not complete. (Also, it would be good for us, so we don't have to copy the file all the time :) etc.)

(Note: the semicolons are necessary here, since they are in the class property syntax.)