### PR TITLE
enforce decodeStack receives a stack array

### DIFF
--- a/src/templates/multisig/input.js
+++ b/src/templates/multisig/input.js
@@ -53,6 +53,7 @@ function encode (signatures, scriptPubKey) {
 }
 
 function decodeStack (stack, allowIncomplete) {
+  typeforce(typeforce.Array, stack)
   typeforce(check, stack, allowIncomplete)
   return stack.slice(1)
 }

--- a/src/templates/pubkey/input.js
+++ b/src/templates/pubkey/input.js
@@ -21,6 +21,7 @@ function encode (signature) {
 }
 
 function decodeStack (stack) {
+  typeforce(typeforce.Array, stack)
   typeforce(check, stack)
   return stack[0]
 }

--- a/src/templates/pubkeyhash/input.js
+++ b/src/templates/pubkeyhash/input.js
@@ -29,6 +29,7 @@ function encode (signature, pubKey) {
 }
 
 function decodeStack (stack) {
+  typeforce(typeforce.Array, stack)
   typeforce(check, stack)
 
   return {

--- a/src/templates/scripthash/input.js
+++ b/src/templates/scripthash/input.js
@@ -59,6 +59,7 @@ function encode (redeemScriptSig, redeemScript) {
 }
 
 function decodeStack (stack) {
+  typeforce(typeforce.Array, stack)
   typeforce(check, stack)
 
   return {

--- a/src/templates/witnesspubkeyhash/input.js
+++ b/src/templates/witnesspubkeyhash/input.js
@@ -29,6 +29,7 @@ function encodeStack (signature, pubKey) {
 }
 
 function decodeStack (stack) {
+  typeforce(typeforce.Array, stack)
   typeforce(check, stack)
 
   return {

--- a/src/templates/witnessscripthash/input.js
+++ b/src/templates/witnessscripthash/input.js
@@ -48,11 +48,12 @@ function encodeStack (witnessData, witnessScript) {
   return [].concat(witnessData, witnessScript)
 }
 
-function decodeStack (chunks) {
-  typeforce(check, chunks)
+function decodeStack (stack) {
+  typeforce(typeforce.Array, stack)
+  typeforce(check, stack)
   return {
-    witnessData: chunks.slice(0, -1),
-    witnessScript: chunks[chunks.length - 1]
+    witnessData: stack.slice(0, -1),
+    witnessScript: stack[stack.length - 1]
   }
 }
 

--- a/test/transaction_builder.js
+++ b/test/transaction_builder.js
@@ -500,10 +500,10 @@ describe('TransactionBuilder', function () {
       '194a565cd6aa4cc38b8eaffa343402201c5b4b61d73fa38e49c1ee68cc0e6dfd2f5dae453dd86eb142e87a' +
       '0bafb1bc8401210283409659355b6d1cc3c32decd5d561abaac86c37a353b52895a5e6c196d6f44800000000'
       var txb = TransactionBuilder.fromTransaction(Transaction.fromHex(rawtx))
-      txb.inputs[0].value = 81530
-      txb.inputs[1].value = 81530
-      txb.inputs[2].value = 88920
-      txb.inputs[3].value = 88920
+      txb.inputs[0].value = 241530
+      txb.inputs[1].value = 241530
+      txb.inputs[2].value = 248920
+      txb.inputs[3].value = 248920
 
       assert.throws(function () {
         txb.build()


### PR DESCRIPTION
Burned by this twice, a `Buffer` can pass `check` because of ambiguity in `decompile`,  returning a `.slice` of bytes, not chunks, which makes zero sense.