### PR TITLE
decode* functions for output scripts

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -108,7 +108,7 @@ function expandOutput (script, scriptType, ourPubKey) {
 
   var scriptChunks = bscript.decompile(script)
   if (!scriptType) {
-    scriptType = bscript.classifyOutput(scriptChunks)
+    scriptType = bscript.classifyOutput(script)
   }
 
   var pubKeys = []

--- a/test/address.js
+++ b/test/address.js
@@ -36,15 +36,6 @@ describe('address', function () {
       })
     })
 
-    fixtures.valid.forEach(function (f) {
-      it('parses (as chunks) ' + f.script.slice(0, 30) + '... (' + f.network + ')', function () {
-        var chunks = bscript.decompile(bscript.fromASM(f.script))
-        var address = baddress.fromOutputScript(chunks, networks[f.network])
-
-        assert.strictEqual(address, f.base58check)
-      })
-    })
-
     fixtures.invalid.fromOutputScript.forEach(function (f) {
       it('throws when ' + f.script.slice(0, 30) + '... ' + f.exception, function () {
         var script = bscript.fromASM(f.script)

--- a/test/fixtures/script.json
+++ b/test/fixtures/script.json
@@ -226,18 +226,90 @@
       {
         "description": "non-canonical pubkey (too long)",
         "scriptPubKey": "02359c6e3f04cefbf089cf1d6670dc47c3fb4df68e2bad1fa5a369f9ce4b42bbd1ffffff OP_CHECKSIG"
+      },
+      {
+        "description": "last operator is wrong for pubkey-output",
+        "scriptPubKeyHex": "21027a71801ab59336de37785c50005b6abd8ea859eecce1edbe8e81afa74ee5c752ae"
+      },
+      {
+        "description": "missing OP_CHECKSIG",
+        "scriptPubKeyHex": "21027a71801ab59336de37785c50005b6abd8ea859eecce1edbe8e81afa74ee5c752"
+      },
+      {
+        "description": "non-canonical pubkey (bad prefix)",
+        "scriptPubKey": "427a71801ab59336de37785c50005b6abd8ea859eecce1edbe8e81afa74ee5c752 OP_CHECKSIG"
+      },
+      {
+        "description": "has extra opcode at the end isPubKeyOutput",
+        "scriptPubKey": "027a71801ab59336de37785c50005b6abd8ea859eecce1edbe8e81afa74ee5c752 OP_CHECKSIG OP_0"
       }
     ],
     "isPubKeyHashOutput": [
       {
         "description": "non-minimal encoded isPubKeyHashOutput (non BIP62 compliant)",
         "scriptPubKeyHex": "76a94c14aa4d7985c57e011a8b3dd8e0e5a73aaef41629c588ac"
+      },
+      {
+        "description": "bad OP_DUP isPubKeyHashOutput",
+        "scriptPubKeyHex": "aca914aa4d7985c57e011a8b3dd8e0e5a73aaef41629c588ac"
+      },
+      {
+        "description": "bad OP_HASH160 isPubKeyHashOutput",
+        "scriptPubKeyHex": "76ac14aa4d7985c57e011a8b3dd8e0e5a73aaef41629c588ac"
+      },
+      {
+        "description": "bad OP_EQUALVERIFY isPubKeyHashOutput",
+        "scriptPubKeyHex": "76a914aa4d7985c57e011a8b3dd8e0e5a73aaef41629c5acac"
+      },
+      {
+        "description": "bad OP_CHECKSIG isPubKeyHashOutput",
+        "scriptPubKeyHex": "76a914aa4d7985c57e011a8b3dd8e0e5a73aaef41629c58888"
+      },
+      {
+        "description": "bad length isPubKeyHashOutput",
+        "scriptPubKeyHex": "76a920aa4d7985c57e011a8b3dd8e0e5a73aaef41629c588ac"
+      },
+      {
+        "description": "has something at the end isPubKeyHashOutput",
+        "scriptPubKeyHex": "76a920aa4d7985c57e011a8b3dd8e0e5a73aaef41629c588ac00"
       }
     ],
     "isScriptHashOutput": [
       {
         "description": "non-minimal encoded isScriptHashOutput (non BIP62 compliant)",
         "scriptPubKeyHex": "a94c14c286a1af0947f58d1ad787385b1c2c4a976f9e7187"
+      },
+      {
+        "description": "wrong OP_HASH160 opcode",
+        "scriptPubKeyHex": "ac4c14c286a1af0947f58d1ad787385b1c2c4a976f9e7187"
+      },
+      {
+        "description": "wrong length marker",
+        "scriptPubKeyHex": "a916c286a1af0947f58d1ad787385b1c2c4a976f9e7187"
+      },
+      {
+        "description": "wrong OP_EQUAL opcode",
+        "scriptPubKeyHex": "a914c286a1af0947f58d1ad787385b1c2c4a976f9e7188"
+      }
+    ],
+    "isWitnessPubKeyHashOutput": [
+      {
+        "description": "wrong version",
+        "scriptPubKeyHex": "51149090909090909090909090909090909090909090"
+      },
+      {
+        "description": "wrong length marker",
+        "scriptPubKeyHex": "00209090909090909090909090909090909090909090"
+      }
+    ],
+    "isWitnessScriptHashOutput": [
+      {
+        "description": "wrong version",
+        "scriptPubKeyHex": "51209090909090909090909090909090909090909090909090909090909090909090"
+      },
+      {
+        "description": "wrong length marker",
+        "scriptPubKeyHex": "00219090909090909090909090909090909090909090909090909090909090909090"
       }
     ],
     "isMultisigOutput": [

--- a/test/script.js
+++ b/test/script.js
@@ -10,7 +10,16 @@ var fixtures = require('./fixtures/script.json')
 
 describe('script', function () {
   // TODO
-  describe.skip('isCanonicalPubKey', function () {})
+  describe('isCanonicalPubKey', function () {
+    it('rejects if not provided a Buffer', function () {
+      assert.strictEqual(false, bscript.isCanonicalPubKey(0))
+    })
+    it('rejects smaller than 33', function () {
+      for (var i = 0; i < 33; i++) {
+        assert.strictEqual(false, bscript.isCanonicalPubKey(new Buffer('', i)))
+      }
+    })
+  })
   describe.skip('isCanonicalSignature', function () {})
 
   describe('fromASM/toASM', function () {


### PR DESCRIPTION
As brought up in #680, there is a case for including functions capable of decoding the supported output scripts. While #680 only adds this for multi-signature scripts, this PR adds methods for pubkey / pubkeyhash / multisig / nulldata / scripthash / witnesskeyhash / witnessscripthash. They were written based on the conditions used by the previous `is*` functions, and test fixtures for these conditions are included.

While starting this work I noticed something awkward - that various is* functions call `compile` on input, whereas others used `decompile`. I opted to restrict the input accepted by `is*Output` and `classifyOutput` to scripts only.

The intent for the decode* functions is to return:

  - the type of script
  - the data a wallet uses to check if it can spend the funds (pubkey for P2PK, a hash for P2PKH, a list of keys for multisig, a hash for P2SH, a hash for P2WSH, a hash for P2WPKH)
  - future supported types might return other fields: csv_locktime, cltv..

Each is* function now attempts to decode against the script type - if an exception is thrown, return false, otherwise return true. 

**NB** A nice break would be to return the output of decode after calling `is*`. Maybe this could also cascade up to classifyOutput, so once you classify you get all information about the output, cos quite often as soon as you determine it's P2SH (eg), you need to check the scriptHash against something. This takes two decodes at the moment.