### PR TITLE
package: remove prepublish step

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "coverage-report": "nyc report --reporter=lcov",
     "coverage": "nyc --check-coverage --branches 90 --functions 90 mocha",
     "integration": "mocha test/integration/",
-    "prepublish": "npm run test",
     "standard": "standard",
     "test": "npm run standard && npm run unit",
     "unit": "mocha"


### PR DESCRIPTION
Great in theory,  but for some reason this causes the tests to always run `postinstall` too, which is very frustrating locally, and also on travis which ends up running the integration tests twice **(causing an effectual DOS for poor blocktrails testnet faucet)**.

First noticed this on my other repositories if you actually watch the travis logs (they `clear` after `npm install` finishes, so it doesn't show in the final job log).