### PR TITLE
crypto.sha256 should receive a Buffer as an input rather than a string

### DIFF
--- a/test/integration/addresses.js
+++ b/test/integration/addresses.js
@@ -17,7 +17,7 @@ describe('bitcoinjs-lib (addresses)', function () {
   })
 
   it('can generate an address from a SHA256 hash', function () {
-    var hash = bitcoin.crypto.sha256('correct horse battery staple')
+    var hash = bitcoin.crypto.sha256(Buffer.from('correct horse battery staple'))
     var d = bigi.fromBuffer(hash)
 
     var keyPair = new bitcoin.ECPair(d)


### PR DESCRIPTION
checked and it works with buffers.

if you wanted to use string implicitly, the function parameter should be renamed  from buffer to string.
https://github.com/bitcoinjs/bitcoinjs-lib/blob/f4caaf42e7b58332d74c1540f88bcda7e55b82e6/src/crypto.js#L11