### PR TITLE
payments: dont always require output data

### DIFF
--- a/src/payments/p2ms.js
+++ b/src/payments/p2ms.js
@@ -20,7 +20,8 @@ function stacksEqual (a, b) {
 function p2ms (a, opts) {
   if (
     !a.output &&
-    !(a.pubkeys && a.m !== undefined)
+    !(a.pubkeys && a.m !== undefined) &&
+    !a.signatures
   ) throw new TypeError('Not enough data')
   opts = opts || { validate: true }
 

--- a/src/payments/p2pk.js
+++ b/src/payments/p2pk.js
@@ -11,7 +11,9 @@ let BITCOIN_NETWORK = require('../networks').bitcoin
 function p2pk (a, opts) {
   if (
     !a.output &&
-    !a.pubkey
+    !a.pubkey &&
+    !a.input &&
+    !a.signature
   ) throw new TypeError('Not enough data')
   opts = opts || { validate: true }
 

--- a/src/payments/p2sh.js
+++ b/src/payments/p2sh.js
@@ -37,7 +37,7 @@ function p2sh (a, opts) {
 
     redeem: typef.maybe({
       network: typef.maybe(typef.Object),
-      output: typef.Buffer,
+      output: typef.maybe(typef.Buffer),
       input: typef.maybe(typef.Buffer),
       witness: typef.maybe(typef.arrayOf(typef.Buffer))
     }),
@@ -86,7 +86,7 @@ function p2sh (a, opts) {
     return _redeem()
   })
   lazy.prop(o, 'input', function () {
-    if (!a.redeem || !a.redeem.input) return
+    if (!a.redeem || !a.redeem.input || !a.redeem.output) return
     return bscript.compile([].concat(
       bscript.decompile(a.redeem.input),
       a.redeem.output
@@ -124,13 +124,15 @@ function p2sh (a, opts) {
     // inlined to prevent 'no-inner-declarations' failing
     const checkRedeem = function (redeem) {
       // is the redeem output empty/invalid?
-      const decompile = bscript.decompile(redeem.output)
-      if (!decompile || decompile.length < 1) throw new TypeError('Redeem.output too short')
+      if (redeem.output) {
+        const decompile = bscript.decompile(redeem.output)
+        if (!decompile || decompile.length < 1) throw new TypeError('Redeem.output too short')
 
-      // match hash against other sources
-      const hash2 = bcrypto.hash160(redeem.output)
-      if (hash && !hash.equals(hash2)) throw new TypeError('Hash mismatch')
-      else hash = hash2
+        // match hash against other sources
+        const hash2 = bcrypto.hash160(redeem.output)
+        if (hash && !hash.equals(hash2)) throw new TypeError('Hash mismatch')
+        else hash = hash2
+      }
 
       if (redeem.input) {
         const hasInput = redeem.input.length > 0

--- a/test/integration/_regtest.js
+++ b/test/integration/_regtest.js
@@ -67,12 +67,8 @@ function verify (txo, callback) {
   })
 }
 
-// TODO: remove
-const baddress = bitcoin.address
-const bcrypto = bitcoin.crypto
 function getAddress (node, network) {
-  network = network || bitcoin.networks.bitcoin
-  return baddress.toBase58Check(bcrypto.hash160(node.publicKey), network.pubKeyHash)
+  return bitcoin.payments.p2pkh({ pubkey: node.publicKey, network }).address
 }
 
 function randomAddress () {

--- a/test/integration/addresses.js
+++ b/test/integration/addresses.js
@@ -18,18 +18,10 @@ const LITECOIN = {
 // deterministic RNG for testing only
 function rng () { return Buffer.from('zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz') }
 
-// TODO: remove
-const baddress = bitcoin.address
-const bcrypto = bitcoin.crypto
-function getAddress (node, network) {
-  network = network || bitcoin.networks.bitcoin
-  return baddress.toBase58Check(bcrypto.hash160(node.publicKey), network.pubKeyHash)
-}
-
 describe('bitcoinjs-lib (addresses)', function () {
   it('can generate a random address', function () {
     const keyPair = bitcoin.ECPair.makeRandom({ rng: rng })
-    const address = getAddress(keyPair)
+    const { address } = bitcoin.payments.p2pkh({ pubkey: keyPair.publicKey })
 
     assert.strictEqual(address, '1F5VhMHukdnUES9kfXqzPzMeF1GPHKiF64')
   })
@@ -38,7 +30,7 @@ describe('bitcoinjs-lib (addresses)', function () {
     const hash = bitcoin.crypto.sha256(Buffer.from('correct horse battery staple'))
 
     const keyPair = bitcoin.ECPair.fromPrivateKey(hash)
-    const address = getAddress(keyPair)
+    const { address } = bitcoin.payments.p2pkh({ pubkey: keyPair.publicKey })
 
     // Generating addresses from SHA256 hashes is not secure if the input to the hash function is predictable
     // Do not use with predictable inputs
@@ -47,76 +39,71 @@ describe('bitcoinjs-lib (addresses)', function () {
 
   it('can import an address via WIF', function () {
     const keyPair = bitcoin.ECPair.fromWIF('Kxr9tQED9H44gCmp6HAdmemAzU3n84H3dGkuWTKvE23JgHMW8gct')
-    const address = getAddress(keyPair)
+    const { address } = bitcoin.payments.p2pkh({ pubkey: keyPair.publicKey })
 
     assert.strictEqual(address, '19AAjaTUbRjQCMuVczepkoPswiZRhjtg31')
   })
 
-  it('can generate a 2-of-3 multisig P2SH address', function () {
-    const pubKeys = [
+  it('can generate a P2SH, pay-to-multisig (2-of-3) address', function () {
+    const pubkeys = [
       '026477115981fe981a6918a6297d9803c4dc04f328f22041bedff886bbc2962e01',
       '02c96db2302d19b43d4c69368babace7854cc84eb9e061cde51cfa77ca4a22b8b9',
       '03c6103b3b83e4a24a0e33a4df246ef11772f9992663db0c35759a5e2ebf68d8e9'
-    ].map(function (hex) { return Buffer.from(hex, 'hex') })
-
-    const redeemScript = bitcoin.script.multisig.output.encode(2, pubKeys) // 2 of 3
-    const scriptPubKey = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(redeemScript))
-    const address = bitcoin.address.fromOutputScript(scriptPubKey)
+    ].map((hex) => Buffer.from(hex, 'hex'))
+    const { address } = bitcoin.payments.p2sh({
+      redeem: bitcoin.payments.p2ms({ m: 2, pubkeys })
+    })
 
     assert.strictEqual(address, '36NUkt6FWUi3LAWBqWRdDmdTWbt91Yvfu7')
   })
 
   it('can generate a SegWit address', function () {
     const keyPair = bitcoin.ECPair.fromWIF('Kxr9tQED9H44gCmp6HAdmemAzU3n84H3dGkuWTKvE23JgHMW8gct')
-
-    const scriptPubKey = bitcoin.script.witnessPubKeyHash.output.encode(bitcoin.crypto.hash160(keyPair.publicKey))
-    const address = bitcoin.address.fromOutputScript(scriptPubKey)
+    const { address } = bitcoin.payments.p2wpkh({ pubkey: keyPair.publicKey })
 
     assert.strictEqual(address, 'bc1qt97wqg464zrhnx23upykca5annqvwkwujjglky')
   })
 
   it('can generate a SegWit address (via P2SH)', function () {
     const keyPair = bitcoin.ECPair.fromWIF('Kxr9tQED9H44gCmp6HAdmemAzU3n84H3dGkuWTKvE23JgHMW8gct')
-
-    const redeemScript = bitcoin.script.witnessPubKeyHash.output.encode(bitcoin.crypto.hash160(keyPair.publicKey))
-    const scriptPubKey = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(redeemScript))
-    const address = bitcoin.address.fromOutputScript(scriptPubKey)
+    const { address } = bitcoin.payments.p2sh({
+      redeem: bitcoin.payments.p2wpkh({ pubkey: keyPair.publicKey })
+    })
 
     assert.strictEqual(address, '34AgLJhwXrvmkZS1o5TrcdeevMt22Nar53')
   })
 
-  it('can generate a SegWit 3-of-4 multisig address', function () {
-    const pubKeys = [
+  it('can generate a P2WSH (SegWit), pay-to-multisig (3-of-4) address', function () {
+    const pubkeys = [
       '026477115981fe981a6918a6297d9803c4dc04f328f22041bedff886bbc2962e01',
       '02c96db2302d19b43d4c69368babace7854cc84eb9e061cde51cfa77ca4a22b8b9',
       '023e4740d0ba639e28963f3476157b7cf2fb7c6fdf4254f97099cf8670b505ea59',
       '03c6103b3b83e4a24a0e33a4df246ef11772f9992663db0c35759a5e2ebf68d8e9'
-    ].map(function (hex) { return Buffer.from(hex, 'hex') })
-
-    const witnessScript = bitcoin.script.multisig.output.encode(3, pubKeys) // 3 of 4
-    const scriptPubKey = bitcoin.script.witnessScriptHash.output.encode(bitcoin.crypto.sha256(witnessScript))
-    const address = bitcoin.address.fromOutputScript(scriptPubKey)
+    ].map((hex) => Buffer.from(hex, 'hex'))
+    const { address } = bitcoin.payments.p2wsh({
+      redeem: bitcoin.payments.p2ms({ m: 3, pubkeys })
+    })
 
     assert.strictEqual(address, 'bc1q75f6dv4q8ug7zhujrsp5t0hzf33lllnr3fe7e2pra3v24mzl8rrqtp3qul')
   })
 
-  it('can generate a SegWit 2-of-2 multisig address (via P2SH)', function () {
-    const pubKeys = [
+  it('can generate a P2SH(P2WSH(...)), pay-to-multisig (2-of-2) address', function () {
+    const pubkeys = [
       '026477115981fe981a6918a6297d9803c4dc04f328f22041bedff886bbc2962e01',
       '02c96db2302d19b43d4c69368babace7854cc84eb9e061cde51cfa77ca4a22b8b9'
-    ].map(function (hex) { return Buffer.from(hex, 'hex') })
-
-    const witnessScript = bitcoin.script.multisig.output.encode(2, pubKeys) // 2 of 2
-    const redeemScript = bitcoin.script.witnessScriptHash.output.encode(bitcoin.crypto.sha256(witnessScript))
-    const scriptPubKey = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(redeemScript))
-    const address = bitcoin.address.fromOutputScript(scriptPubKey)
+    ].map((hex) => Buffer.from(hex, 'hex'))
+    const { address } = bitcoin.payments.p2sh({
+      redeem: bitcoin.payments.p2wsh({
+        redeem: bitcoin.payments.p2ms({ m: 2, pubkeys })
+      })
+    })
 
     assert.strictEqual(address, '3P4mrxQfmExfhxqjLnR2Ah4WES5EB1KBrN')
   })
 
   it('can support the retrieval of transactions for an address (via 3PBP)', function (done) {
     const keyPair = bitcoin.ECPair.makeRandom()
-    const address = getAddress(keyPair)
+    const { address } = bitcoin.payments.p2pkh({ pubkey: keyPair.publicKey })
 
     dhttp({
       method: 'GET',
@@ -137,7 +124,7 @@ describe('bitcoinjs-lib (addresses)', function () {
     const testnet = bitcoin.networks.testnet
     const keyPair = bitcoin.ECPair.makeRandom({ network: testnet, rng: rng })
     const wif = keyPair.toWIF()
-    const address = getAddress(keyPair, testnet)
+    const { address } = bitcoin.payments.p2pkh({ pubkey: keyPair.publicKey, network: testnet })
 
     assert.strictEqual(address, 'mubSzQNtZfDj1YdNP6pNDuZy6zs6GDn61L')
     assert.strictEqual(wif, 'cRgnQe9MUu1JznntrLaoQpB476M8PURvXVQB5R2eqms5tXnzNsrr')
@@ -146,7 +133,7 @@ describe('bitcoinjs-lib (addresses)', function () {
   it('can generate a Litecoin address', function () {
     const keyPair = bitcoin.ECPair.makeRandom({ network: LITECOIN, rng: rng })
     const wif = keyPair.toWIF()
-    const address = getAddress(keyPair, LITECOIN)
+    const { address } = bitcoin.payments.p2pkh({ pubkey: keyPair.publicKey, network: LITECOIN })
 
     assert.strictEqual(address, 'LZJSxZbjqJ2XVEquqfqHg1RQTDdfST5PTn')
     assert.strictEqual(wif, 'T7A4PUSgTDHecBxW1ZiYFrDNRih2o7M8Gf9xpoCgudPF9gDiNvuS')

--- a/test/integration/bip32.js
+++ b/test/integration/bip32.js
@@ -5,12 +5,8 @@ const bip32 = require('bip32')
 const bip39 = require('bip39')
 const bitcoin = require('../../')
 
-// TODO: remove
-const baddress = bitcoin.address
-const bcrypto = bitcoin.crypto
 function getAddress (node, network) {
-  network = network || bitcoin.networks.bitcoin
-  return baddress.toBase58Check(bcrypto.hash160(node.publicKey), network.pubKeyHash)
+  return bitcoin.payments.p2pkh({ pubkey: node.publicKey, network }).address
 }
 
 describe('bitcoinjs-lib (BIP32)', function () {

--- a/test/integration/cltv.js
+++ b/test/integration/cltv.js
@@ -12,6 +12,7 @@ const bob = bitcoin.ECPair.fromWIF('cMkopUXKWsEzAjfa1zApksGRwjVpJRB3831qM9W4gKZs
 describe('bitcoinjs-lib (transactions w/ CLTV)', function () {
   // force update MTP
   before(function (done) {
+    this.timeout(30000)
     regtestUtils.mine(11, done)
   })
 

--- a/test/integration/stealth.js
+++ b/test/integration/stealth.js
@@ -4,11 +4,8 @@ const assert = require('assert')
 const bitcoin = require('../../')
 const ecc = require('tiny-secp256k1')
 
-// TODO: remove
-const baddress = bitcoin.address
-const bcrypto = bitcoin.crypto
-function getAddress (node) {
-  return baddress.toBase58Check(bcrypto.hash160(node.publicKey), bitcoin.networks.bitcoin.pubKeyHash)
+function getAddress (node, network) {
+  return bitcoin.payments.p2pkh({ pubkey: node.publicKey, network }).address
 }
 
 // vG = (dG \+ sha256(e * dG)G)


### PR DESCRIPTION
Previously we upheld that there was `enough data` for atleast `.output`,  however,  in many use cases,  you might only have the data [and only want] for `.input`.

I started loosening this in https://github.com/bitcoinjs/bitcoinjs-lib/commit/8197f9d7040671375f250f7656974a1ee28709e7,  but this follows through a bit more for P2SH/P2WSH.