### PR TITLE
Correctly decoding op_return data

### DIFF
--- a/src/templates/nulldata.js
+++ b/src/templates/nulldata.js
@@ -6,10 +6,8 @@ var typeforce = require('typeforce')
 var OPS = require('bitcoin-ops')
 
 function check (script) {
-  var buffer = bscript.compile(script)
-
-  return buffer.length > 1 &&
-    buffer[0] === OPS.OP_RETURN
+  return script.length === 2 &&
+    script[0] === OPS.OP_RETURN
 }
 check.toJSON = function () { return 'null data output' }
 
@@ -20,9 +18,11 @@ function encode (data) {
 }
 
 function decode (buffer) {
-  typeforce(check, buffer)
+  var script = bscript.decompile(buffer)
 
-  return buffer.slice(2)
+  typeforce(check, script)
+
+  return script[1]
 }
 
 module.exports = {


### PR DESCRIPTION
As currently written, nulldata.decode doesn't return correct results with longer data.

An example:

[This transaction]( https://blockchain.info/tx/8e533c09bae92c9b47ef9bc26b58707550f2a54a3b9238dc1a7545273523b84f?format=hex) when decoded starts data with 0x50, but that is the amount of data after OP_PUSHDATA1

It was working on smaller nulldata, because it stripped the one OP_PUSHDATA correctly

I will write tests that trigger this issue in old code, but don't in this fix, later