### PR TITLE
Add in missing Classify export (fixes #1148)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,5 +12,6 @@ module.exports = {
   networks: require('./networks'),
   opcodes: require('bitcoin-ops'),
   payments: require('./payments'),
+  classify: require('./classify'),
   script: script
 }


### PR DESCRIPTION
Hello!

In a recent commit, the `templates` class was refactored into the `classify` class, and in the process, the `templates` class was removed as being an export (previously attached under the `scripts` export). This issue is documented at #1148.

This pull request fixes the issue of the removed export by adding the `classify` class as an export, to allow (similar) access to the `templates` export that was removed.

Please let me know if any changes are required, I can happily make them.

Thanks!
Sky Young