### PR TITLE
P2SH/P2WSH payments .network should use .redeem.network if undefined

### DIFF
--- a/src/payments/p2sh.js
+++ b/src/payments/p2sh.js
@@ -45,7 +45,11 @@ function p2sh (a, opts) {
     witness: typef.maybe(typef.arrayOf(typef.Buffer))
   }, a)
 
-  const network = a.network || BITCOIN_NETWORK
+  let network = a.network
+  if (!network) {
+    network = (a.redeem && a.redeem.network) || BITCOIN_NETWORK
+  }
+
   const o = { network }
 
   const _address = lazy.value(function () {

--- a/src/payments/p2wsh.js
+++ b/src/payments/p2wsh.js
@@ -59,7 +59,11 @@ function p2wsh (a, opts) {
   })
   const _rchunks = lazy.value(function () { return bscript.decompile(a.redeem.input) })
 
-  const network = a.network || BITCOIN_NETWORK
+  let network = a.network
+  if (!network) {
+    network = (a.redeem && a.redeem.network) || BITCOIN_NETWORK
+  }
+
   const o = { network }
 
   lazy.prop(o, 'address', function () {

--- a/test/fixtures/p2sh.json
+++ b/test/fixtures/p2sh.json
@@ -326,6 +326,24 @@
       }
     },
     {
+      "exception": "Network mismatch",
+      "arguments": {
+        "network": "bitcoin",
+        "redeem": {
+          "network": "testnet"
+        }
+      }
+    },
+    {
+      "exception": "Network mismatch",
+      "arguments": {
+        "network": "testnet",
+        "redeem": {
+          "network": "bitcoin"
+        }
+      }
+    },
+    {
       "exception": "Empty input",
       "arguments": {
         "inputHex": "01ff"

--- a/test/fixtures/p2sh.json
+++ b/test/fixtures/p2sh.json
@@ -166,6 +166,24 @@
           ]
         }
       }
+    },
+    {
+      "description": "p2sh-p2pkh, out (network derived from redeem)",
+      "arguments": {
+        "redeem": {
+          "address": "this is P2PKH context, unknown and ignored by P2SH",
+          "output": "OP_DUP OP_HASH160 c30afa58ae0673b00a45b5c17dff4633780f1400 OP_EQUALVERIFY OP_CHECKSIG",
+          "network": "testnet"
+        }
+      },
+      "expected": {
+        "address": "2N7nfc7zeWuADtpdR4MrR7Wq3dzr7LxTCgS",
+        "hash": "9f840a5fc02407ef0ad499c2ec0eb0b942fb0086",
+        "output": "OP_HASH160 9f840a5fc02407ef0ad499c2ec0eb0b942fb0086 OP_EQUAL",
+        "input": null,
+        "witness": null,
+        "network": "testnet"
+      }
     }
   ],
   "invalid": [

--- a/test/fixtures/p2wsh.json
+++ b/test/fixtures/p2wsh.json
@@ -179,6 +179,24 @@
           ]
         }
       }
+    },
+    {
+      "description": "p2wsh-p2pkh, out (network derived from redeem)",
+      "arguments": {
+        "redeem": {
+          "address": "this is P2PKH context, unknown and ignored by p2wsh",
+          "output": "OP_DUP OP_HASH160 c30afa58ae0673b00a45b5c17dff4633780f1400 OP_EQUALVERIFY OP_CHECKSIG",
+          "network": "testnet"
+        }
+      },
+      "expected": {
+        "address": "tb1qusxlgq9quu27ucxs7a2fg8nv0pycdzvxsjk9npyupupxw3y892ssaskm8v",
+        "hash": "e40df400a0e715ee60d0f754941e6c784986898684ac59849c0f026744872aa1",
+        "output": "OP_0 e40df400a0e715ee60d0f754941e6c784986898684ac59849c0f026744872aa1",
+        "input": null,
+        "witness": null,
+        "network": "testnet"
+      }
     }
   ],
   "invalid": [

--- a/test/fixtures/p2wsh.json
+++ b/test/fixtures/p2wsh.json
@@ -307,6 +307,15 @@
       }
     },
     {
+      "exception": "Network mismatch",
+      "arguments": {
+        "network": "testnet",
+        "redeem": {
+          "network": "bitcoin"
+        }
+      }
+    },
+    {
       "exception": "Invalid prefix or Network mismatch",
       "arguments": {
         "address": "foo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs30dvv"

--- a/test/payments.utils.js
+++ b/test/payments.utils.js
@@ -1,6 +1,6 @@
 const t = require('assert')
 const bscript = require('../src/script')
-const bnetworks = require('../src/networks')
+const BNETWORKS = require('../src/networks')
 
 function tryHex (x) {
   if (Buffer.isBuffer(x)) return x.toString('hex')
@@ -58,7 +58,7 @@ function equate (a, b, args) {
 
   equateBase(a, b, '')
   if (b.redeem) equateBase(a.redeem, b.redeem, 'redeem.')
-  if (b.network) t.deepEqual(a.network, b.network, 'Inequal *.network')
+  if (b.network) t.deepEqual(a.network, BNETWORKS[b.network], 'Inequal *.network')
 
   // contextual
   if (b.signature === null) b.signature = undefined
@@ -76,7 +76,7 @@ function equate (a, b, args) {
 function preform (x) {
   x = Object.assign({}, x)
 
-  if (x.network) x.network = bnetworks[x.network]
+  if (x.network) x.network = BNETWORKS[x.network]
   if (typeof x.inputHex === 'string') {
     x.input = Buffer.from(x.inputHex, 'hex')
     delete x.inputHex
@@ -96,10 +96,11 @@ function preform (x) {
   if (x.pubkeys) x.pubkeys = x.pubkeys.map(fromHex)
   if (x.signatures) x.signatures = x.signatures.map(function (y) { return Number.isFinite(y) ? y : Buffer.from(y, 'hex') })
   if (x.redeem) {
+    x.redeem = Object.assign({}, x.redeem)
     if (typeof x.redeem.input === 'string') x.redeem.input = asmToBuffer(x.redeem.input)
     if (typeof x.redeem.output === 'string') x.redeem.output = asmToBuffer(x.redeem.output)
     if (Array.isArray(x.redeem.witness)) x.redeem.witness = x.redeem.witness.map(fromHex)
-    if (x.redeem.network) x.redeem.network = bnetworks[x.redeem.network]
+    if (x.redeem.network) x.redeem.network = BNETWORKS[x.redeem.network]
   }
 
   return x


### PR DESCRIPTION
The default `network` now favours that which is defined...