### PR TITLE
Test: verify Transaction.hashForSignature uses non-witness format.

### DIFF
--- a/test/transaction.js
+++ b/test/transaction.js
@@ -205,6 +205,29 @@ describe('Transaction', function () {
   })
 
   describe('hashForSignature', function () {
+    it('only uses V0 serialization', function () {
+      var randScript = new Buffer('6a', 'hex')
+
+      var tmp = new Transaction()
+      tmp.addInput(new Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex'), 0)
+      tmp.addOutput(randScript, 5000000000)
+      tmp.___toBuffer = tmp.__toBuffer
+      tmp.__toBuffer = function (a, b, c) {
+        if (c !== false) {
+          throw new Error('Not meant to pass true to __toBuffer in hashForSignature')
+        }
+        return this.___toBuffer(a, b, c)
+      }
+
+      assert.throws(function () {
+        tmp.__toBuffer(undefined, undefined, true)
+      }, 'Verify our replacement of __toBuffer can lead to an error if using witness')
+
+      assert.doesNotThrow(function () {
+        tmp.hashForSignature(0, randScript, 1)
+      }, "check that this situation doesn't occur normally")
+    })
+
     fixtures.hashForSignature.forEach(function (f) {
       it('should return ' + f.hash + ' for ' + (f.description ? ('case "' + f.description + '"') : f.script), function () {
         var tx = Transaction.fromHex(f.txHex)


### PR DESCRIPTION
This PR adds a small test that `tx.__toBuffer` is "never" called with `__allowWitnesses=true` during hashForSignature. This would only arise due to error since __toBuffer gets directly called in this function, and passes false always. 

Related issue: https://github.com/bitcoinjs/bitcoinjs-lib/issues/702