### PR TITLE
add litecoin testnet support

### DIFF
--- a/src/networks.js
+++ b/src/networks.js
@@ -33,5 +33,16 @@ module.exports = {
     pubKeyHash: 0x30,
     scriptHash: 0x32,
     wif: 0xb0
-  }
+  },
+  litecointn: {
+     messagePrefix: '\x19Litecoin Signed Message:\n',
+     bech32: 'tltc',
+     bip32: {
+       public: 0x043587cf,
+       private: 0x04358394
+     },
+     pubKeyHash: 0x6f,
+     scriptHash: 0x3a,
+     wif: 0xef
+   }
 }


### PR DESCRIPTION
noted that litecoin uses SCRIPT_ADDRESS2 for scriptHash based on [params]
[params]: https://github.com/litecoin-project/litecoin/blob/master/src/base58.cpp#L290