### PR TITLE
Clarify its using non-witness, not necessarily legacy

### DIFF
--- a/test/transaction.js
+++ b/test/transaction.js
@@ -213,7 +213,7 @@ describe('Transaction', function () {
   })
 
   describe('hashForSignature', function () {
-    it('only uses legacy serialization', function () {
+    it('does not use Witness serialization', function () {
       var randScript = new Buffer('6a', 'hex')
 
       var tx = new Transaction()


### PR DESCRIPTION
I think implying the previous serialisation methods are `legacy` actually may be the wrong way to go about this.