### PR TITLE
Add regtest network

### DIFF
--- a/src/networks.js
+++ b/src/networks.js
@@ -13,6 +13,17 @@ module.exports = {
     scriptHash: 0x05,
     wif: 0x80
   },
+  regtest: {
+    messagePrefix: '\x18Bitcoin Signed Message:\n',
+    bech32: 'bcrt',
+    bip32: {
+      public: 0x043587cf,
+      private: 0x04358394
+    },
+    pubKeyHash: 0x6f,
+    scriptHash: 0xc4,
+    wif: 0xef
+  },
   testnet: {
     messagePrefix: '\x18Bitcoin Signed Message:\n',
     bech32: 'tb',

--- a/test/fixtures/address.json
+++ b/test/fixtures/address.json
@@ -63,6 +63,20 @@
       "bech32": "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
       "data": "000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
       "script": "OP_0 000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"
+    },
+    {
+      "network": "regtest",
+      "version": 0,
+      "bech32": "bcrt1qjh3dnrafy8f2zszh5sdqn6c3ycfljh930yza9nt72v30dkw8mlvscn82zx",
+      "data": "95e2d98fa921d2a14057a41a09eb112613f95cb17905d2cd7e5322f6d9c7dfd9",
+      "script": "OP_0 95e2d98fa921d2a14057a41a09eb112613f95cb17905d2cd7e5322f6d9c7dfd9"
+    },
+    {
+      "network": "regtest",
+      "version": 0,
+      "bech32": "bcrt1qqqqqqqqqqqqqqahrwf6d62emdxmpq8gu3xe9au9fjwc9sxxn4k2qujfh7u",
+      "data": "000000000000000076e37274dd2b3b69b6101d1c89b25ef0a993b05818d3ad94",
+      "script": "OP_0 000000000000000076e37274dd2b3b69b6101d1c89b25ef0a993b05818d3ad94"
     }
   ],
   "bech32": [
@@ -179,4 +193,3 @@
     ]
   }
 }
-


### PR DESCRIPTION
ECPair.fromWIF uses .pop() to grab the networks from the list in tests...

If we added regtest AFTER testnet the tests fail........