### PR TITLE
Support ypub/zprv, plus custom addresses

### DIFF
--- a/src/hdnode.js
+++ b/src/hdnode.js
@@ -148,9 +148,13 @@ HDNode.fromBase58 = function (string, networks, prefixes) {
   return hd
 }
 
+HDNode.prototype.getScriptData = function () {
+  return this.prefix.scriptFactory.convert(this.keyPair)
+}
+
 HDNode.prototype.getAddress = function () {
-  var data = this.prefix.scriptFactory.convert(this.keyPair)
-  return baddress.fromOutputScript(data.scriptPubKey, this.keyPair.network)
+  var scriptData = this.getScriptData()
+  return baddress.fromOutputScript(scriptData.scriptPubKey, this.keyPair.network)
 }
 
 HDNode.prototype.getIdentifier = function () {

--- a/src/keytoscript.js
+++ b/src/keytoscript.js
@@ -1,0 +1,124 @@
+var bcrypto = require('./crypto')
+var btemplates = require('./templates')
+
+function checkAllowedP2sh (keyFactory) {
+  if (!(keyFactory instanceof P2pkhFactory ||
+      keyFactory instanceof P2wpkhFactory ||
+      keyFactory instanceof P2pkFactory
+    )) {
+    throw new Error('Unsupported script factory for P2SH')
+  }
+}
+
+function checkAllowedP2wsh (keyFactory) {
+  if (!(keyFactory instanceof P2pkhFactory ||
+      keyFactory instanceof P2pkFactory
+    )) {
+    throw new Error('Unsupported script factory for P2SH')
+  }
+}
+
+var P2pkFactory = function () {
+
+}
+
+/**
+ * @param {bitcoin.ECPair} key
+ */
+P2pkFactory.prototype.convert = function (key) {
+  return {
+    scriptPubKey: btemplates.pubKey.output.encode(key.getPublicKeyBuffer()),
+    signData: {}
+  }
+}
+
+var P2pkhFactory = function () {
+
+}
+
+/**
+ * @param {bitcoin.ECPair} key
+ */
+P2pkhFactory.prototype.convert = function (key) {
+  var hash160 = bcrypto.hash160(key.getPublicKeyBuffer())
+  return {
+    scriptPubKey: btemplates.pubKeyHash.output.encode(hash160),
+    signData: {}
+  }
+}
+
+var P2wpkhFactory = function () {
+
+}
+
+/**
+ * @param {bitcoin.ECPair} key
+ */
+P2wpkhFactory.prototype.convert = function (key) {
+  var hash160 = bcrypto.hash160(key.getPublicKeyBuffer())
+  return {
+    scriptPubKey: btemplates.witnessPubKeyHash.output.encode(hash160),
+    signData: {}
+  }
+}
+
+var P2shFactory = function (keyFactory) {
+  checkAllowedP2sh(keyFactory)
+  this.factory = keyFactory
+}
+
+P2shFactory.prototype.convert = function (key) {
+  var detail = this.factory.convert(key)
+  var hash160 = bcrypto.hash160(detail.scriptPubKey)
+  return {
+    scriptPubKey: btemplates.scriptHash.output.encode(hash160),
+    signData: {
+      redeemScript: detail.scriptPubKey
+    }
+  }
+}
+
+var P2wshFactory = function (keyFactory) {
+  checkAllowedP2wsh(keyFactory)
+  this.factory = keyFactory
+}
+
+P2wshFactory.prototype.convert = function (key) {
+  var detail = this.factory.convert(key)
+  var hash160 = bcrypto.hash160(detail.scriptPubKey)
+  return {
+    scriptPubKey: btemplates.scriptHash.output.encode(hash160),
+    signData: {
+      redeemScript: detail.scriptPubKey
+    }
+  }
+}
+
+var P2shP2wshFactory = function (keyFactory) {
+  checkAllowedP2wsh(keyFactory)
+  this.factory = keyFactory
+}
+
+P2shP2wshFactory.prototype.convert = function (key) {
+  var detail = this.factory.convert(key)
+  var sha256 = bcrypto.sha256(detail.scriptPubKey)
+  var wp = btemplates.witnessScriptHash.output.encode(sha256)
+  var hash160 = bcrypto.hash160(wp)
+  var spk = btemplates.scriptHash.output.encode(hash160)
+  return {
+    scriptPubKey: spk,
+    signData: {
+      redeemScript: wp,
+      witnessScript: detail.scriptPubKey
+    }
+  }
+}
+
+module.exports = {
+  P2pkhFactory: P2pkhFactory,
+  P2wpkhFactory: P2wpkhFactory,
+  P2pkFactory: P2pkFactory,
+  P2shFactory: P2shFactory,
+  P2wshFactory: P2wshFactory,
+  P2shP2wshFactory: P2shP2wshFactory
+}

--- a/src/networks.js
+++ b/src/networks.js
@@ -1,5 +1,9 @@
+var KeyToScript = require('./keytoscript')
 // https://en.bitcoin.it/wiki/List_of_address_prefixes
 // Dogecoin BIP32 is a proposed standard: https://bitcointalk.org/index.php?topic=409731
+
+var p2pkh = new KeyToScript.P2pkhFactory()
+var p2wpkh = new KeyToScript.P2wpkhFactory()
 
 module.exports = {
   bitcoin: {
@@ -7,7 +11,18 @@ module.exports = {
     bech32: 'bc',
     bip32: {
       public: 0x0488b21e,
-      private: 0x0488ade4
+      private: 0x0488ade4,
+      scriptFactory: p2pkh
+    },
+    bip49: {
+      private: 0x049d7878,
+      public: 0x049d7cb2,
+      scriptFactory: new KeyToScript.P2shFactory(p2wpkh)
+    },
+    bip84: {
+      private: 0x04b2430c,
+      public: 0x04b24746,
+      scriptFactory: p2wpkh
     },
     pubKeyHash: 0x00,
     scriptHash: 0x05,
@@ -18,7 +33,8 @@ module.exports = {
     bech32: 'tb',
     bip32: {
       public: 0x043587cf,
-      private: 0x04358394
+      private: 0x04358394,
+      scriptFactory: p2pkh
     },
     pubKeyHash: 0x6f,
     scriptHash: 0xc4,
@@ -28,7 +44,8 @@ module.exports = {
     messagePrefix: '\x19Litecoin Signed Message:\n',
     bip32: {
       public: 0x019da462,
-      private: 0x019d9cfe
+      private: 0x019d9cfe,
+      scriptFactory: p2pkh
     },
     pubKeyHash: 0x30,
     scriptHash: 0x32,

--- a/test/hdaddress.js
+++ b/test/hdaddress.js
@@ -1,0 +1,95 @@
+/* global describe, it */
+/* eslint-disable no-new */
+
+var assert = require('assert')
+var HDNode = require('../src/hdnode')
+var bnetwork = require('../src/networks')
+
+describe('bip44', function () {
+  it('works without a ScriptFactory', function () {
+    // mnemonic: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+    var seed = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4'
+    var network = bnetwork.bitcoin
+
+    var root = HDNode.fromSeedHex(seed, network)
+    assert.equal(
+      root.toBase58(),
+      'xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu'
+    )
+
+    var account = root.derivePath('44\'/0\'/0\'')
+    assert.equal(
+      account.toBase58(),
+      'xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb'
+    )
+    assert.equal(
+      'xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj',
+      account.neutered().toBase58()
+    )
+
+    var key = account.derivePath('0/0')
+    assert.equal('1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA', key.getAddress())
+  })
+
+  it('works with a prefix', function () {
+    // mnemonic: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+    var seed = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4'
+    var network = bnetwork.bitcoin
+
+    var root = HDNode.fromSeedHex(seed, network, network.bip32)
+    var account = root.derivePath('44\'/0\'/0\'')
+    assert.equal(
+      account.toBase58(),
+      'xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb'
+    )
+    assert.equal(
+      'xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj',
+      account.neutered().toBase58()
+    )
+
+    var key = account.derivePath('0/0')
+    assert.equal('1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA', key.getAddress())
+  })
+})
+
+describe('bip49', function () {
+  it('serialization and address', function () {
+    // mnemonic: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+    var seed = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4'
+    var network = bnetwork.bitcoin
+    var root = HDNode.fromSeedHex(seed, network, network.bip49)
+    var account = root.derivePath('49\'/0\'/0\'')
+    assert.equal(
+      account.toBase58(),
+      'yprvAHwhK6RbpuS3dgCYHM5jc2ZvEKd7Bi61u9FVhYMpgMSuZS613T1xxQeKTffhrHY79hZ5PsskBjcc6C2V7DrnsMsNaGDaWev3GLRQRgV7hxF'
+    )
+    assert.equal(
+      'ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP',
+      account.neutered().toBase58()
+    )
+
+    var key = account.derivePath('0/0')
+    assert.equal('37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf', key.getAddress())
+  })
+})
+
+describe('bip84', function () {
+  it('serialization and address', function () {
+    // mnemonic: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+    var seed = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4'
+    var network = bnetwork.bitcoin
+    var root = HDNode.fromSeedHex(seed, network, network.bip84)
+    var account = root.derivePath('84\'/0\'/0\'')
+    assert.equal(
+      account.toBase58(),
+      'zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE'
+    )
+    assert.equal(
+      'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs',
+      account.neutered().toBase58()
+    )
+
+    var key = account.derivePath('0/0')
+    assert.equal('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu', key.getAddress())
+  })
+})

--- a/test/hdnode.js
+++ b/test/hdnode.js
@@ -50,7 +50,6 @@ describe('HDNode', function () {
 
     it('has a default depth/index of 0', function () {
       var hd = new HDNode(keyPair, chainCode)
-
       assert.strictEqual(hd.depth, 0)
       assert.strictEqual(hd.index, 0)
     })
@@ -124,12 +123,12 @@ describe('HDNode', function () {
     })
 
     describe('getAddress', function () {
-      it('wraps keyPair.getAddress', setupTest(function () {
-        this.mock(keyPair).expects('getAddress')
-          .once().withArgs().returns('foobar')
-
-        assert.strictEqual(hd.getAddress(), 'foobar')
-      }))
+      // it('wraps keyPair.getAddress', setupTest(function () {
+      //   this.mock(keyPair).expects('getAddress')
+      //     .once().withArgs().returns('foobar')
+      //
+      //   assert.strictEqual(hd.getAddress(), 'foobar')
+      // }))
     })
 
     describe('getNetwork', function () {


### PR DESCRIPTION
This PR adds a new parameter to the hdnode constructor. The parameter describes a bip32 prefix, and has the public & private prefix values, plus a scriptFactory field. This exposes a function, `convert(ECPair key)` and produces:
```
{
  scriptPubKey: Buffer,
  signData: {
    redeemScript: x,
    witnessScript: y
  }
}
```
 - also updated fromSeedHex, so you can persistently mark a key and it's children with a prefix
 - updated fromBase58, if no list of networks is provided (in which case, we only compare against `.bip32`, we assume the network is an object (or take bitcoin as the default), and in this case will check the prefix from the key against the `.private` and `.public` members of the list of prefixes. 
 - if no prefix is set, we default to p2pkh.
- getAddress was modified to use the script factory, by doing address.fromOutputScript() on the resulting scriptPubKey - please see the test I commented out, and lets talk about that! https://github.com/bitcoinjs/bitcoinjs-lib/pull/1014/files#diff-4db2c2d53279dc2a5cf3fee520cbb23eR126
 - added the bip49 and bip84 prefixes to networks. 
 - added tests, basically just covering the expected behavior of a key with a prefix, using the fixtures from slip132

Not sure what direction this are going with the new templates/script stuff, so all ears for feedback on the stuff in keytoscript!