### PR TITLE
Support for BIP49 YPUB/UPUB

### DIFF
--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -64,7 +64,9 @@ HDNode.fromBase58 = function (string, networks) {
   if (Array.isArray(networks)) {
     network = networks.filter(function (x) {
       return version === x.bip32.private ||
-             version === x.bip32.public
+             version === x.bip32.public ||
+             version === x.bip49.private ||
+             version === x.bip49.public
     }).pop()
 
     if (!network) throw new Error('Unknown network version')
@@ -75,7 +77,9 @@ HDNode.fromBase58 = function (string, networks) {
   }
 
   if (version !== network.bip32.private &&
-    version !== network.bip32.public) throw new Error('Invalid network version')
+    version !== network.bip32.public &&
+    version !== network.bip49.private &&
+    version !== network.bip49.public) throw new Error('Invalid network version')
 
   // 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 descendants, ...
   var depth = buffer[4]

--- a/src/networks.js
+++ b/src/networks.js
@@ -9,6 +9,10 @@ module.exports = {
       public: 0x0488b21e,
       private: 0x0488ade4
     },
+    bip49: {
+      public: 0x049D7CB2,
+      private: 0x049D7878
+    },
     pubKeyHash: 0x00,
     scriptHash: 0x05,
     wif: 0x80
@@ -19,6 +23,10 @@ module.exports = {
     bip32: {
       public: 0x043587cf,
       private: 0x04358394
+    },
+    bip49: {
+      public: 0x044A5262,
+      private: 0x044A4E28
     },
     pubKeyHash: 0x6f,
     scriptHash: 0xc4,


### PR DESCRIPTION
The only thing missing from bitcoinjs-lib to support BIP49 is the network type designator. This simple change allows the HD wallet to support BIP49 YPUB's (or testnet UPUB's). This allows for the import of pure segwit HD wallets.

See also: https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki

Understanding that BIP49 is draft, you may reject this change, but I've made this change for a project and figured submitting a PR would be an appropriate offer to allow you to implement this simple functionality.