### PR TITLE
Caters for a different RIPEMD160 name for LibreSSL

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,7 +1,13 @@
 const createHash = require('create-hash')
 
 function ripemd160 (buffer) {
-  return createHash('rmd160').update(buffer).digest()
+  let hash
+  try {
+    hash = createHash('rmd160')
+  } catch (err) {
+    hash = createHash('ripemd160')
+  }
+  return hash.update(buffer).digest()
 }
 
 function sha1 (buffer) {


### PR DESCRIPTION
Solution for #1363. It catches the error and attempts to create a hash using the new name.