### PR TITLE
Use NYC over blanket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "mocha": "^2.2.0",
     "proxyquire": "^1.4.0",
     "sinon": "^1.12.2",
-    "standard": "^5.0.0",
+    "standard": "^8.0.0",
     "travis-cov": "^0.2.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     }
   ],
   "scripts": {
-    "coverage": "mocha --require blanket -R travis-cov",
-    "coverage-local": "mocha --require blanket -R html-cov",
+    "coverage-report": "nyc report --reporter=lcov",
+    "coverage": "nyc --check-coverage --branches 90 --functions 90 mocha",
     "integration": "mocha test/integration/",
     "prepublish": "npm run test",
     "standard": "standard",
@@ -47,20 +47,6 @@
   "files": [
     "src"
   ],
-  "config": {
-    "blanket": {
-      "pattern": [
-        ""
-      ],
-      "data-cover-never": [
-        "node_modules",
-        "test"
-      ]
-    },
-    "travis-cov": {
-      "threshold": 99
-    }
-  },
   "dependencies": {
     "bigi": "^1.4.0",
     "bip66": "^1.1.0",
@@ -77,17 +63,16 @@
   },
   "devDependencies": {
     "async": "^1.5.0",
-    "blanket": "^1.1.0",
     "browserify": "^10.0.0",
     "bs58": "^2.0.1",
     "cb-http-client": "^0.2.0",
     "httpify": "^1.0.0",
     "minimaldata": "^1.0.0",
     "mocha": "^2.2.0",
+    "nyc": "^8.1.0",
     "proxyquire": "^1.4.0",
     "sinon": "^1.12.2",
-    "standard": "^8.0.0",
-    "travis-cov": "^0.2.0"
+    "standard": "^8.0.0"
   },
   "license": "MIT"
 }

--- a/test/bitcoin.core.js
+++ b/test/bitcoin.core.js
@@ -4,19 +4,19 @@ var assert = require('assert')
 var base58 = require('bs58')
 var bitcoin = require('../')
 
-var base58_encode_decode = require('./fixtures/core/base58_encode_decode.json')
-var base58_keys_invalid = require('./fixtures/core/base58_keys_invalid.json')
-var base58_keys_valid = require('./fixtures/core/base58_keys_valid.json')
-var blocks_valid = require('./fixtures/core/blocks.json')
-var sig_canonical = require('./fixtures/core/sig_canonical.json')
-var sig_noncanonical = require('./fixtures/core/sig_noncanonical.json')
-var sighash = require('./fixtures/core/sighash.json')
-var tx_valid = require('./fixtures/core/tx_valid.json')
+var base58EncodeDecode = require('./fixtures/core/base58_encode_decode.json')
+var base58KeysInvalid = require('./fixtures/core/base58_keys_invalid.json')
+var base58KeysValid = require('./fixtures/core/base58_keys_valid.json')
+var blocksValid = require('./fixtures/core/blocks.json')
+var sigCanonical = require('./fixtures/core/sig_canonical.json')
+var sigHash = require('./fixtures/core/sighash.json')
+var sigNoncanonical = require('./fixtures/core/sig_noncanonical.json')
+var txValid = require('./fixtures/core/tx_valid.json')
 
 describe('Bitcoin-core', function () {
-  // base58_encode_decode
+  // base58EncodeDecode
   describe('base58', function () {
-    base58_encode_decode.forEach(function (f) {
+    base58EncodeDecode.forEach(function (f) {
       var fhex = f[0]
       var fb58 = f[1]
 
@@ -36,14 +36,14 @@ describe('Bitcoin-core', function () {
     })
   })
 
-  // base58_keys_valid
+  // base58KeysValid
   describe('address.toBase58Check', function () {
     var typeMap = {
       'pubkey': 'pubKeyHash',
       'script': 'scriptHash'
     }
 
-    base58_keys_valid.forEach(function (f) {
+    base58KeysValid.forEach(function (f) {
       var expected = f[0]
       var hash = new Buffer(f[1], 'hex')
       var params = f[2]
@@ -59,7 +59,7 @@ describe('Bitcoin-core', function () {
     })
   })
 
-  // base58_keys_invalid
+  // base58KeysInvalid
   describe('address.fromBase58Check', function () {
     var allowedNetworks = [
       bitcoin.networks.bitcoin.pubkeyhash,
@@ -68,7 +68,7 @@ describe('Bitcoin-core', function () {
       bitcoin.networks.testnet.scripthash
     ]
 
-    base58_keys_invalid.forEach(function (f) {
+    base58KeysInvalid.forEach(function (f) {
       var string = f[0]
 
       it('throws on ' + string, function () {
@@ -81,9 +81,9 @@ describe('Bitcoin-core', function () {
     })
   })
 
-  // base58_keys_valid
+  // base58KeysValid
   describe('ECPair', function () {
-    base58_keys_valid.forEach(function (f) {
+    base58KeysValid.forEach(function (f) {
       var string = f[0]
       var hex = f[1]
       var params = f[2]
@@ -104,14 +104,14 @@ describe('Bitcoin-core', function () {
     })
   })
 
-  // base58_keys_invalid
+  // base58KeysInvalid
   describe('ECPair.fromWIF', function () {
     var allowedNetworks = [
       bitcoin.networks.bitcoin,
       bitcoin.networks.testnet
     ]
 
-    base58_keys_invalid.forEach(function (f) {
+    base58KeysInvalid.forEach(function (f) {
       var string = f[0]
 
       it('throws on ' + string, function () {
@@ -123,7 +123,7 @@ describe('Bitcoin-core', function () {
   })
 
   describe('Block.fromHex', function () {
-    blocks_valid.forEach(function (f) {
+    blocksValid.forEach(function (f) {
       it('can parse ' + f.id, function () {
         var block = bitcoin.Block.fromHex(f.hex)
 
@@ -133,9 +133,9 @@ describe('Bitcoin-core', function () {
     })
   })
 
-  // tx_valid
+  // txValid
   describe('Transaction.fromHex', function () {
-    tx_valid.forEach(function (f) {
+    txValid.forEach(function (f) {
       // Objects that are only a single string are ignored
       if (f.length === 1) return
 
@@ -163,7 +163,7 @@ describe('Bitcoin-core', function () {
   })
 
   describe('script.fromASM', function () {
-    tx_valid.forEach(function (f) {
+    txValid.forEach(function (f) {
       // Objects that are only a single string are ignored
       if (f.length === 1) return
 
@@ -193,7 +193,7 @@ describe('Bitcoin-core', function () {
 
   // sighash
   describe('Transaction', function () {
-    sighash.forEach(function (f) {
+    sigHash.forEach(function (f) {
       // Objects that are only a single string are ignored
       if (f.length === 1) return
 
@@ -228,7 +228,7 @@ describe('Bitcoin-core', function () {
   })
 
   describe('ECSignature.parseScriptSignature', function () {
-    sig_canonical.forEach(function (hex) {
+    sigCanonical.forEach(function (hex) {
       var buffer = new Buffer(hex, 'hex')
 
       it('can parse ' + hex, function () {
@@ -238,11 +238,11 @@ describe('Bitcoin-core', function () {
       })
     })
 
-    sig_noncanonical.forEach(function (hex, i) {
+    sigNoncanonical.forEach(function (hex, i) {
       if (i === 0) return
       if (i % 2 !== 0) return
 
-      var description = sig_noncanonical[i - 1].slice(0, -1)
+      var description = sigNoncanonical[i - 1].slice(0, -1)
       var buffer = new Buffer(hex, 'hex')
 
       it('throws on ' + description, function () {


### PR DESCRIPTION
Blanket has been abandoned.

Welcome back istanbul my old friend.
Install times are slower (5s vs 15s), but if we knock off `mocha` to `tape`, it'll probably come back down.
Whatever.

At least `nyc` is really nice to use compared to the old istanbul CLI.