### PR TITLE
TransactionBuilder: if prevOutScript is defined, but not signable, try again

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -191,15 +191,16 @@ function prepareInput (input, kpPubKey, redeemScript, hashType) {
 
       var prevOutScriptScriptHash = bscript.decompile(input.prevOutScript)[1]
       if (!prevOutScriptScriptHash.equals(redeemScriptHash)) throw new Error('Inconsistent hash160(RedeemScript)')
-
-    // or, we don't have a prevOutScript, so generate a P2SH script
-    } else {
-      input.prevOutScript = bscript.scriptHashOutput(redeemScriptHash)
-      input.prevOutType = 'scripthash'
     }
 
     var expanded = expandOutput(redeemScript, undefined, kpPubKey)
     if (!expanded.pubKeys) throw new Error('RedeemScript not supported "' + bscript.toASM(redeemScript) + '"')
+
+    // if we don't have a prevOutScript, generate a P2SH script
+    if (!input.prevOutType) {
+      input.prevOutScript = bscript.scriptHashOutput(redeemScriptHash)
+      input.prevOutType = 'scripthash'
+    }
 
     input.pubKeys = expanded.pubKeys
     input.redeemScript = redeemScript

--- a/test/fixtures/transaction_builder.json
+++ b/test/fixtures/transaction_builder.json
@@ -285,6 +285,28 @@
             "value": 10000
           }
         ]
+      },
+      {
+        "description": "Transaction w/ 1 pubKeyHash transaction input (Issue #644)",
+        "network": "testnet",
+        "txHex": "010000000132595835c74fccf097db4ccae9dc2de621e58e0d3f697a27b469b61c7a223b39000000006b483045022100d771395776280955561190c09a6bca731684d09db8995c53496b816b8222019302202a21c9a90d0b5de188800673ad31861183c3f4cb15ea0988b485686aed9fce1d012103f29374a4c2c218a4077db9ba0b9d674cde3719560460af4eb3190d512dd5de92ffffffff0170170000000000001976a914ff99e06c1a4ac394b4e1cb3d3a4b2b47749e339a88ac00000000",
+        "inputs": [
+          {
+            "txHex": "0100000001f7e6430096cd2790bac115aaab22c0a50fb0a1794305302e1a399e81d8d354f4020000006a47304402205793a862d193264afc32713e2e14541e1ff9ebb647dd7e7e6a0051d0faa87de302205216653741ecbbed573ea2fc053209dd6980616701c27be5b958a159fc97f45a012103e877e7deb32d19250dcfe534ea82c99ad739800295cd5429a7f69e2896c36fcdfeffffff0340420f00000000001976a9145c7b8d623fba952d2387703d051d8e931a6aa0a188ac8bda2702000000001976a9145a0ef60784137d03e7868d063b05424f2f43799f88ac40420f00000000001976a9145c7b8d623fba952d2387703d051d8e931a6aa0a188ac2fcc0e00",
+            "vout": 0,
+            "signs": [
+              {
+                "keyPair": "cQ6483mDWwoG8o4tn6nU9Jg52RKMjPUWXSY1vycAyPRXQJ1Pn2Rq"
+              }
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "script": "OP_DUP OP_HASH160 ff99e06c1a4ac394b4e1cb3d3a4b2b47749e339a OP_EQUALVERIFY OP_CHECKSIG",
+            "value": 6000
+          }
+        ]
       }
     ],
     "fromTransaction": [

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -23,11 +23,11 @@ function construct (f, sign) {
   f.inputs.forEach(function (input) {
     var prevTxScript
 
-    if (input.prevTxScript) {
+    if (!input.txHex && input.prevTxScript) {
       prevTxScript = bscript.fromASM(input.prevTxScript)
     }
 
-    txb.addInput(input.txId, input.vout, input.sequence, prevTxScript)
+    txb.addInput(input.txId || Transaction.fromHex(input.txHex), input.vout, input.sequence, prevTxScript)
   })
 
   f.outputs.forEach(function (output) {


### PR DESCRIPTION
This should have fixed https://github.com/bitcoinjs/bitcoinjs-lib/issues/644#issuecomment-251782056,  but I'm still getting issues.

None the less, we need to add some test cases for this,  as it is a valid case.