### PR TITLE
force update MTP for when tests not recently run

### DIFF
--- a/test/integration/cltv.js
+++ b/test/integration/cltv.js
@@ -1,4 +1,4 @@
-/* global describe, it */
+/* global describe, it, before */
 
 var assert = require('assert')
 var bitcoin = require('../../')
@@ -10,7 +10,12 @@ var alice = bitcoin.ECPair.fromWIF('cScfkGjbzzoeewVWmU2hYPUHeVGJRDdFt7WhmrVVGkxp
 var bob = bitcoin.ECPair.fromWIF('cMkopUXKWsEzAjfa1zApksGRwjVpJRB3831qM9W4gKZsLwjHXA9x', regtest)
 
 describe('bitcoinjs-lib (transactions w/ CLTV)', function () {
-  var hashType = bitcoin.Transaction.SIGHASH_ALL
+  // force update MTP
+  before(function (done) {
+    regtestUtils.mine(11, done)
+  })
+
+  let hashType = bitcoin.Transaction.SIGHASH_ALL
 
   function cltvCheckSigOutput (aQ, bQ, lockTime) {
     return bitcoin.script.compile([

--- a/test/integration/csv.js
+++ b/test/integration/csv.js
@@ -1,4 +1,4 @@
-/* global describe, it */
+/* global describe, it, before */
 
 let assert = require('assert')
 let bitcoin = require('../../')
@@ -10,6 +10,11 @@ let alice = bitcoin.ECPair.fromWIF('cScfkGjbzzoeewVWmU2hYPUHeVGJRDdFt7WhmrVVGkxp
 let bob = bitcoin.ECPair.fromWIF('cMkopUXKWsEzAjfa1zApksGRwjVpJRB3831qM9W4gKZsLwjHXA9x', regtest)
 
 describe('bitcoinjs-lib (transactions w/ CSV)', function () {
+  // force update MTP
+  before(function (done) {
+    regtestUtils.mine(11, done)
+  })
+
   let hashType = bitcoin.Transaction.SIGHASH_ALL
 
   // IF MTP (from when confirmed) > seconds, aQ can redeem


### PR DESCRIPTION
Median time past was unchanging unless several blocks were found recently.

This was failing tests that rely on MTP (CLTV, CSV) as their expiries were in the past (-3 hours),  but not _actually in the past in terms of MTP_. 