### PR TITLE
travis: no need for before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: false
 language: node_js
-before_install:
-  - npm install npm -g
 node_js:
   - "0.12"
   - "4"


### PR DESCRIPTION
I can't see why this is necessary,  so I'm removing it.  If anyone knows why,  I'll put it back.