### PR TITLE
Remove Node 6, update to Node LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
-  - "7"
   - "8"
   - "9"
   - "10"
 matrix:
   include:
-    - node_js: "6"
+    - node_js: "8"
       env: TEST_SUITE=standard
-    - node_js: "6"
+    - node_js: "8"
       env: TEST_SUITE=coverage
 env:
   - TEST_SUITE=unit

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "keywords": [
     "bitcoinjs",


### PR DESCRIPTION
Restricts the library to Node 8 and above.

Thoughts? Queries? Qualms?

Does this go in `4.0.0`? (https://github.com/bitcoinjs/bitcoinjs-lib/pull/1131)