### PR TITLE
Fix for Webpack

### DIFF
--- a/src/bufferutils.js
+++ b/src/bufferutils.js
@@ -1,4 +1,4 @@
-var opcodes = require('./opcodes')
+var opcodes = require('./opcodes.json')
 
 // https://github.com/feross/buffer/blob/master/index.js#L1127
 function verifuint (value, max) {

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,6 @@ module.exports = {
   crypto: require('./crypto'),
   message: require('./message'),
   networks: require('./networks'),
-  opcodes: require('./opcodes'),
+  opcodes: require('./opcodes.json'),
   script: require('./script')
 }

--- a/src/script.js
+++ b/src/script.js
@@ -3,7 +3,7 @@ var bufferutils = require('./bufferutils')
 var typeforce = require('typeforce')
 var types = require('./types')
 
-var OPS = require('./opcodes')
+var OPS = require('./opcodes.json')
 var REVERSE_OPS = (function () {
   var result = {}
   for (var op in OPS) {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -2,7 +2,7 @@ var bcrypto = require('./crypto')
 var bscript = require('./script')
 var bufferutils = require('./bufferutils')
 var bufferReverse = require('buffer-reverse')
-var opcodes = require('./opcodes')
+var opcodes = require('./opcodes.json')
 var typeforce = require('typeforce')
 var types = require('./types')
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -4,7 +4,7 @@ var bscript = require('./script')
 var bufferEquals = require('buffer-equals')
 var bufferReverse = require('buffer-reverse')
 var networks = require('./networks')
-var ops = require('./opcodes')
+var ops = require('./opcodes.json')
 var typeforce = require('typeforce')
 var types = require('./types')
 


### PR DESCRIPTION
It's been reported to me by @shea256 that `bitcoinjs-lib` doesn't work with Webpack even using the Webpack JSON loader. Apparently it's because the Webpack needs the `.json` extension in `require` statements so that it knows to use the JSON loader.