### PR TITLE
tests: add minimally encoded 0-length buffer script

### DIFF
--- a/test/fixtures/script.json
+++ b/test/fixtures/script.json
@@ -144,6 +144,11 @@
       "scriptPubKeyHex": "000000ae"
     },
     {
+      "type": "nonstandard",
+      "scriptPubKey": "OP_0",
+      "scriptPubKeyHex": "00"
+    },
+    {
       "type": "scripthash",
       "redeemScript": "OP_0",
       "redeemScriptSig": "OP_0",


### PR DESCRIPTION
Just a curiosity worth noting/testing