### PR TITLE
package: npm test should run coverage too

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "coverage": "nyc --check-coverage --branches 90 --functions 90 mocha",
     "integration": "mocha test/integration/",
     "standard": "standard",
-    "test": "npm run standard && npm run unit",
+    "test": "npm run standard && npm run coverage",
     "unit": "mocha"
   },
   "repository": {


### PR DESCRIPTION
This is only ever used locally,  `travis` uses the test targets.