### PR TITLE
Script: add {compile,decompile}PushOnly

### DIFF
--- a/test/script.js
+++ b/test/script.js
@@ -40,6 +40,19 @@ describe('script', function () {
     })
   })
 
+  describe('decompilePushOnly/compilePushOnly', function () {
+    fixtures.valid.forEach(function (f) {
+      if (f.scriptSig) {
+        it('encodes/decodes scriptSigs as script stack: ' + f.scriptSig, function () {
+          var script = bscript.fromASM(f.scriptSig)
+          var sigStack = bscript.decompilePushOnly(script)
+          var rebuildScript = bscript.compilePushOnly(sigStack)
+          assert.strictEqual(bscript.toASM(rebuildScript), f.scriptSig)
+        })
+      }
+    })
+  })
+
   describe('compile (via fromASM)', function () {
     fixtures.valid.forEach(function (f) {
       if (f.scriptSig) {


### PR DESCRIPTION
This adds two functions to script, building upon the existing `compile` and `decompile` functions. 

`var script = bscript.compilePushOnly( stack )`
`var stack = bscript.decompilePushOnly( script )`

They are pretty much only useful for dealing with scriptSigs. It's useful for signing, you can have functions return witness data (eg, ['', '30440220......', '5103...'], and then using `compilePushOnly` to convert that '' (or any small int) buffer to OP_0 (or the respective OP_x) and into a usable scriptSig.

`decompilePushOnly` decompiles a script and interprets the OP_x opcodes into buffers. It's output is essentially the state of the stack after bitcoin script evaluates script with the VERIFY_SIGPUSHONLY flag (it rejects any non-push opcodes (OP_0 allowed, not OP_HASH160 etc)

This sets us up nicely for signing segwit transactions, because internally functions can extract signatures from the results of `decompilePushOnly`, or if witness is involved the witness data is used. So the templated signature extraction now operates on an array of Buffers. 

`compilePushOnly` can be used to have `buildInput` call something that produces the script stack, in order to be compiled into a scriptSig, or used directly as witness. We need `buildInput` to start returning `{scriptSig: x, witness: y}` or something to relay this information to `TransactionBuilder.__build` (actually, check my signing branch for this)

This replaces #689, and should probably include some of it's tests. 

Note the naming might be overloading the terms compile / decompile given current use (so open to suggestions on names). This is slightly different, because we're converting the OP_x range whenever they're encountered. The tests check that we can decompilePushOnly->compilePushOnly->toASM and match the same scriptSig (that's the only place it's expected to work)