### PR TITLE
Add ECPair.toUncheckedHex() and ECPair.fromUncheckedHex(hex, network, compressed)

### DIFF
--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -90,9 +90,9 @@ ECPair.fromUncheckedHex = function (hex, network, compressed) {
 	network = network || NETWORKS.bitcoin
 	
 	return new ECPair(BigInteger.fromHex(hex), null, {
-		compressed: compressed,
-		network: network
-	})
+    compressed: compressed,
+    network: network
+  })
 }
 
 ECPair.makeRandom = function (options) {

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -84,17 +84,6 @@ ECPair.fromWIF = function (string, network) {
   })
 }
 
-ECPair.fromUncheckedHex = function (hex, network, compressed) {
-	
-	// assume a network object (or default to bitcoin)
-	network = network || NETWORKS.bitcoin
-	
-	return new ECPair(BigInteger.fromHex(hex), null, {
-		compressed: compressed,
-		network: network
-	})
-}
-
 ECPair.makeRandom = function (options) {
   options = options || {}
 
@@ -133,12 +122,6 @@ ECPair.prototype.toWIF = function () {
   if (!this.d) throw new Error('Missing private key')
 
   return wif.encode(this.network.wif, this.d.toBuffer(32), this.compressed)
-}
-
-ECPair.prototype.toUncheckedHex = function () {
-  if (!this.d) throw new Error('Missing private key')
-  
-  return this.d.toHex().toUpperCase();
 }
 
 ECPair.prototype.verify = function (hash, signature) {

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -84,6 +84,17 @@ ECPair.fromWIF = function (string, network) {
   })
 }
 
+ECPair.fromUncheckedHex = function (hex, network, compressed) {
+	
+	// assume a network object (or default to bitcoin)
+	network = network || NETWORKS.bitcoin
+	
+	return new ECPair(BigInteger.fromHex(hex), null, {
+		compressed: compressed,
+		network: network
+	})
+}
+
 ECPair.makeRandom = function (options) {
   options = options || {}
 
@@ -122,6 +133,12 @@ ECPair.prototype.toWIF = function () {
   if (!this.d) throw new Error('Missing private key')
 
   return wif.encode(this.network.wif, this.d.toBuffer(32), this.compressed)
+}
+
+ECPair.prototype.toUncheckedHex = function () {
+  if (!this.d) throw new Error('Missing private key')
+  
+  return this.d.toHex().toUpperCase();
 }
 
 ECPair.prototype.verify = function (hash, signature) {


### PR DESCRIPTION
This PR adds the ability to get the private key as unchecked hex (without network or compression information) and initialize a new ECPair from unchecked hex, network, and compression.

This is helpful to minimize the encoded data for encryption and splitting with Shamir's Secret Sharing which is why other libraries usually offer this in their API.

I'm using this API in the [CryptoStorage tool](https://cryptostorage.com/) [here](https://github.com/cryptostorage/cryptostorage.com/blob/aa9900a2361e9e8871a8b22cfccb6969fa011f66/js/CryptoPlugins.js#L585) and [here](https://github.com/cryptostorage/cryptostorage.com/blob/aa9900a2361e9e8871a8b22cfccb6969fa011f66/js/CryptoPlugins.js#L590).