### PR TITLE
types: add Script ASM type check [WIP]

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -119,7 +119,7 @@ function toASM (chunks) {
 }
 
 function fromASM (asm) {
-  typeforce(types.String, asm)
+  typeforce(types.ASM, asm)
 
   return compile(asm.split(' ').map(function (chunkStr) {
     // opcode?

--- a/src/types.js
+++ b/src/types.js
@@ -6,13 +6,17 @@ function UInt31 (value) {
 }
 
 function BIP32Path (value) {
-  return typeforce.String(value) && value.match(/^(m\/)?(\d+'?\/)*\d+'?$/)
+  return typeforce.String(value) && /^(m\/)?(\d+'?\/)*\d+'?$/.test(value)
 }
 BIP32Path.toJSON = function () { return 'BIP32 derivation path' }
 
 var SATOSHI_MAX = 21 * 1e14
 function Satoshi (value) {
   return typeforce.UInt53(value) && value <= SATOSHI_MAX
+}
+
+function ASM (value) {
+  return typeforce.String(value) && /^((OP_[A-Z0-9]+)|([a-f0-9]+)| )+$/g.test(value)
 }
 
 // external dependent types
@@ -34,6 +38,7 @@ var Network = typeforce.compile({
 
 // extend typeforce types with ours
 var types = {
+  ASM: ASM,
   BigInt: BigInt,
   BIP32Path: BIP32Path,
   Buffer256bit: typeforce.BufferN(32),

--- a/test/fixtures/script.json
+++ b/test/fixtures/script.json
@@ -193,6 +193,12 @@
         "hex": "4effffffff01"
       }
     ],
+    "fromASM": [
+      {
+        "description": "Expected ASM, got String",
+        "script": "0xff OP_CHECKSIG"
+      }
+    ],
     "pubKey": {
       "inputs": [
         {

--- a/test/script.js
+++ b/test/script.js
@@ -38,6 +38,14 @@ describe('script', function () {
         })
       }
     })
+
+    fixtures.invalid.fromASM.forEach(function (f) {
+      it('throws ' + f.description, function () {
+        assert.throws(function () {
+          bscript.fromASM(f.script)
+        }, new RegExp(f.description))
+      })
+    })
   })
 
   describe('decompilePushOnly/compilePushOnly', function () {


### PR DESCRIPTION
This does result in a double parse, but it is useful for avoiding weird cases where `Buffer` will accept `0xff` but returns `Buffer< >`...