### PR TITLE
Revert "HDNode: remove unnecessary this context"

### DIFF
--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -314,7 +314,7 @@ HDNode.prototype.derivePath = function (path) {
       index = parseInt(indexStr, 10)
       return prevHd.derive(index)
     }
-  })
+  }, this)
 }
 
 HDNode.prototype.toString = HDNode.prototype.toBase58


### PR DESCRIPTION
Reverts bitcoinjs/bitcoinjs-lib#648,  I misread Travis.
@rubensayshi we need to fix the integration tests failing again,  its quite confusing and can lead to stupid errors like this :+1: 