### PR TITLE
remove errant argument to buildInput in __build

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -397,7 +397,7 @@ function buildInput (input, allowIncomplete) {
   var sig = []
   var witness = []
   if (SIGNABLE.indexOf(scriptType) !== -1) {
-    sig = buildStack(scriptType, input.signatures, input.pubKeys, input.script, allowIncomplete)
+    sig = buildStack(scriptType, input.signatures, input.pubKeys, allowIncomplete)
   }
 
   var p2sh = false

--- a/test/fixtures/transaction_builder.json
+++ b/test/fixtures/transaction_builder.json
@@ -1703,33 +1703,6 @@
         ]
       },
       {
-        "description": "Incomplete transaction w/ prevTxScript defined",
-        "exception": "Not enough signatures provided",
-        "incomplete": true,
-        "inputs": [
-          {
-            "txId": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            "vout": 0,
-            "signs": [
-              {
-                "keyPair": "KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn"
-              }
-            ]
-          },
-          {
-            "txId": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            "vout": 1,
-            "prevTxScript": "OP_DUP OP_HASH160 aa4d7985c57e011a8b3dd8e0e5a73aaef41629c5 OP_EQUALVERIFY OP_CHECKSIG"
-          }
-        ],
-        "outputs": [
-          {
-            "script": "OP_DUP OP_HASH160 aa4d7985c57e011a8b3dd8e0e5a73aaef41629c5 OP_EQUALVERIFY OP_CHECKSIG",
-            "value": 1000
-          }
-        ]
-      },
-      {
         "description": "Duplicate transaction outs",
         "exception": "Duplicate TxOut: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff:0",
         "incomplete": true,

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -354,6 +354,18 @@ describe('TransactionBuilder', function () {
         }
       })
     })
+
+    it('for incomplete with 0 signatures', function () {
+      var randomTxData = '0100000000010100010000000000000000000000000000000000000000000000000000000000000000000000ffffffff01e8030000000000001976a9144c9c3dfac4207d5d8cb89df5722cb3d712385e3f88ac02483045022100aa5d8aa40a90f23ce2c3d11bc845ca4a12acd99cbea37de6b9f6d86edebba8cb022022dedc2aa0a255f74d04c0b76ece2d7c691f9dd11a64a8ac49f62a99c3a05f9d01232103596d3451025c19dbbdeb932d6bf8bfb4ad499b95b6f88db8899efac102e5fc71ac00000000'
+      var randomAddress = '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH'
+
+      var randomTx = Transaction.fromHex(randomTxData)
+      var tx = new TransactionBuilder()
+      tx.addInput(randomTx, 0)
+      tx.addOutput(baddress.toOutputScript(randomAddress), 1000)
+      tx = tx.buildIncomplete()
+      assert(tx)
+    })
   })
 
   describe('multisig', function () {


### PR DESCRIPTION
`buildInput` was passing `buildStack` an incorrect number of arguments. Based on the call signature of `buildStack`, I removed `input.script`.

This caused the "Incomplete transaction w/ prevTxScript defined" test to fail because it no longer threw an exception. However I don't think that exception should be thrown, since if `allowIncomplete` is set to `true` then a lack of signatures shouldn't be a problem.