### PR TITLE
Adding Flow definitions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ Example:
 uglifyjs ... --mangle --reserved 'Array,BigInteger,Boolean,Buffer,ECPair,Function,Number,Point'
 ```
 
+### Flow
+
+Definition for [Flow typechecker](https://flowtype.org/) are available in flow-typed repository.
+
+[You can either download them direcly](https://github.com/flowtype/flow-typed/blob/master/definitions/npm/bitcoinjs-lib_v2.x.x/flow_%3E%3Dv0.17.x/bitcoinjs-lib_v2.x.x.js) from the repo, or with the flow-typed CLI
+
+    # npm install -g flow-typed
+    $ flow-typed install -f 0.27 bitcoinjs-lib@2.2.0 # 0.27 for flow version, 2.2.0 for bitcoinjs-lib version
+    
+The definition should be complete and cover all the functions and classes in the API. 
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ uglifyjs ... --mangle --reserved 'Array,BigInteger,Boolean,Buffer,ECPair,Functio
 
 ### Flow
 
-Definition for [Flow typechecker](https://flowtype.org/) are available in flow-typed repository.
+Definitions for [Flow typechecker](https://flowtype.org/) are available in flow-typed repository.
 
-[You can either download them direcly](https://github.com/flowtype/flow-typed/blob/master/definitions/npm/bitcoinjs-lib_v2.x.x/flow_%3E%3Dv0.17.x/bitcoinjs-lib_v2.x.x.js) from the repo, or with the flow-typed CLI
+[You can either download them directly](https://github.com/flowtype/flow-typed/blob/master/definitions/npm/bitcoinjs-lib_v2.x.x/flow_%3E%3Dv0.17.x/bitcoinjs-lib_v2.x.x.js) from the repo, or with the flow-typed CLI
 
     # npm install -g flow-typed
     $ flow-typed install -f 0.27 bitcoinjs-lib@2.2.0 # 0.27 for flow version, 2.2.0 for bitcoinjs-lib version
     
-The definition should be complete and cover all the functions and classes in the API. 
+The definitions are complete and up to date with version 2.2.0. The definitions are maintained by [@runn1ng](https://github.com/runn1ng).
 
 ## Examples
 


### PR DESCRIPTION
The link is now in the flow-typed repo. So I added a link.

It might get outdated though, especially after the major version changes - with the minor/patch changes it should be OK, only incomplete.