### PR TITLE
Fix buildstack

### DIFF
--- a/src/templates/multisig/input.js
+++ b/src/templates/multisig/input.js
@@ -39,7 +39,12 @@ function encodeStack (signatures, scriptPubKey) {
     }
   }
 
-  return [].concat(EMPTY_BUFFER, signatures)
+  return [].concat(EMPTY_BUFFER, signatures.map(function (sig) {
+    if (sig === OPS.OP_0) {
+      return EMPTY_BUFFER
+    }
+    return sig
+  }))
 }
 
 function encode (signatures, scriptPubKey) {

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -389,14 +389,14 @@ function buildStack (type, signatures, pubKeys, allowIncomplete) {
   } else if (type === scriptTypes.MULTISIG) {
     if (signatures.length > 0) {
       signatures = signatures.map(function (signature) {
-        return signature || ops.OP_0
+        return signature || Buffer.from('', 'hex')
       })
       if (!allowIncomplete) {
         // remove blank signatures
-        signatures = signatures.filter(function (x) { return x !== ops.OP_0 })
+        signatures = signatures.filter(function (x) { return x.length !== 0 })
       }
 
-      return bscript.multisig.input.encodeStack(signatures /* see if it's necessary first */)
+      return [].concat(Buffer.from('', 'hex'), signatures)
     }
   } else {
     throw new Error('Not yet supported')
@@ -463,7 +463,7 @@ function buildInput (input, allowIncomplete) {
   return {
     type: scriptType,
     script: bscript.compile(sig),
-    witness: bscript.toStack(witness)
+    witness: witness
   }
 }
 

--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -389,14 +389,14 @@ function buildStack (type, signatures, pubKeys, allowIncomplete) {
   } else if (type === scriptTypes.MULTISIG) {
     if (signatures.length > 0) {
       signatures = signatures.map(function (signature) {
-        return signature || Buffer.from('', 'hex')
+        return signature || ops.OP_0
       })
       if (!allowIncomplete) {
         // remove blank signatures
-        signatures = signatures.filter(function (x) { return x.length !== 0 })
+        signatures = signatures.filter(function (x) { return x !== ops.OP_0 })
       }
 
-      return [].concat(Buffer.from('', 'hex'), signatures)
+      return bscript.multisig.input.encodeStack(signatures)
     }
   } else {
     throw new Error('Not yet supported')


### PR DESCRIPTION
Avoids weird edge case with buildStack, should only return Buffers. multisig.input.encodeStack is now in charge of converting OP_0's to a buffer, which when compiled produces the desired scriptSig. 

This works because TransactionBuilder controls the input to encodeStack, and has added/removed OP_0's depending on buildIncomplete