### PR TITLE
Fix errors for bitcoin core 0.17.0

### DIFF
--- a/test/integration/cltv.js
+++ b/test/integration/cltv.js
@@ -212,7 +212,7 @@ describe('bitcoinjs-lib (transactions w/ CLTV)', function () {
       regtestUtils.broadcast(tx.toHex(), function (err) {
         assert.throws(function () {
           if (err) throw err
-        }, /Error: 64: non-final/)
+        }, /Error: non-final \(code 64\)/)
 
         done()
       })

--- a/test/integration/csv.js
+++ b/test/integration/csv.js
@@ -132,7 +132,7 @@ describe('bitcoinjs-lib (transactions w/ CSV)', function () {
       regtestUtils.broadcast(tx.toHex(), function (err) {
         assert.throws(function () {
           if (err) throw err
-        }, /Error: 64: non-BIP68-final/)
+        }, /Error: non-BIP68-final \(code 64\)/)
 
         done()
       })


### PR DESCRIPTION
This fix is necessary if you use 0.17.0 behind the regtest-server for integration tests.

Do not merge until the backend if bumped to 0.17...