### PR TITLE
Change nulldata to return Array

### DIFF
--- a/src/templates/nulldata.js
+++ b/src/templates/nulldata.js
@@ -14,15 +14,15 @@ function check (script) {
 check.toJSON = function () { return 'null data output' }
 
 function encode (data) {
-  typeforce(types.Buffer, data)
+  typeforce([types.Buffer], data)
 
-  return bscript.compile([OPS.OP_RETURN, data])
+  return bscript.compile([OPS.OP_RETURN].concat(data))
 }
 
 function decode (buffer) {
   typeforce(check, buffer)
 
-  return buffer.slice(2)
+  return bscript.decompile(buffer).slice(1)
 }
 
 module.exports = {

--- a/test/fixtures/script.json
+++ b/test/fixtures/script.json
@@ -96,6 +96,10 @@
       "script": "6a14deadffffffffffffffffffffffffffffffffbeef"
     },
     {
+      "asm": "OP_RETURN deadffffffffffffffffffffffffffffffffbeef deadffffffffffffffffffffffffffffffffbeef",
+      "script": "6a14deadffffffffffffffffffffffffffffffffbeef14deadffffffffffffffffffffffffffffffffbeef"
+    },
+    {
       "asm": "OP_0 OP_0 3044022001ab168e80b863fdec694350b587339bb72a37108ac3c989849251444d13ebba02201811272023e3c1038478eb972a82d3ad431bfc2408e88e4da990f1a7ecbb263901 3045022100aaeb7204c17eee2f2c4ff1c9f8b39b79e75e7fbf33e92cc67ac51be8f15b75f90220659eee314a4943a6384d2b154fa5821ef7a084814d7ee2c6f9f7f0ffb53be34b01",
       "script": "0000473044022001ab168e80b863fdec694350b587339bb72a37108ac3c989849251444d13ebba02201811272023e3c1038478eb972a82d3ad431bfc2408e88e4da990f1a7ecbb263901483045022100aaeb7204c17eee2f2c4ff1c9f8b39b79e75e7fbf33e92cc67ac51be8f15b75f90220659eee314a4943a6384d2b154fa5821ef7a084814d7ee2c6f9f7f0ffb53be34b01",
       "stack": [

--- a/test/fixtures/templates.json
+++ b/test/fixtures/templates.json
@@ -113,13 +113,26 @@
     },
     {
       "type": "nulldata",
-      "data": "06deadbeef03f895a2ad89fb6d696497af486cb7c644a27aa568c7a18dd06113401115185474",
+      "data": [
+        "06deadbeef03f895a2ad89fb6d696497af486cb7c644a27aa568c7a18dd06113401115185474"
+      ],
       "output": "OP_RETURN 06deadbeef03f895a2ad89fb6d696497af486cb7c644a27aa568c7a18dd06113401115185474",
       "outputHex": "6a2606deadbeef03f895a2ad89fb6d696497af486cb7c644a27aa568c7a18dd06113401115185474"
     },
     {
       "type": "nulldata",
-      "data": "deadffffffffffffffffffffffffffffffffbeef",
+      "data": [
+        "deadffffffffffffffffffffffffffffffffbeef",
+        "deadffffffffffffffffffffffffffffffffbeef"
+      ],
+      "output": "OP_RETURN deadffffffffffffffffffffffffffffffffbeef deadffffffffffffffffffffffffffffffffbeef",
+      "outputHex": "6a14deadffffffffffffffffffffffffffffffffbeef14deadffffffffffffffffffffffffffffffffbeef"
+    },
+    {
+      "type": "nulldata",
+      "data": [
+        "deadffffffffffffffffffffffffffffffffbeef"
+      ],
       "output": "OP_RETURN deadffffffffffffffffffffffffffffffffbeef",
       "outputHex": "6a14deadffffffffffffffffffffffffffffffffbeef"
     },

--- a/test/templates.js
+++ b/test/templates.js
@@ -499,7 +499,7 @@ describe('script-templates', function () {
     fixtures.valid.forEach(function (f) {
       if (f.type !== 'nulldata') return
 
-      var data = Buffer.from(f.data, 'hex')
+      var data = f.data.map(function (x) { return Buffer.from(x, 'hex') })
       var output = btemplates.nullData.output.encode(data)
 
       it('encodes to ' + f.output, function () {


### PR DESCRIPTION
Original PR https://github.com/bitcoinjs/bitcoinjs-lib/pull/859/files

This changes

``` haskell
nulldata.output.encode :: Buffer -> Buffer
nulldata.output.decode :: Buffer -> Buffer
```

to

``` haskell
nulldata.output.decode :: Buffer -> Array
nulldata.output.encode :: Array -> Buffer
```

While necesssary,  this is dangerous and may burn users who aren't doing any type checking.
I suggest we opt- for a different template name other than `nulldata`,  perhaps this is added to the new payments API instead as `P2NULL`?

Either way,  this PR can hold that discussion. 