### PR TITLE
Support for extended LTC-keys in xprv/xpub format

### DIFF
--- a/src/networks.js
+++ b/src/networks.js
@@ -33,5 +33,15 @@ module.exports = {
     pubKeyHash: 0x30,
     scriptHash: 0x32,
     wif: 0xb0
+  },
+  litecoinXprv: {
+    messagePrefix: '\x19Litecoin Signed Message:\n',
+    bip32: {
+      public: 0x0488b21e,
+      private: 0x0488ade4,
+    },
+    pubKeyHash: 0x30,
+    scriptHash: 0x32,
+    wif: 0xb0
   }
 }


### PR DESCRIPTION
Because LTC is natively supported by bitcoinjs-lib I think it is justifiedd to support extended LTC-keys in xprv/xpub format, especially because this format is used by some common wallets (e.g. Jaxx and I believe Exodus). The network definition was taken from @iancolemn (see [https://github.com/iancoleman/bip39/blob/master/src/js/bitcoinjs-extensions.js](url)).
