### PR TITLE
TxBuilder: fix canSign returning true for missing witness value

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -663,7 +663,10 @@ function canSign (input) {
     input.signatures !== undefined &&
     input.signatures.length === input.pubKeys.length &&
     input.pubKeys.length > 0 &&
-    input.witness !== undefined
+    (
+      input.witness === false ||
+      (input.witness === true && input.value !== undefined)
+    )
 }
 
 TransactionBuilder.prototype.sign = function (vin, keyPair, redeemScript, hashType, witnessValue, witnessScript) {


### PR DESCRIPTION
`canSign` didn't care if `input.value` was undefined,  even if `input.witness === true`.
This fixes that, forcing `prepareInput` to be called and `input.value` assigned.

Thanks to @dakk for reporting the issue in #901.