### PR TITLE
index: add .network default for bitcoin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ module.exports = {
   crypto: require('./crypto'),
   message: require('./message'),
   networks: require('./networks'),
+  network: require('./networks').bitcoin,
   opcodes: require('./opcodes.json'),
   script: require('./script')
 }


### PR DESCRIPTION
Implementation is a bit lame,  but,  thoughts on the concept?  @jprichardson ?
Example that shows my motivation:

``` js
var bitcoin = require('bitcoinjs-lib')

// ...

console.log(bitcoin.network.pubKeyHash)
// or maybe console.log(bitcoin.network.constants.pubKeyHash)
console.log(bitcoin.networks.bitcoin.pubKeyHash)
```