### PR TITLE
Add getter for attribute `compressed` of `ECPair`

### DIFF
--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -104,6 +104,10 @@ ECPair.prototype.getAddress = function () {
   return baddress.toBase58Check(bcrypto.hash160(this.getPublicKeyBuffer()), this.getNetwork().pubKeyHash)
 }
 
+ECPair.prototype.getCompressed = function () {
+  return this.compressed
+}
+
 ECPair.prototype.getNetwork = function () {
   return this.network
 }

--- a/test/ecpair.js
+++ b/test/ecpair.js
@@ -217,6 +217,17 @@ describe('ECPair', function () {
     })
   })
 
+  describe('getCompressed', function () {
+    fixtures.valid.forEach(function (f) {
+      it('returns ' + f.compressed + ' for ' + f.WIF, function () {
+        var compressed = f.compressed
+        var keyPair = ECPair.fromWIF(f.WIF, NETWORKS_LIST)
+
+        assert.strictEqual(keyPair.getCompressed(), compressed)
+      })
+    })
+  })
+
   describe('ecdsa wrappers', function () {
     var keyPair, hash
 


### PR DESCRIPTION
This PR adds a `getCompressed()` getter for the `compressed` attribute from `ECPair`.
I tried to stick to the `getNetwork()` getter / tests. Not sure if the test is supposed to work this way.

Please let me know if anything is wrong, happy to change things.

---
Related: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24453