### PR TITLE
Remove bufferutils

### DIFF
--- a/src/bufferutils.js
+++ b/src/bufferutils.js
@@ -1,6 +1,3 @@
-var pushdata = require('pushdata-bitcoin')
-var varuint = require('varuint-bitcoin')
-
 // https://github.com/feross/buffer/blob/master/index.js#L1127
 function verifuint (value, max) {
   if (typeof value !== 'number') throw new Error('cannot write a non-number as a number')
@@ -15,7 +12,6 @@ function readUInt64LE (buffer, offset) {
   b *= 0x100000000
 
   verifuint(b + a, 0x001fffffffffffff)
-
   return b + a
 }
 
@@ -27,30 +23,7 @@ function writeUInt64LE (buffer, value, offset) {
   return offset + 8
 }
 
-// TODO: remove in 4.0.0?
-function readVarInt (buffer, offset) {
-  var result = varuint.decode(buffer, offset)
-
-  return {
-    number: result,
-    size: varuint.decode.bytes
-  }
-}
-
-// TODO: remove in 4.0.0?
-function writeVarInt (buffer, number, offset) {
-  varuint.encode(number, buffer, offset)
-  return varuint.encode.bytes
-}
-
 module.exports = {
-  pushDataSize: pushdata.encodingLength,
-  readPushDataInt: pushdata.decode,
   readUInt64LE: readUInt64LE,
-  readVarInt: readVarInt,
-  varIntBuffer: varuint.encode,
-  varIntSize: varuint.encodingLength,
-  writePushDataInt: pushdata.encode,
-  writeUInt64LE: writeUInt64LE,
-  writeVarInt: writeVarInt
+  writeUInt64LE: writeUInt64LE
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,6 @@ for (var key in templates) {
 }
 
 module.exports = {
-  bufferutils: require('./bufferutils'), // TODO: remove in 4.0.0
-
   Block: require('./block'),
   ECPair: require('./ecpair'),
   ECSignature: require('./ecsignature'),

--- a/test/bufferutils.js
+++ b/test/bufferutils.js
@@ -6,49 +6,10 @@ var bufferutils = require('../src/bufferutils')
 var fixtures = require('./fixtures/bufferutils.json')
 
 describe('bufferutils', function () {
-  describe('pushDataSize', function () {
-    fixtures.valid.forEach(function (f) {
-      it('determines the pushDataSize of ' + f.dec + ' correctly', function () {
-        if (!f.hexPD) return
-
-        var size = bufferutils.pushDataSize(f.dec)
-
-        assert.strictEqual(size, f.hexPD.length / 2)
-      })
-    })
-  })
-
-  describe('readPushDataInt', function () {
-    fixtures.valid.forEach(function (f) {
-      if (!f.hexPD) return
-
-      it('decodes ' + f.hexPD + ' correctly', function () {
-        var buffer = Buffer.from(f.hexPD, 'hex')
-        var d = bufferutils.readPushDataInt(buffer, 0)
-        var fopcode = parseInt(f.hexPD.substr(0, 2), 16)
-
-        assert.strictEqual(d.opcode, fopcode)
-        assert.strictEqual(d.number, f.dec)
-        assert.strictEqual(d.size, buffer.length)
-      })
-    })
-
-    fixtures.invalid.readPushDataInt.forEach(function (f) {
-      if (!f.hexPD) return
-
-      it('decodes ' + f.hexPD + ' as null', function () {
-        var buffer = Buffer.from(f.hexPD, 'hex')
-
-        var n = bufferutils.readPushDataInt(buffer, 0)
-        assert.strictEqual(n, null)
-      })
-    })
-  })
-
   describe('readUInt64LE', function () {
     fixtures.valid.forEach(function (f) {
-      it('decodes ' + f.hex64 + ' correctly', function () {
-        var buffer = Buffer.from(f.hex64, 'hex')
+      it('decodes ' + f.hex, function () {
+        var buffer = Buffer.from(f.hex, 'hex')
         var number = bufferutils.readUInt64LE(buffer, 0)
 
         assert.strictEqual(number, f.dec)
@@ -57,7 +18,7 @@ describe('bufferutils', function () {
 
     fixtures.invalid.readUInt64LE.forEach(function (f) {
       it('throws on ' + f.description, function () {
-        var buffer = Buffer.from(f.hex64, 'hex')
+        var buffer = Buffer.from(f.hex, 'hex')
 
         assert.throws(function () {
           bufferutils.readUInt64LE(buffer, 0)
@@ -66,68 +27,13 @@ describe('bufferutils', function () {
     })
   })
 
-  describe('readVarInt', function () {
-    fixtures.valid.forEach(function (f) {
-      it('decodes ' + f.hexVI + ' correctly', function () {
-        var buffer = Buffer.from(f.hexVI, 'hex')
-        var d = bufferutils.readVarInt(buffer, 0)
-
-        assert.strictEqual(d.number, f.dec)
-        assert.strictEqual(d.size, buffer.length)
-      })
-    })
-
-    fixtures.invalid.readUInt64LE.forEach(function (f) {
-      it('throws on ' + f.description, function () {
-        var buffer = Buffer.from(f.hexVI, 'hex')
-
-        assert.throws(function () {
-          bufferutils.readVarInt(buffer, 0)
-        }, new RegExp(f.exception))
-      })
-    })
-  })
-
-  describe('varIntBuffer', function () {
-    fixtures.valid.forEach(function (f) {
-      it('encodes ' + f.dec + ' correctly', function () {
-        var buffer = bufferutils.varIntBuffer(f.dec)
-
-        assert.strictEqual(buffer.toString('hex'), f.hexVI)
-      })
-    })
-  })
-
-  describe('varIntSize', function () {
-    fixtures.valid.forEach(function (f) {
-      it('determines the varIntSize of ' + f.dec + ' correctly', function () {
-        var size = bufferutils.varIntSize(f.dec)
-
-        assert.strictEqual(size, f.hexVI.length / 2)
-      })
-    })
-  })
-
-  describe('writePushDataInt', function () {
-    fixtures.valid.forEach(function (f) {
-      if (!f.hexPD) return
-
-      it('encodes ' + f.dec + ' correctly', function () {
-        var buffer = Buffer.alloc(5, 0)
-
-        var n = bufferutils.writePushDataInt(buffer, f.dec, 0)
-        assert.strictEqual(buffer.slice(0, n).toString('hex'), f.hexPD)
-      })
-    })
-  })
-
   describe('writeUInt64LE', function () {
     fixtures.valid.forEach(function (f) {
-      it('encodes ' + f.dec + ' correctly', function () {
+      it('encodes ' + f.dec, function () {
         var buffer = Buffer.alloc(8, 0)
 
         bufferutils.writeUInt64LE(buffer, f.dec, 0)
-        assert.strictEqual(buffer.toString('hex'), f.hex64)
+        assert.strictEqual(buffer.toString('hex'), f.hex)
       })
     })
 
@@ -137,27 +43,6 @@ describe('bufferutils', function () {
 
         assert.throws(function () {
           bufferutils.writeUInt64LE(buffer, f.dec, 0)
-        }, new RegExp(f.exception))
-      })
-    })
-  })
-
-  describe('writeVarInt', function () {
-    fixtures.valid.forEach(function (f) {
-      it('encodes ' + f.dec + ' correctly', function () {
-        var buffer = Buffer.alloc(9, 0)
-
-        var n = bufferutils.writeVarInt(buffer, f.dec, 0)
-        assert.strictEqual(buffer.slice(0, n).toString('hex'), f.hexVI)
-      })
-    })
-
-    fixtures.invalid.readUInt64LE.forEach(function (f) {
-      it('throws on ' + f.description, function () {
-        var buffer = Buffer.alloc(9, 0)
-
-        assert.throws(function () {
-          bufferutils.writeVarInt(buffer, f.dec, 0)
         }, new RegExp(f.exception))
       })
     })

--- a/test/fixtures/bufferutils.json
+++ b/test/fixtures/bufferutils.json
@@ -2,84 +2,59 @@
   "valid": [
     {
       "dec": 0,
-      "hex64": "0000000000000000",
-      "hexVI": "00",
-      "hexPD": "00"
+      "hex": "0000000000000000"
     },
     {
       "dec": 1,
-      "hex64": "0100000000000000",
-      "hexVI": "01",
-      "hexPD": "01"
+      "hex": "0100000000000000"
     },
     {
       "dec": 252,
-      "hex64": "fc00000000000000",
-      "hexVI": "fc",
-      "hexPD": "4cfc"
+      "hex": "fc00000000000000"
     },
     {
       "dec": 253,
-      "hex64": "fd00000000000000",
-      "hexVI": "fdfd00",
-      "hexPD": "4cfd"
+      "hex": "fd00000000000000"
     },
     {
       "dec": 254,
-      "hex64": "fe00000000000000",
-      "hexVI": "fdfe00",
-      "hexPD": "4cfe"
+      "hex": "fe00000000000000"
     },
     {
       "dec": 255,
-      "hex64": "ff00000000000000",
-      "hexVI": "fdff00",
-      "hexPD": "4cff"
+      "hex": "ff00000000000000"
     },
     {
       "dec": 65534,
-      "hex64": "feff000000000000",
-      "hexVI": "fdfeff",
-      "hexPD": "4dfeff"
+      "hex": "feff000000000000"
     },
     {
       "dec": 65535,
-      "hex64": "ffff000000000000",
-      "hexVI": "fdffff",
-      "hexPD": "4dffff"
+      "hex": "ffff000000000000"
     },
     {
       "dec": 65536,
-      "hex64": "0000010000000000",
-      "hexVI": "fe00000100",
-      "hexPD": "4e00000100"
+      "hex": "0000010000000000"
     },
     {
       "dec": 65537,
-      "hex64": "0100010000000000",
-      "hexVI": "fe01000100",
-      "hexPD": "4e01000100"
+      "hex": "0100010000000000"
     },
     {
       "dec": 4294967295,
-      "hex64": "ffffffff00000000",
-      "hexVI": "feffffffff",
-      "hexPD": "4effffffff"
+      "hex": "ffffffff00000000"
     },
     {
       "dec": 4294967296,
-      "hex64": "0000000001000000",
-      "hexVI": "ff0000000001000000"
+      "hex": "0000000001000000"
     },
     {
       "dec": 4294967297,
-      "hex64": "0100000001000000",
-      "hexVI": "ff0100000001000000"
+      "hex": "0100000001000000"
     },
     {
       "dec": 9007199254740991,
-      "hex64": "ffffffffffff1f00",
-      "hexVI": "ffffffffffffff1f00"
+      "hex": "ffffffffffff1f00"
     }
   ],
   "invalid": {
@@ -87,30 +62,14 @@
       {
         "description": "n === 2^53",
         "exception": "RangeError: value out of range",
-        "hex64": "0000000000002000",
-        "hexVI": "ff0000000000000020",
+        "hex": "0000000000002000",
         "dec": 9007199254740992
       },
       {
         "description": "n > 2^53",
         "exception": "RangeError: value out of range",
-        "hex64": "0100000000002000",
-        "hexVI": "ff0100000000000020",
+        "hex": "0100000000002000",
         "dec": 9007199254740993
-      }
-    ],
-    "readPushDataInt": [
-      {
-        "description": "OP_PUSHDATA1, no size",
-        "hexPD": "4c"
-      },
-      {
-        "description": "OP_PUSHDATA2, no size",
-        "hexPD": "4d"
-      },
-      {
-        "description": "OP_PUSHDATA4, no size",
-        "hexPD": "4e"
       }
     ]
   }


### PR DESCRIPTION
Internal for now.
I don't know if the code removal of the `*UInt64LE` functions would justify the `int53` dependency.  