### PR TITLE
WIP: Implement segwit_address.js against bech32 commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   ],
   "dependencies": {
     "bigi": "^1.4.0",
+    "bech32": "git@github.com:bitcoinjs/bech32.git#81bc22761b3c8d286d6d8dc7bc10bda855adeb78",
     "bip66": "^1.1.0",
     "bitcoin-ops": "^1.3.0",
     "bs58check": "^2.0.0",

--- a/src/segwit_address.js
+++ b/src/segwit_address.js
@@ -1,0 +1,50 @@
+var bech32 = require('bech32')
+
+function decode (expectedPrefix, string) {
+  var result = bech32.decode(string)
+  if (result.prefix !== expectedPrefix) {
+    throw new Error('Unexpected prefix')
+  }
+
+  if (!(result.bitData.length > 0) && (result.bitData.length < 66)) {
+    throw new Error('Invalid length of encoded data')
+  }
+
+  var version = result.bitData[0]
+  if (version > 16) {
+    throw new Error('Invalid witness version')
+  }
+
+  var program = bech32.convertBits(result.bitData.slice(1), 5, 8, false)
+  if (program.length < 2 || program.length > 40) {
+    throw new Error('Invalid length of witness program')
+  }
+
+  // witness version 0 length checks
+  if (version === 0) {
+    if (!((program.length === 20) || (program.length === 32))) {
+      throw new Error('Invalid length of V0 witness program')
+    }
+  }
+
+  return { version: version, program: Buffer.from(program) }
+}
+
+function encode (prefix, version, program) {
+  // witness version 0 length checks
+  if (version === 0) {
+    if (!((program.length === 20) || (program.length === 32))) {
+      throw new Error('Invalid length of V0 witness program')
+    }
+  }
+
+  var bitData = bech32.convertBits(program, 8, 5, true)
+  bitData.unshift(version)
+
+  return bech32.encode(prefix, bitData)
+}
+
+module.exports = {
+  encode: encode,
+  decode: decode
+}

--- a/test/fixtures/segwit_address.json
+++ b/test/fixtures/segwit_address.json
@@ -1,0 +1,65 @@
+{
+  "addresses": {
+    "valid": [
+      {
+        "string": "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
+        "prefix": "bc",
+        "hex": "751e76e8199196d454941c45d1b3a323f1433bd6",
+        "version": 0
+      },
+      {
+        "string": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+        "prefix": "tb",
+        "hex": "1863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+        "version": 0
+      },
+      {
+        "string": "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+        "prefix": "bc",
+        "hex": "751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
+        "version": 1
+      },
+      {
+        "string": "BC1SW50QA3JX3S",
+        "prefix": "bc",
+        "hex": "751e",
+        "version": 16
+      },
+      {
+        "string": "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
+        "prefix": "bc",
+        "hex": "751e76e8199196d454941c45d1b3a323",
+        "version": 2
+      },
+      {
+        "string": "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
+        "prefix": "tb",
+        "hex": "000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+        "version": 0
+      }
+    ],
+    "invalid": [
+      "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+      "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+      "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+      "bc1rw5uspcuh",
+      "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+      "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+      "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+      "tb1pw508d6qejxtdg4y5r3zarqfsj6c3",
+      "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv"
+    ]
+  },
+  "program": {
+    "invalid": [
+      {
+        "version": 0,
+        "program": "000102030405060708090001020304050607080900"
+      },
+      {
+        "version": 1,
+        "program": "0001020304050607080900010203040506070809000102030405060708090001020304050607080900010203040506070809000102030405060708090001020304050607080900010203040506070809"
+      }
+    ]
+  }
+}

--- a/test/segwit_address.js
+++ b/test/segwit_address.js
@@ -1,0 +1,45 @@
+/* global describe, it */
+
+var assert = require('assert')
+var segaddr = require('../src/segwit_address')
+
+var fixtures = require('./fixtures/segwit_address.json')
+
+describe('bech32 segwit address', function () {
+  fixtures.addresses.valid.forEach(function (fixture) {
+    var program = Buffer.from(fixture.hex, 'hex')
+    it('can be encoded: ' + fixture.string, function () {
+      var encoded = segaddr.encode(fixture.prefix,
+        fixture.version,
+        program
+      )
+      assert.equal(encoded, fixture.string.toLowerCase())
+    })
+
+    it('can be decoded: ' + fixture.string, function () {
+      var decoded = segaddr.decode(fixture.prefix,
+        fixture.string
+      )
+      assert.equal(fixture.version, decoded.version)
+      assert(program.equals(decoded.program))
+    })
+  })
+  fixtures.addresses.invalid.forEach(function (fixture) {
+    it('cant be decoded: ' + fixture, function () {
+      assert.throws(function () {
+        segaddr.decode('bc', fixture)
+      })
+      assert.throws(function () {
+        segaddr.decode('tb', fixture)
+      })
+    })
+  })
+  fixtures.program.invalid.forEach(function (fixture) {
+    var program = Buffer.from(fixture.program, 'hex')
+    it('cant be encoded: ' + fixture.version + '-' + fixture.program, function () {
+      assert.throws(function () {
+        segaddr.encode('bc', fixture.version, program)
+      })
+    })
+  })
+})


### PR DESCRIPTION
WIP, but about time for feedback - this moves the segwit address logic from bech32 to this library, and implements the encode/decode functions with some tests.

Related: https://github.com/bitcoinjs/bech32/pull/8 (the PR uses this branch)