### PR TITLE
HDNode: remove HDNode.toString for safety

### DIFF
--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -317,6 +317,4 @@ HDNode.prototype.derivePath = function (path) {
   }, this)
 }
 
-HDNode.prototype.toString = HDNode.prototype.toBase58
-
 module.exports = HDNode


### PR DESCRIPTION
Not sure why this was ever added, when we came to decision back in `1.0.0` IIRC to disable `toString` possibilities for private keys in general.
If you want the Base58... `toBase58` is the same number of letters... and is generally a more explicit opt-in.

Breaking change as someone could be relying on it for serialisation.