### PR TITLE
TransactionBuilder: further cleanup and refactoring

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -11,15 +11,14 @@ var ECPair = require('./ecpair')
 var ECSignature = require('./ecsignature')
 var Transaction = require('./transaction')
 
-// inspects a scriptSig w/ optional provided redeemScript and derives
-// all necessary input information as required by TransactionBuilder
+// inspects a scriptSig w/ optional redeemScript and
+// derives any input information required
 function expandInput (scriptSig, redeemScript) {
   var scriptSigChunks = bscript.decompile(scriptSig)
-  var scriptSigType = bscript.classifyInput(scriptSigChunks, true)
-
+  var prevOutType = bscript.classifyInput(scriptSigChunks, true)
   var hashType, pubKeys, signatures, prevOutScript
 
-  switch (scriptSigType) {
+  switch (prevOutType) {
     case 'scripthash':
       // FIXME: maybe depth limit instead, how possible is this anyway?
       if (redeemScript) throw new Error('Recursive P2SH script')
@@ -42,7 +41,6 @@ function expandInput (scriptSig, redeemScript) {
       signatures = [s.signature]
 
       if (redeemScript) break
-
       prevOutScript = bscript.pubKeyHashOutput(bcrypto.hash160(pubKeys[0]))
       break
 
@@ -74,7 +72,6 @@ function expandInput (scriptSig, redeemScript) {
 
         return sss.signature
       })
-
       break
   }
 
@@ -83,7 +80,7 @@ function expandInput (scriptSig, redeemScript) {
     pubKeys: pubKeys,
     signatures: signatures,
     prevOutScript: prevOutScript,
-    prevOutType: scriptSigType
+    prevOutType: prevOutType
   }
 }
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -182,16 +182,12 @@ function prepareInput (input, kpPubKey, redeemScript, hashType) {
     var expanded = expandOutput(redeemScript, undefined, kpPubKey)
     if (!expanded.pubKeys) throw new Error('RedeemScript not supported "' + bscript.toASM(redeemScript) + '"')
 
-    // if we don't have a prevOutScript, generate a P2SH script
-    if (!input.prevOutType) {
-      input.prevOutScript = bscript.scriptHashOutput(redeemScriptHash)
-      input.prevOutType = 'scripthash'
-    }
-
     input.pubKeys = expanded.pubKeys
+    input.signatures = expanded.signatures
     input.redeemScript = redeemScript
     input.redeemScriptType = expanded.scriptType
-    input.signatures = expanded.signatures
+    input.prevOutScript = input.prevOutScript || bscript.scriptHashOutput(redeemScriptHash)
+    input.prevOutType = 'scripthash'
 
   // maybe we have some prevOut knowledge
   } else if (input.prevOutType) {

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -213,17 +213,12 @@ function prepareInput (input, kpPubKey, redeemScript, hashType) {
 }
 
 function fixMultisigOrder (input, transaction, vin) {
-  var hashScriptType = input.redeemScriptType || input.prevOutType
-  if (hashScriptType !== 'multisig') return
-
-  var hashScript = input.redeemScript || input.prevOutScript
-  if (!hashScript) return
-  if (!input.pubKeys) return
+  if (input.redeemScriptType !== 'multisig' || !input.redeemScript) return
   if (input.pubKeys.length === input.signatures.length) return
 
   var unmatched = input.signatures.concat()
   var hashType = input.hashType || Transaction.SIGHASH_ALL
-  var hash = transaction.hashForSignature(vin, hashScript, hashType)
+  var hash = transaction.hashForSignature(vin, input.redeemScript, hashType)
 
   input.signatures = input.pubKeys.map(function (pubKey, y) {
     var keyPair = ECPair.fromPublicKeyBuffer(pubKey)

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -84,6 +84,7 @@ function expandInput (scriptSig, redeemScript) {
   }
 }
 
+// could be done in expandInput, but requires the original Transaction for hashForSignature
 function fixMultisigOrder (input, transaction, vin) {
   if (input.redeemScriptType !== 'multisig' || !input.redeemScript) return
   if (input.pubKeys.length === input.signatures.length) return

--- a/test/fixtures/transaction_builder.json
+++ b/test/fixtures/transaction_builder.json
@@ -197,6 +197,34 @@
         ]
       },
       {
+        "description": "Transaction w/ scriptHash(multisig 2-of-3), different hash types",
+        "network": "testnet",
+        "txHex": "0100000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000fd5e0100483045022100eec19e061cad41610f9b42d2b06638b6b0fec3da0de9c6858e7f8c06053979900220622936dd47e202b2ad17639cda680e52334d407149252959936bb1f38e4acc5201483045022100d404fb6de6cf42efb9d7948d2e8fb6618f8eba55ecd25907d18d576d9aa6f39d02205ec2e7fa7c5f8a9793732ca9d2f9aba3b2bb04ca6d467ba36940e0f695e48de5024cc952410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a4104f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e67253aeffffffff01e8030000000000001976a914aa4d7985c57e011a8b3dd8e0e5a73aaef41629c588ac00000000",
+        "inputs": [
+          {
+            "txId": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "vout": 0,
+            "signs": [
+              {
+                "keyPair": "91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx",
+                "redeemScript": "OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a 04f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9388f7b0f632de8140fe337e62a37f3566500a99934c2231b6cb9fd7584b8e672 OP_3 OP_CHECKMULTISIG",
+                "hashType": 1
+              },
+              {
+                "keyPair": "91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgx3cTMqe",
+                "hashType": 2
+              }
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "script": "OP_DUP OP_HASH160 aa4d7985c57e011a8b3dd8e0e5a73aaef41629c5 OP_EQUALVERIFY OP_CHECKSIG",
+            "value": 1000
+          }
+        ]
+      },
+      {
         "description": "Transaction w/ scriptHash(pubKey) -> pubKeyHash",
         "txHex": "0100000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000006c47304402201115644b134932c8a7a8e925769d130a801288d477130e2bf6fadda20b33754d02202ecefbf63844d7cb2d5868539c39f973fe019f72e5c31a707836c0d61ef317db012321033e29aea1168a835d5e386c292082db7b7807172a10ec634ad34226f36d79e70facffffffff0100f90295000000001976a914aa4d7985c57e011a8b3dd8e0e5a73aaef41629c588ac00000000",
         "inputs": [

--- a/test/fixtures/transaction_builder.json
+++ b/test/fixtures/transaction_builder.json
@@ -835,34 +835,6 @@
         ]
       },
       {
-        "exception": "Inconsistent hashType",
-        "network": "testnet",
-        "inputs": [
-          {
-            "txId": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            "vout": 0,
-            "signs": [
-              {
-                "redeemScript": "OP_2 0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a OP_2 OP_CHECKMULTISIG",
-                "keyPair": "91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgwmaKkrx",
-                "hashType": 4
-              },
-              {
-                "keyPair": "91avARGdfge8E4tZfYLoxeJ5sGBdNJQH4kvjJoQFacbgww7vXtT",
-                "hashType": 2,
-                "throws": true
-              }
-            ]
-          }
-        ],
-        "outputs": [
-          {
-            "script": "OP_DUP OP_HASH160 aa4d7985c57e011a8b3dd8e0e5a73aaef41629c5 OP_EQUALVERIFY OP_CHECKSIG",
-            "value": 1000
-          }
-        ]
-      },
-      {
         "exception": "RedeemScript not supported \"OP_HASH160 7f67f0521934a57d3039f77f9f32cf313f3ac74b OP_EQUAL\"",
         "inputs": [
           {

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -34,20 +34,20 @@ function construct (f, sign) {
     txb.addOutput(bscript.fromASM(output.script), output.value)
   })
 
-  if (sign === undefined || sign) {
-    f.inputs.forEach(function (input, index) {
-      input.signs.forEach(function (sign) {
-        var keyPair = ECPair.fromWIF(sign.keyPair, network)
-        var redeemScript
+  if (sign === false) return txb
 
-        if (sign.redeemScript) {
-          redeemScript = bscript.fromASM(sign.redeemScript)
-        }
+  f.inputs.forEach(function (input, index) {
+    input.signs.forEach(function (sign) {
+      var keyPair = ECPair.fromWIF(sign.keyPair, network)
+      var redeemScript
 
-        txb.sign(index, keyPair, redeemScript, sign.hashType)
-      })
+      if (sign.redeemScript) {
+        redeemScript = bscript.fromASM(sign.redeemScript)
+      }
+
+      txb.sign(index, keyPair, redeemScript, sign.hashType)
     })
-  }
+  })
 
   return txb
 }
@@ -65,7 +65,7 @@ describe('TransactionBuilder', function () {
 
   describe('fromTransaction', function () {
     fixtures.valid.build.forEach(function (f) {
-      it('builds TransactionBuilder, with ' + f.description, function () {
+      it('returns TransactionBuilder, with ' + f.description, function () {
         var network = NETWORKS[f.network || 'bitcoin']
         var tx = Transaction.fromHex(f.txHex)
         var txb = TransactionBuilder.fromTransaction(tx, network)
@@ -76,7 +76,7 @@ describe('TransactionBuilder', function () {
     })
 
     fixtures.valid.fromTransaction.forEach(function (f) {
-      it('builds TransactionBuilder, with ' + f.description, function () {
+      it('returns TransactionBuilder, with ' + f.description, function () {
         var tx = new Transaction()
 
         f.inputs.forEach(function (input) {


### PR DESCRIPTION
Just part of the effort of making this more review-able. 

Cleaned up a few assumptions that weren't correct too in `fixMultisigOrder`,  it simply won't ever work unless a `redeemScript` was provided (and hence, `pubKeys` defined)

Also resolves #642 