### PR TITLE
Re #833: fix bug when dealing with incomplete P2SH/P2WSH inputs.

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -409,12 +409,15 @@ function buildInput (input, allowIncomplete) {
     if (P2SH.indexOf(input.redeemScriptType) === -1 && !allowIncomplete) {
       throw new Error('Impossible to sign this type')
     }
-    p2sh = true
+
     if (SIGNABLE.indexOf(input.redeemScriptType) !== -1) {
       sig = buildStack(input.redeemScriptType, input.signatures, input.pubKeys, allowIncomplete)
     }
     // If it wasn't SIGNABLE, it's witness, defer to that
-    scriptType = input.redeemScriptType
+    if (input.redeemScriptType) {
+      p2sh = true
+      scriptType = input.redeemScriptType
+    }
   }
 
   if (scriptType === bscript.types.P2WPKH) {

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -406,7 +406,7 @@ function buildInput (input, allowIncomplete) {
   if (scriptType === bscript.types.P2SH) {
     // We can remove this error later when we have a guarantee prepareInput
     // rejects unsignable scripts - it MUST be signable at this point.
-    if (P2SH.indexOf(input.redeemScriptType) === -1) {
+    if (P2SH.indexOf(input.redeemScriptType) === -1 && !allowIncomplete) {
       throw new Error('Impossible to sign this type')
     }
     p2sh = true
@@ -422,16 +422,13 @@ function buildInput (input, allowIncomplete) {
     witness = buildStack(bscript.types.P2PKH, input.signatures, input.pubKeys, allowIncomplete)
   } else if (scriptType === bscript.types.P2WSH) {
     // We can remove this check later
-    if (SIGNABLE.indexOf(input.witnessScriptType) !== -1) {
+    if (SIGNABLE.indexOf(input.witnessScriptType) === -1 && !allowIncomplete) {
+      throw new Error('Impossible to sign this type')
+    } else if (SIGNABLE.indexOf(input.witnessScriptType) !== -1) {
       witness = buildStack(input.witnessScriptType, input.signatures, input.pubKeys, allowIncomplete)
       witness.push(input.witnessScript)
-    } else {
-      // We can remove this error later when we have a guarantee prepareInput
-      // rejects unsignble scripts - it MUST be signable at this point.
-      throw new Error()
+      scriptType = input.witnessScriptType
     }
-
-    scriptType = input.witnessScriptType
   }
 
   // append redeemScript if necessary
@@ -578,7 +575,6 @@ TransactionBuilder.prototype.__addInputUnsafe = function (txHash, vout, options)
   var vin = this.tx.addInput(txHash, vout, options.sequence, options.scriptSig)
   this.inputs[vin] = input
   this.prevTxMap[prevTxOut] = vin
-
   return vin
 }
 

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -362,7 +362,7 @@ describe('TransactionBuilder', function () {
       var randomTx = Transaction.fromHex(randomTxData)
       var tx = new TransactionBuilder()
       tx.addInput(randomTx, 0)
-      tx.addOutput(baddress.toOutputScript(randomAddress), 1000)
+      tx.addOutput(randomAddress, 1000)
       tx = tx.buildIncomplete()
       assert(tx)
     })
@@ -373,7 +373,7 @@ describe('TransactionBuilder', function () {
 
       var txb = new TransactionBuilder(NETWORKS.testnet)
       txb.addInput(inpTx, 0)
-      txb.addOutput(baddress.toOutputScript('2NAkqp5xffoomp5RLBcakuGpZ12GU4twdz4', NETWORKS.testnet), 1e8) // arbitrary output
+      txb.addOutput('2NAkqp5xffoomp5RLBcakuGpZ12GU4twdz4', 1e8) // arbitrary output
 
       txb.buildIncomplete()
     })
@@ -384,7 +384,7 @@ describe('TransactionBuilder', function () {
 
       var txb = new TransactionBuilder(NETWORKS.testnet)
       txb.addInput(inpTx, 0)
-      txb.addOutput(baddress.toOutputScript('2NAkqp5xffoomp5RLBcakuGpZ12GU4twdz4', NETWORKS.testnet), 1e8) // arbitrary output
+      txb.addOutput('2NAkqp5xffoomp5RLBcakuGpZ12GU4twdz4', 1e8) // arbitrary output
 
       txb.buildIncomplete()
     })
@@ -394,7 +394,7 @@ describe('TransactionBuilder', function () {
 
       var txb = new TransactionBuilder(NETWORKS.testnet)
       txb.addInput(inpTx, 0)
-      txb.addOutput(baddress.toOutputScript('2NAkqp5xffoomp5RLBcakuGpZ12GU4twdz4', NETWORKS.testnet), 1e8) // arbitrary output
+      txb.addOutput('2NAkqp5xffoomp5RLBcakuGpZ12GU4twdz4', 1e8) // arbitrary output
 
       txb.buildIncomplete()
     })

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -366,6 +366,38 @@ describe('TransactionBuilder', function () {
       tx = tx.buildIncomplete()
       assert(tx)
     })
+
+    it('for incomplete P2SH with 0 signatures', function () {
+      var inp = Buffer.from('010000000173120703f67318aef51f7251272a6816d3f7523bb25e34b136d80be959391c100000000000ffffffff0100c817a80400000017a91471a8ec07ff69c6c4fee489184c462a9b1b9237488700000000', 'hex') // arbitrary P2SH input
+      var inpTx = Transaction.fromBuffer(inp)
+
+      var txb = new TransactionBuilder(NETWORKS.testnet)
+      txb.addInput(inpTx, 0)
+      txb.addOutput(baddress.toOutputScript('2NAkqp5xffoomp5RLBcakuGpZ12GU4twdz4', NETWORKS.testnet), 1e8) // arbitrary output
+
+      txb.buildIncomplete()
+    })
+
+    it('for incomplete P2WPKH with 0 signatures', function () {
+      var inp = Buffer.from('010000000173120703f67318aef51f7251272a6816d3f7523bb25e34b136d80be959391c100000000000ffffffff0100c817a8040000001600141a15805e1f4040c9f68ccc887fca2e63547d794b00000000', 'hex')
+      var inpTx = Transaction.fromBuffer(inp)
+
+      var txb = new TransactionBuilder(NETWORKS.testnet)
+      txb.addInput(inpTx, 0)
+      txb.addOutput(baddress.toOutputScript('2NAkqp5xffoomp5RLBcakuGpZ12GU4twdz4', NETWORKS.testnet), 1e8) // arbitrary output
+
+      txb.buildIncomplete()
+    })
+
+    it('for incomplete P2WSH with 0 signatures', function () {
+      var inpTx = Transaction.fromBuffer(Buffer.from('010000000173120703f67318aef51f7251272a6816d3f7523bb25e34b136d80be959391c100000000000ffffffff0100c817a80400000022002072df76fcc0b231b94bdf7d8c25d7eef4716597818d211e19ade7813bff7a250200000000', 'hex'))
+
+      var txb = new TransactionBuilder(NETWORKS.testnet)
+      txb.addInput(inpTx, 0)
+      txb.addOutput(baddress.toOutputScript('2NAkqp5xffoomp5RLBcakuGpZ12GU4twdz4', NETWORKS.testnet), 1e8) // arbitrary output
+
+      txb.buildIncomplete()
+    })
   })
 
   describe('multisig', function () {


### PR DESCRIPTION
Should be able to deal with incomplete P2SH/P2WSH inputs when allowIncomplete is set. Incorporates suggestion from @Melvillian and does similar for P2WSH, adding test cases for p2sh/p2wsh/p2wpkh.

Fixes #833 