### PR TITLE
TxBuilder: add setVersion

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -163,6 +163,13 @@ TransactionBuilder.prototype.setLockTime = function (locktime) {
   this.tx.locktime = locktime
 }
 
+TransactionBuilder.prototype.setVersion = function (version) {
+  typeforce(types.UInt32, version)
+
+  // XXX: this might eventually become more complex depending on what the versions represent
+  this.tx.version = version
+}
+
 TransactionBuilder.fromTransaction = function (transaction, network) {
   var txb = new TransactionBuilder(network)
 

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -17,14 +17,8 @@ function construct (f, sign) {
   var network = NETWORKS[f.network]
   var txb = new TransactionBuilder(network)
 
-  // FIXME: add support for version in TransactionBuilder API
-  if (f.version !== undefined) {
-    txb.tx.version = f.version
-  }
-
-  if (f.locktime !== undefined) {
-    txb.setLockTime(f.locktime)
-  }
+  if (f.version !== undefined) txb.setVersion(f.version)
+  if (f.locktime !== undefined) txb.setLockTime(f.locktime)
 
   f.inputs.forEach(function (input) {
     var prevTxScript


### PR DESCRIPTION
I wasn't sure about this function at first,  as it seemed so pass-through'ish (aka, perhaps a a sign of bad design).

But with BIP68 about to come into effect,  it may be worth having some sanity checking logic here.  We'll see.

(aka, `setVersion(1)` for a transaction the CSV OP codes is effectively invalid AFAIK)