### PR TITLE
increase max feerate sanity check from 1000 to 2500

### DIFF
--- a/src/transaction_builder.js
+++ b/src/transaction_builder.js
@@ -469,7 +469,7 @@ function TransactionBuilder (network, maximumFeeRate) {
   this.network = network || networks.bitcoin
 
   // WARNING: This is __NOT__ to be relied on, its just another potential safety mechanism (safety in-depth)
-  this.maximumFeeRate = maximumFeeRate || 1000
+  this.maximumFeeRate = maximumFeeRate || 2500
 
   this.inputs = []
   this.tx = new Transaction()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1884338/33144691-c8765540-cf72-11e7-91c6-27645a7a7a66.png)

Back in Nov 2016 when we first set the maximum fee rate sanity check the average feerate for inclusion in 1-2 blocks was ~70 sat/byte and there was relatively low variability. Nowadays we're seeing an increase in variability, with the fee rates spiking to over ~1000 sat/byte.

We've had multiple customers trigger this "absurd fees" error when trying to build their transactions. 

I think the current fee market warrants increasing this to a higher value. I think 2500 sat/byte is appropriate because it will be handle more than double the current largest spike we've seen, and it's roughly 10x what the average feerate has been for the past 10 months.