### PR TITLE
block: use merkle-lib instead of inline calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.3",
     "ecurve": "^1.0.0",
+    "merkle-lib": "^1.0.0",
     "randombytes": "^2.0.1",
     "typeforce": "^1.8.7",
     "varuint-bitcoin": "^1.0.4",

--- a/src/block.js
+++ b/src/block.js
@@ -2,6 +2,8 @@ var bufferutils = require('./bufferutils')
 var bcrypto = require('./crypto')
 var bufferReverse = require('buffer-reverse')
 var fastMerkleRoot = require('merkle-lib/fastRoot')
+var typeforce = require('typeforce')
+var types = require('./types')
 
 var Transaction = require('./transaction')
 
@@ -134,6 +136,7 @@ Block.calculateTarget = function (bits) {
 }
 
 Block.calculateMerkleRoot = function (transactions) {
+  typeforce([{ getHash: types.Function }], transactions)
   if (transactions.length === 0) throw TypeError('Cannot compute merkle root for zero transactions')
 
   var hashes = transactions.map(function (transaction) {


### PR DESCRIPTION
Ref: https://github.com/bitcoinjs/merkle-lib

While I had @jprichardson's comments about NIH syndrome in the back of mind RE this.
Ultimately I wanted a library I could use for other projects that was returning the tree format in a flat array,  used `Buffer`s internally and was very easy to review.

I also wanted to continue to use the constant-space root calculation algorithm which we were using in this library.