### PR TITLE
Add witness is true to signing

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -87,6 +87,7 @@ function expandInput (scriptSig, witnessStack) {
     witnessScript = witnessStack[witnessStack.length - 1]
     witnessScriptType = bscript.classifyOutput(witnessScript)
     p2wsh = true
+    witness = true
     if (scriptSig.length === 0) {
       prevOutScript = bscript.witnessScriptHash.output.encode(bcrypto.sha256(witnessScript))
       prevOutType = scriptTypes.P2WSH
@@ -112,6 +113,7 @@ function expandInput (scriptSig, witnessStack) {
     scriptType = witnessScriptType
     chunks = witnessStack.slice(0, -1)
   } else if (classifyWitness === scriptTypes.P2WPKH) {
+    witness = true
     var key = witnessStack[witnessStack.length - 1]
     var keyHash = bcrypto.hash160(key)
     if (scriptSig.length === 0) {


### PR DESCRIPTION
This was causing problems with multisig signing in rare cases... (why not all cases... not sure)

`var witness = false` is declared near the top but it is never used... so I figured it should be in master.