### PR TITLE
Update bech32 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This is because of the function-name-duck-typing used in [typeforce](https://git
 
 Example:
 ``` bash
-uglifyjs ... --mangle --reserved 'BigInteger,ECPair,Point'
+uglifyjs ... --mangle reserved=['BigInteger','ECPair','Point']
 ```
 
 **NOTE**: This library tracks Node LTS features,  if you need strict ES5,  use [`--transform babelify`](https://github.com/babel/babelify) in conjunction with your `browserify` step (using an [`es2015`](http://babeljs.io/docs/plugins/preset-es2015/) preset).

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "src"
   ],
   "dependencies": {
-    "bech32": "0.0.3",
+    "bech32": "^1.1.2",
     "bigi": "^1.4.0",
     "bip66": "^1.1.0",
     "bitcoin-ops": "^1.3.0",


### PR DESCRIPTION
I tried to browserify -> uglify using the normal ES5 `uglify-js` command while on v4, and it worked fine.

However, the README explanation was old syntax, I checked the help docs and found the correct syntax.