### PR TITLE
Remove source files before rebuilding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1845,6 +1845,31 @@
         "path-parse": "^1.0.5"
       }
     },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "bitcoinjs"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "clean": "rimraf src",
+    "build": "npm run clean && tsc -p ./tsconfig.json",
     "coverage-report": "npm run build && npm run nobuild:coverage-report",
     "coverage-html": "npm run build && npm run nobuild:coverage-html",
     "coverage": "npm run build && npm run nobuild:coverage",
@@ -71,6 +72,7 @@
     "nyc": "^13.3.0",
     "prettier": "1.16.4",
     "proxyquire": "^2.0.1",
+    "rimraf": "^2.6.3",
     "tslint": "5.13.1",
     "typescript": "3.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "bitcoinjs"
   ],
   "scripts": {
-    "clean": "rimraf src",
     "build": "npm run clean && tsc -p ./tsconfig.json",
+    "clean": "rimraf src",
     "coverage-report": "npm run build && npm run nobuild:coverage-report",
     "coverage-html": "npm run build && npm run nobuild:coverage-html",
     "coverage": "npm run build && npm run nobuild:coverage",


### PR DESCRIPTION
To ensure removing TypeScript source files also deletes the built JavaScript.

Added `rimraf` dependency for portability, otherwise building will fail on Windows.