### PR TITLE
HDNode test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "scripts": {
     "coverage-report": "nyc report --reporter=lcov",
+    "coverage-html": "nyc report --reporter=html",
     "coverage": "nyc --check-coverage --branches 90 --functions 90 mocha",
     "integration": "mocha test/integration/",
     "standard": "standard",

--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -107,7 +107,6 @@ HDNode.fromBase58 = function (string, networks) {
   // 33 bytes: public key data (0x02 + X or 0x03 + X)
   } else {
     var Q = ecurve.Point.decodeFrom(curve, buffer.slice(45, 78))
-    if (!Q.compressed) throw new Error('Invalid public key')
 
     // Verify that the X coordinate in the public point corresponds to a point on the curve.
     // If not, the extended public key is invalid.

--- a/test/fixtures/hdnode.json
+++ b/test/fixtures/hdnode.json
@@ -199,6 +199,26 @@
         "string": "xprvQQQQQQQQQQQQQQQQCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334"
       },
       {
+        "exception": "Invalid buffer length",
+        "network": "bitcoin",
+        "string": "HAsbc6CgKmTYEQg2CTz7m5STEPAB"
+      },
+      {
+        "exception": "Invalid parent fingerprint",
+        "network": "bitcoin",
+        "string": "xprv9tnJFvAXAXPfPnMTKfwpwnkty7MzJwELVgp4NTBquaKXy4RndyfJJCJJf7zNaVpBpzrwVRutZNLRCVLEcZHcvuCNG3zGbGBcZn57FbNnmSP"
+      },
+      {
+        "exception": "Invalid private key",
+        "network": "bitcoin",
+        "string": "xprv9s21ZrQH143K3yLysFvsu3n1dMwhNusmNHr7xArzAeCc7MQYqDBBStmqnZq6WLi668siBBNs3SjiyaexduHu9sXT9ixTsqptL67ADqcaBdm"
+      },
+      {
+        "exception": "Invalid index",
+        "network": "bitcoin",
+        "string": "xprv9s21ZrQYdgnodnKW4Drm1Qg7poU6Gf2WUDsjPxvYiK7iLBMrsjbnF1wsZZQgmXNeMSG3s7jmHk1b3JrzhG5w8mwXGxqFxfrweico7k8DtxR"
+      },
+      {
         "exception": "Unknown network version",
         "string": "1111111111111adADjFaSNPxwXqLjHLj4mBfYxuewDPbw9hEj1uaXCzMxRPXDFF3cUoezTFYom4sEmEVSQmENPPR315cFk9YUFVek73wE9"
       },


### PR DESCRIPTION
 - First commit adds an npm script for HTML coverage reports. 
 - Second is test cases that hit simple checks in fromBuffer
 - Third commit removes the check for uncompressed keys whilst parsing from base58. We slice only 33 bytes and `ecurve.Point.decodeFrom` throws given \x04 keys which aren't 65 bytes

I guess it's making assumptions about `ecurve.Point.decodeFrom`, but it's untestable at the moment :)