### PR TITLE
package: update to typeforce 1.8.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "create-hmac": "^1.1.3",
     "ecurve": "^1.0.0",
     "randombytes": "^2.0.1",
-    "typeforce": "^1.6.2",
+    "typeforce": "^1.8.7",
     "wif": "^2.0.1"
   },
   "devDependencies": {

--- a/src/types.js
+++ b/src/types.js
@@ -1,29 +1,9 @@
 var typeforce = require('typeforce')
 
-function nBuffer (value, n) {
-  typeforce(typeforce.Buffer, value)
-  if (value.length !== n) throw new typeforce.TfTypeError('Expected ' + (n * 8) + '-bit Buffer, got ' + (value.length * 8) + '-bit Buffer')
-
-  return true
-}
-
-function Hash160bit (value) { return nBuffer(value, 20) }
-function Hash256bit (value) { return nBuffer(value, 32) }
-function Buffer256bit (value) { return nBuffer(value, 32) }
-
-var UINT53_MAX = Math.pow(2, 53) - 1
 var UINT31_MAX = Math.pow(2, 31) - 1
 function UInt2 (value) { return (value & 3) === value }
-function UInt8 (value) { return (value & 0xff) === value }
-function UInt32 (value) { return (value >>> 0) === value }
 function UInt31 (value) {
-  return UInt32(value) && value <= UINT31_MAX
-}
-function UInt53 (value) {
-  return typeforce.Number(value) &&
-    value >= 0 &&
-    value <= UINT53_MAX &&
-    Math.floor(value) === value
+  return typeforce.UInt32(value) && value <= UINT31_MAX
 }
 
 function Bip32Path (value) {
@@ -40,29 +20,26 @@ var ECSignature = typeforce.compile({ r: BigInt, s: BigInt })
 var Network = typeforce.compile({
   messagePrefix: typeforce.oneOf(typeforce.Buffer, typeforce.String),
   bip32: {
-    public: UInt32,
-    private: UInt32
+    public: typeforce.UInt32,
+    private: typeforce.UInt32
   },
-  pubKeyHash: UInt8,
-  scriptHash: UInt8,
-  wif: UInt8,
-  dustThreshold: UInt53
+  pubKeyHash: typeforce.UInt8,
+  scriptHash: typeforce.UInt8,
+  wif: typeforce.UInt8,
+  dustThreshold: typeforce.UInt53
 })
 
 // extend typeforce types with ours
 var types = {
   BigInt: BigInt,
-  Buffer256bit: Buffer256bit,
+  Buffer256bit: typeforce.BufferN(32),
   ECPoint: ECPoint,
   ECSignature: ECSignature,
-  Hash160bit: Hash160bit,
-  Hash256bit: Hash256bit,
+  Hash160bit: typeforce.BufferN(20),
+  Hash256bit: typeforce.BufferN(32),
   Network: Network,
   UInt2: UInt2,
-  UInt8: UInt8,
   UInt31: UInt31,
-  UInt32: UInt32,
-  UInt53: UInt53,
   Bip32Path: Bip32Path
 }
 

--- a/test/fixtures/ecdsa.json
+++ b/test/fixtures/ecdsa.json
@@ -188,7 +188,7 @@
       },
       {
         "description": "Invalid i value (> 3)",
-        "exception": "Expected UInt2, got Number 4",
+        "exception": "Expected property \"2\" of type UInt2, got Number 4",
         "e": "01",
         "signatureRaw": {
           "r": "00",

--- a/test/fixtures/script.json
+++ b/test/fixtures/script.json
@@ -338,25 +338,25 @@
     ],
     "pubKeyHashOutput": [
       {
-        "exception": "Expected 160-bit Buffer, got 16-bit Buffer",
+        "exception": "Expected Buffer\\(Length: 20\\), got Buffer\\(Length: 2\\)",
         "hash": "ffff"
       }
     ],
     "scriptHashOutput": [
       {
-        "exception": "Expected 160-bit Buffer, got 24-bit Buffer",
+        "exception": "Expected Buffer\\(Length: 20\\), got Buffer\\(Length: 3\\)",
         "hash": "ffffff"
       }
     ],
     "witnessPubKeyHashOutput": [
       {
-        "exception": "Expected 160-bit Buffer, got 24-bit Buffer",
+        "exception": "Expected Buffer\\(Length: 20\\), got Buffer\\(Length: 3\\)",
         "hash": "ffffff"
       }
     ],
     "witnessScriptHashOutput": [
       {
-        "exception": "Expected 256-bit Buffer, got 24-bit Buffer",
+        "exception": "Expected Buffer\\(Length: 32\\), got Buffer\\(Length: 3\\)",
         "hash": "ffffff"
       }
     ]

--- a/test/fixtures/transaction.json
+++ b/test/fixtures/transaction.json
@@ -273,12 +273,12 @@
   "invalid": {
     "addInput": [
       {
-        "exception": "Expected 256-bit Buffer, got 240-bit Buffer",
+        "exception": "Expected property \"0\" of type Buffer\\(Length: 32\\), got Buffer\\(Length: 30\\)",
         "hash": "0aed1366a73b6057ee7800d737bff1bdf8c448e98d86bc0998f2b009816d",
         "index": 0
       },
       {
-        "exception": "Expected 256-bit Buffer, got 272-bit Buffer",
+        "exception": "Expected property \"0\" of type Buffer\\(Length: 32\\), got Buffer\\(Length: 34\\)",
         "hash": "0aed1366a73b6057ee7800d737bff1bdf8c448e98d86bc0998f2b009816da9b0ffff",
         "index": 0
       }

--- a/test/hdnode.js
+++ b/test/hdnode.js
@@ -55,7 +55,7 @@ describe('HDNode', function () {
     it('throws when an invalid length chain code is given', function () {
       assert.throws(function () {
         new HDNode(keyPair, new Buffer(20))
-      }, /Expected 256-bit Buffer, got 160-bit/)
+      }, /Expected property "1" of type Buffer\(Length: 32\), got Buffer\(Length: 20\)/)
     })
   })
 

--- a/test/types.js
+++ b/test/types.js
@@ -27,18 +27,23 @@ describe('types', function () {
     })
 
     it('return true for oneOf', function () {
-      assert(typeforce(types.oneOf(types.Hash160bit, types.Hash256bit), buffer32byte))
-      assert(typeforce(types.oneOf(types.Hash256bit, types.Hash160bit), buffer32byte))
+      assert.doesNotThrow(function () {
+        typeforce(types.oneOf(types.Hash160bit, types.Hash256bit), buffer32byte)
+      })
+
+      assert.doesNotThrow(function () {
+        typeforce(types.oneOf(types.Hash256bit, types.Hash160bit), buffer32byte)
+      })
     })
 
     it('throws for invalid size', function () {
       assert.throws(function () {
         types.Hash160bit(buffer32byte)
-      }, /Expected 160-bit Buffer, got 256-bit Buffer/)
+      }, /Expected Buffer\(Length: 20\), got Buffer\(Length: 32\)/)
 
       assert.throws(function () {
         types.Hash256bit(buffer20byte)
-      }, /Expected 256-bit Buffer, got 160-bit Buffer/)
+      }, /Expected Buffer\(Length: 32\), got Buffer\(Length: 20\)/)
     })
   })
 })


### PR DESCRIPTION
Uses `typeforce.BufferN` and `UInt*` functions over our own,  better tested although the exception message for a 256-bit Buffer is slightly different.
IMHO not a breaking change,  but if someone was directly matching the error message,  it could break their flow.

It also fixes the error messages for function arguments checking which previously omitted the positional information.