### PR TITLE
Create async sign interface for TransactionBuilder

### DIFF
--- a/src/ecc.js
+++ b/src/ecc.js
@@ -1,0 +1,4 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const ecc = require('tiny-secp256k1');
+exports.ecc = ecc;

--- a/src/eccAsync.js
+++ b/src/eccAsync.js
@@ -1,0 +1,34 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const _ecc = require('tiny-secp256k1');
+const r = Promise.resolve;
+const ecc = {
+  isPoint(derEncodedPoint) {
+    return r(_ecc.isPoint(derEncodedPoint));
+  },
+  isPrivate(privateKey) {
+    return r(_ecc.isPrivate(privateKey));
+  },
+  pointAddScalar(derEncodedPoint, scalar32Bytes, toCompressed) {
+    return r(_ecc.pointAddScalar(derEncodedPoint, scalar32Bytes, toCompressed));
+  },
+  pointCompress(derEncodedPoint, toCompressed) {
+    return r(_ecc.pointCompress(derEncodedPoint, toCompressed));
+  },
+  pointFromScalar(scalar32Bytes, toCompressed) {
+    return r(_ecc.pointFromScalar(scalar32Bytes, toCompressed));
+  },
+  privateAdd(privateKey, scalar32Bytes) {
+    return r(_ecc.privateAdd(privateKey, scalar32Bytes));
+  },
+  sign(hash, privateKey) {
+    return r(_ecc.sign(hash, privateKey));
+  },
+  signWithEntropy(hash, privateKey, extraEntropy) {
+    return r(_ecc.signWithEntropy(hash, privateKey, extraEntropy));
+  },
+  verify(hash, publicKey, signature) {
+    return r(_ecc.verify(hash, publicKey, signature));
+  },
+};
+exports.ecc = ecc;

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -1,8 +1,8 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+const ecc_1 = require('./ecc');
 const NETWORKS = require('./networks');
 const types = require('./types');
-const ecc = require('tiny-secp256k1');
 const randomBytes = require('randombytes');
 const typeforce = require('typeforce');
 const wif = require('wif');
@@ -20,13 +20,15 @@ class ECPair {
     this.compressed =
       options.compressed === undefined ? true : options.compressed;
     this.network = options.network || NETWORKS.bitcoin;
-    if (__Q !== undefined) this.__Q = ecc.pointCompress(__Q, this.compressed);
+    if (__Q !== undefined)
+      this.__Q = ecc_1.ecc.pointCompress(__Q, this.compressed);
   }
   get privateKey() {
     return this.__D;
   }
   get publicKey() {
-    if (!this.__Q) this.__Q = ecc.pointFromScalar(this.__D, this.compressed);
+    if (!this.__Q)
+      this.__Q = ecc_1.ecc.pointFromScalar(this.__D, this.compressed);
     return this.__Q;
   }
   toWIF() {
@@ -36,9 +38,9 @@ class ECPair {
   sign(hash, lowR = false) {
     if (!this.__D) throw new Error('Missing private key');
     if (lowR === false) {
-      return ecc.sign(hash, this.__D);
+      return ecc_1.ecc.sign(hash, this.__D);
     } else {
-      let sig = ecc.sign(hash, this.__D);
+      let sig = ecc_1.ecc.sign(hash, this.__D);
       const extraData = Buffer.alloc(32, 0);
       let counter = 0;
       // if first try is lowR, skip the loop
@@ -46,25 +48,25 @@ class ECPair {
       while (sig[0] > 0x7f) {
         counter++;
         extraData.writeUIntLE(counter, 0, 6);
-        sig = ecc.signWithEntropy(hash, this.__D, extraData);
+        sig = ecc_1.ecc.signWithEntropy(hash, this.__D, extraData);
       }
       return sig;
     }
   }
   verify(hash, signature) {
-    return ecc.verify(hash, this.publicKey, signature);
+    return ecc_1.ecc.verify(hash, this.publicKey, signature);
   }
 }
 function fromPrivateKey(buffer, options) {
   typeforce(types.Buffer256bit, buffer);
-  if (!ecc.isPrivate(buffer))
+  if (!ecc_1.ecc.isPrivate(buffer))
     throw new TypeError('Private key not in range [1, n)');
   typeforce(isOptions, options);
   return new ECPair(buffer, undefined, options);
 }
 exports.fromPrivateKey = fromPrivateKey;
 function fromPublicKey(buffer, options) {
-  typeforce(ecc.isPoint, buffer);
+  typeforce(ecc_1.ecc.isPoint, buffer);
   typeforce(isOptions, options);
   return new ECPair(undefined, buffer, options);
 }
@@ -99,7 +101,7 @@ function makeRandom(options) {
   do {
     d = rng(32);
     typeforce(types.Buffer256bit, d);
-  } while (!ecc.isPrivate(d));
+  } while (!ecc_1.ecc.isPrivate(d));
   return fromPrivateKey(d, options);
 }
 exports.makeRandom = makeRandom;

--- a/src/payments/p2ms.js
+++ b/src/payments/p2ms.js
@@ -1,11 +1,11 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+const ecc_1 = require('../ecc');
 const networks_1 = require('../networks');
 const bscript = require('../script');
 const lazy = require('./lazy');
 const OPS = bscript.OPS;
 const typef = require('typeforce');
-const ecc = require('tiny-secp256k1');
 const OP_INT_BASE = OPS.OP_RESERVED; // OP_1 - 1
 function stacksEqual(a, b) {
   if (a.length !== b.length) return false;
@@ -36,7 +36,7 @@ function p2ms(a, opts) {
       m: typef.maybe(typef.Number),
       n: typef.maybe(typef.Number),
       output: typef.maybe(typef.Buffer),
-      pubkeys: typef.maybe(typef.arrayOf(ecc.isPoint)),
+      pubkeys: typef.maybe(typef.arrayOf(ecc_1.ecc.isPoint)),
       signatures: typef.maybe(typef.arrayOf(isAcceptableSignature)),
       input: typef.maybe(typef.Buffer),
     },
@@ -104,7 +104,7 @@ function p2ms(a, opts) {
         throw new TypeError('Output is invalid');
       if (o.m <= 0 || o.n > 16 || o.m > o.n || o.n !== chunks.length - 3)
         throw new TypeError('Output is invalid');
-      if (!o.pubkeys.every(x => ecc.isPoint(x)))
+      if (!o.pubkeys.every(x => ecc_1.ecc.isPoint(x)))
         throw new TypeError('Output is invalid');
       if (a.m !== undefined && a.m !== o.m) throw new TypeError('m mismatch');
       if (a.n !== undefined && a.n !== o.n) throw new TypeError('n mismatch');

--- a/src/payments/p2pk.js
+++ b/src/payments/p2pk.js
@@ -1,11 +1,11 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+const ecc_1 = require('../ecc');
 const networks_1 = require('../networks');
 const bscript = require('../script');
 const lazy = require('./lazy');
 const typef = require('typeforce');
 const OPS = bscript.OPS;
-const ecc = require('tiny-secp256k1');
 // input: {signature}
 // output: {pubKey} OP_CHECKSIG
 function p2pk(a, opts) {
@@ -16,7 +16,7 @@ function p2pk(a, opts) {
     {
       network: typef.maybe(typef.Object),
       output: typef.maybe(typef.Buffer),
-      pubkey: typef.maybe(ecc.isPoint),
+      pubkey: typef.maybe(ecc_1.ecc.isPoint),
       signature: typef.maybe(bscript.isCanonicalScriptSignature),
       input: typef.maybe(typef.Buffer),
     },
@@ -52,7 +52,7 @@ function p2pk(a, opts) {
     if (a.output) {
       if (a.output[a.output.length - 1] !== OPS.OP_CHECKSIG)
         throw new TypeError('Output is invalid');
-      if (!ecc.isPoint(o.pubkey))
+      if (!ecc_1.ecc.isPoint(o.pubkey))
         throw new TypeError('Output pubkey is invalid');
       if (a.pubkey && !a.pubkey.equals(o.pubkey))
         throw new TypeError('Pubkey mismatch');

--- a/src/payments/p2pkh.js
+++ b/src/payments/p2pkh.js
@@ -1,12 +1,12 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 const bcrypto = require('../crypto');
+const ecc_1 = require('../ecc');
 const networks_1 = require('../networks');
 const bscript = require('../script');
 const lazy = require('./lazy');
 const typef = require('typeforce');
 const OPS = bscript.OPS;
-const ecc = require('tiny-secp256k1');
 const bs58check = require('bs58check');
 // input: {signature} {pubkey}
 // output: OP_DUP OP_HASH160 {hash160(pubkey)} OP_EQUALVERIFY OP_CHECKSIG
@@ -20,7 +20,7 @@ function p2pkh(a, opts) {
       address: typef.maybe(typef.String),
       hash: typef.maybe(typef.BufferN(20)),
       output: typef.maybe(typef.BufferN(25)),
-      pubkey: typef.maybe(ecc.isPoint),
+      pubkey: typef.maybe(ecc_1.ecc.isPoint),
       signature: typef.maybe(bscript.isCanonicalScriptSignature),
       input: typef.maybe(typef.Buffer),
     },
@@ -116,7 +116,7 @@ function p2pkh(a, opts) {
       if (chunks.length !== 2) throw new TypeError('Input is invalid');
       if (!bscript.isCanonicalScriptSignature(chunks[0]))
         throw new TypeError('Input has invalid signature');
-      if (!ecc.isPoint(chunks[1]))
+      if (!ecc_1.ecc.isPoint(chunks[1]))
         throw new TypeError('Input has invalid pubkey');
       if (a.signature && !a.signature.equals(chunks[0]))
         throw new TypeError('Signature mismatch');

--- a/src/payments/p2wpkh.js
+++ b/src/payments/p2wpkh.js
@@ -1,12 +1,12 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 const bcrypto = require('../crypto');
+const ecc_1 = require('../ecc');
 const networks_1 = require('../networks');
 const bscript = require('../script');
 const lazy = require('./lazy');
 const typef = require('typeforce');
 const OPS = bscript.OPS;
-const ecc = require('tiny-secp256k1');
 const bech32 = require('bech32');
 const EMPTY_BUFFER = Buffer.alloc(0);
 // witness: {signature} {pubKey}
@@ -23,7 +23,7 @@ function p2wpkh(a, opts) {
       input: typef.maybe(typef.BufferN(0)),
       network: typef.maybe(typef.Object),
       output: typef.maybe(typef.BufferN(22)),
-      pubkey: typef.maybe(ecc.isPoint),
+      pubkey: typef.maybe(ecc_1.ecc.isPoint),
       signature: typef.maybe(bscript.isCanonicalScriptSignature),
       witness: typef.maybe(typef.arrayOf(typef.Buffer)),
     },
@@ -112,7 +112,7 @@ function p2wpkh(a, opts) {
       if (a.witness.length !== 2) throw new TypeError('Witness is invalid');
       if (!bscript.isCanonicalScriptSignature(a.witness[0]))
         throw new TypeError('Witness has invalid signature');
-      if (!ecc.isPoint(a.witness[1]))
+      if (!ecc_1.ecc.isPoint(a.witness[1]))
         throw new TypeError('Witness has invalid pubkey');
       if (a.signature && !a.signature.equals(a.witness[0]))
         throw new TypeError('Signature mismatch');

--- a/src/script.js
+++ b/src/script.js
@@ -1,10 +1,10 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+const ecc_1 = require('./ecc');
 const scriptNumber = require('./script_number');
 const scriptSignature = require('./script_signature');
 const types = require('./types');
 const bip66 = require('bip66');
-const ecc = require('tiny-secp256k1');
 const pushdata = require('pushdata-bitcoin');
 const typeforce = require('typeforce');
 exports.OPS = require('bitcoin-ops');
@@ -157,7 +157,7 @@ function toStack(chunks) {
 }
 exports.toStack = toStack;
 function isCanonicalPubKey(buffer) {
-  return ecc.isPoint(buffer);
+  return ecc_1.ecc.isPoint(buffer);
 }
 exports.isCanonicalPubKey = isCanonicalPubKey;
 function isDefinedHashType(hashType) {

--- a/ts_src/ecc.ts
+++ b/ts_src/ecc.ts
@@ -1,0 +1,51 @@
+export interface Secp256k1EccLib {
+  // checks if given DER encoded point is on the secp256k1 curve
+  // returns true if on curve false if not
+  isPoint(derEncodedPoint: Buffer): boolean;
+  // checks if the given 32 byte buffer is between 1 and n - 1 where n
+  // refers to the order of the curve
+  // returns true if a valid private key
+  isPrivate(privateKey: Buffer): boolean;
+  // Takes a scalar 32 bytes, multiplies it by the generator to get a point
+  // then takes the given DER encoded point and adds it to that point
+  // if toCompressed is given and true the returned value is DER compressed
+  // if toCompressed is not given, then copy the compressed-ness state of the
+  // first argument given (DER encoded point)
+  // returns the point resulting in the addition of the given point and the
+  // calculated point from the given scalar
+  pointAddScalar(
+    derEncodedPoint: Buffer,
+    scalar32Bytes: Buffer,
+    toCompressed?: boolean,
+  ): Buffer;
+  // Given a DER encoded point, convert the encoding to compressed-ness based on
+  // the second argument's boolean value
+  // returns a DER encoded public key point
+  pointCompress(derEncodedPoint: Buffer, toCompressed: boolean): Buffer;
+  // Given a 32 byte scalar, calculate the point (pubkey).
+  // if toCompressed is not given, treat it as true.
+  // returns a DER encoded public key
+  pointFromScalar(scalar32Bytes: Buffer, toCompressed?: boolean): Buffer;
+  // Adds together two 32 byte Buffers and checks that
+  // the result is a valid private key.
+  // returns the sum modulo the curve order as a Buffer
+  privateAdd(privateKey: Buffer, scalar32Bytes: Buffer): Buffer;
+  // Signs the hash using the privateKey. (no hashing is performed inside)
+  // Returns a 64 byte Buffer where the first 32 bytes are the r value
+  // the last 32 bytes are the s value. r and s are both big endian.
+  sign(hash: Buffer, privateKey: Buffer): Buffer;
+  // Same as sign, but with extra entropy added into the RFC6979 nonce
+  // generation. See RFC6979 and libsecp256k1 for details
+  signWithEntropy(
+    hash: Buffer,
+    privateKey: Buffer,
+    extraEntropy: Buffer,
+  ): Buffer;
+  // Given a hash, DER encoded public key buffer, and 64 byte signature Buffer
+  // It returns true if the verification of the signature passes.
+  verify(hash: Buffer, publicKey: Buffer, signature: Buffer): boolean;
+}
+
+const ecc: Secp256k1EccLib = require('tiny-secp256k1');
+
+export { ecc };

--- a/ts_src/eccAsync.ts
+++ b/ts_src/eccAsync.ts
@@ -1,0 +1,102 @@
+export interface Secp256k1EccLibAsync {
+  // checks if given DER encoded point is on the secp256k1 curve
+  // returns true if on curve false if not
+  isPoint(derEncodedPoint: Buffer): Promise<boolean>;
+  // checks if the given 32 byte buffer is between 1 and n - 1 where n
+  // refers to the order of the curve
+  // returns true if a valid private key
+  isPrivate(privateKey: Buffer): Promise<boolean>;
+  // Takes a scalar 32 bytes, multiplies it by the generator to get a point
+  // then takes the given DER encoded point and adds it to that point
+  // if toCompressed is given and true the returned value is DER compressed
+  // if toCompressed is not given, then copy the compressed-ness state of the
+  // first argument given (DER encoded point)
+  // returns the point resulting in the addition of the given point and the
+  // calculated point from the given scalar
+  pointAddScalar(
+    derEncodedPoint: Buffer,
+    scalar32Bytes: Buffer,
+    toCompressed?: boolean,
+  ): Promise<Buffer>;
+  // Given a DER encoded point, convert the encoding to compressed-ness based on
+  // the second argument's boolean value
+  // returns a DER encoded public key point
+  pointCompress(
+    derEncodedPoint: Buffer,
+    toCompressed: boolean,
+  ): Promise<Buffer>;
+  // Given a 32 byte scalar, calculate the point (pubkey).
+  // if toCompressed is not given, treat it as true.
+  // returns a DER encoded public key
+  pointFromScalar(
+    scalar32Bytes: Buffer,
+    toCompressed?: boolean,
+  ): Promise<Buffer>;
+  // Adds together two 32 byte Buffers and checks that
+  // the result is a valid private key.
+  // returns the sum modulo the curve order as a Buffer
+  privateAdd(privateKey: Buffer, scalar32Bytes: Buffer): Promise<Buffer>;
+  // Signs the hash using the privateKey. (no hashing is performed inside)
+  // Returns a 64 byte Buffer where the first 32 bytes are the r value
+  // the last 32 bytes are the s value. r and s are both big endian.
+  sign(hash: Buffer, privateKey: Buffer): Promise<Buffer>;
+  // Same as sign, but with extra entropy added into the RFC6979 nonce
+  // generation. See RFC6979 and libsecp256k1 for details
+  signWithEntropy(
+    hash: Buffer,
+    privateKey: Buffer,
+    extraEntropy: Buffer,
+  ): Promise<Buffer>;
+  // Given a hash, DER encoded public key buffer, and 64 byte signature Buffer
+  // It returns true if the verification of the signature passes.
+  verify(hash: Buffer, publicKey: Buffer, signature: Buffer): Promise<boolean>;
+}
+
+const _ecc = require('tiny-secp256k1');
+const r = Promise.resolve;
+
+const ecc: Secp256k1EccLibAsync = {
+  isPoint(derEncodedPoint: Buffer): Promise<boolean> {
+    return r(_ecc.isPoint(derEncodedPoint));
+  },
+  isPrivate(privateKey: Buffer): Promise<boolean> {
+    return r(_ecc.isPrivate(privateKey));
+  },
+  pointAddScalar(
+    derEncodedPoint: Buffer,
+    scalar32Bytes: Buffer,
+    toCompressed?: boolean,
+  ): Promise<Buffer> {
+    return r(_ecc.pointAddScalar(derEncodedPoint, scalar32Bytes, toCompressed));
+  },
+  pointCompress(
+    derEncodedPoint: Buffer,
+    toCompressed: boolean,
+  ): Promise<Buffer> {
+    return r(_ecc.pointCompress(derEncodedPoint, toCompressed));
+  },
+  pointFromScalar(
+    scalar32Bytes: Buffer,
+    toCompressed?: boolean,
+  ): Promise<Buffer> {
+    return r(_ecc.pointFromScalar(scalar32Bytes, toCompressed));
+  },
+  privateAdd(privateKey: Buffer, scalar32Bytes: Buffer): Promise<Buffer> {
+    return r(_ecc.privateAdd(privateKey, scalar32Bytes));
+  },
+  sign(hash: Buffer, privateKey: Buffer): Promise<Buffer> {
+    return r(_ecc.sign(hash, privateKey));
+  },
+  signWithEntropy(
+    hash: Buffer,
+    privateKey: Buffer,
+    extraEntropy: Buffer,
+  ): Promise<Buffer> {
+    return r(_ecc.signWithEntropy(hash, privateKey, extraEntropy));
+  },
+  verify(hash: Buffer, publicKey: Buffer, signature: Buffer): Promise<boolean> {
+    return r(_ecc.verify(hash, publicKey, signature));
+  },
+};
+
+export { ecc };

--- a/ts_src/ecpair.ts
+++ b/ts_src/ecpair.ts
@@ -19,18 +19,18 @@ interface ECPairOptions {
   rng?(arg0: number): Buffer;
 }
 
-export interface Signer {
+export interface SignerBase {
   publicKey: Buffer;
   network?: Network;
-  sign(hash: Buffer, lowR?: boolean): Buffer;
   getPublicKey?(): Buffer;
 }
 
-export interface SignerAsync {
-  publicKey: Buffer;
-  network?: Network;
+export interface Signer extends SignerBase {
+  sign(hash: Buffer, lowR?: boolean): Buffer;
+}
+
+export interface SignerAsync extends SignerBase {
   sign(hash: Buffer, lowR?: boolean): Promise<Buffer>;
-  getPublicKey?(): Buffer;
 }
 
 export interface ECPairInterface extends Signer {

--- a/ts_src/ecpair.ts
+++ b/ts_src/ecpair.ts
@@ -1,7 +1,7 @@
+import { ecc } from './ecc';
 import { Network } from './networks';
 import * as NETWORKS from './networks';
 import * as types from './types';
-const ecc = require('tiny-secp256k1');
 const randomBytes = require('randombytes');
 const typeforce = require('typeforce');
 const wif = require('wif');
@@ -64,7 +64,7 @@ class ECPair implements ECPairInterface {
 
   get publicKey(): Buffer {
     if (!this.__Q)
-      this.__Q = ecc.pointFromScalar(this.__D, this.compressed) as Buffer;
+      this.__Q = ecc.pointFromScalar(this.__D as Buffer, this.compressed);
     return this.__Q;
   }
 

--- a/ts_src/payments/p2ms.ts
+++ b/ts_src/payments/p2ms.ts
@@ -1,10 +1,10 @@
+import { ecc } from '../ecc';
 import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as bscript from '../script';
 import { Payment, PaymentOpts, Stack } from './index';
 import * as lazy from './lazy';
 const OPS = bscript.OPS;
 const typef = require('typeforce');
-const ecc = require('tiny-secp256k1');
 
 const OP_INT_BASE = OPS.OP_RESERVED; // OP_1 - 1
 

--- a/ts_src/payments/p2pk.ts
+++ b/ts_src/payments/p2pk.ts
@@ -1,10 +1,10 @@
+import { ecc } from '../ecc';
 import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as bscript from '../script';
 import { Payment, PaymentOpts, StackFunction } from './index';
 import * as lazy from './lazy';
 const typef = require('typeforce');
 const OPS = bscript.OPS;
-const ecc = require('tiny-secp256k1');
 
 // input: {signature}
 // output: {pubKey} OP_CHECKSIG
@@ -58,7 +58,7 @@ export function p2pk(a: Payment, opts?: PaymentOpts): Payment {
     if (a.output) {
       if (a.output[a.output.length - 1] !== OPS.OP_CHECKSIG)
         throw new TypeError('Output is invalid');
-      if (!ecc.isPoint(o.pubkey))
+      if (!ecc.isPoint(o.pubkey as Buffer))
         throw new TypeError('Output pubkey is invalid');
       if (a.pubkey && !a.pubkey.equals(o.pubkey!))
         throw new TypeError('Pubkey mismatch');

--- a/ts_src/payments/p2pkh.ts
+++ b/ts_src/payments/p2pkh.ts
@@ -1,11 +1,11 @@
 import * as bcrypto from '../crypto';
+import { ecc } from '../ecc';
 import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as bscript from '../script';
 import { Payment, PaymentOpts, StackFunction } from './index';
 import * as lazy from './lazy';
 const typef = require('typeforce');
 const OPS = bscript.OPS;
-const ecc = require('tiny-secp256k1');
 
 const bs58check = require('bs58check');
 
@@ -129,7 +129,7 @@ export function p2pkh(a: Payment, opts?: PaymentOpts): Payment {
       if (chunks.length !== 2) throw new TypeError('Input is invalid');
       if (!bscript.isCanonicalScriptSignature(chunks[0] as Buffer))
         throw new TypeError('Input has invalid signature');
-      if (!ecc.isPoint(chunks[1]))
+      if (!ecc.isPoint(chunks[1] as Buffer))
         throw new TypeError('Input has invalid pubkey');
 
       if (a.signature && !a.signature.equals(chunks[0] as Buffer))

--- a/ts_src/payments/p2wpkh.ts
+++ b/ts_src/payments/p2wpkh.ts
@@ -1,11 +1,11 @@
 import * as bcrypto from '../crypto';
+import { ecc } from '../ecc';
 import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as bscript from '../script';
 import { Payment, PaymentOpts } from './index';
 import * as lazy from './lazy';
 const typef = require('typeforce');
 const OPS = bscript.OPS;
-const ecc = require('tiny-secp256k1');
 
 const bech32 = require('bech32');
 

--- a/ts_src/script.ts
+++ b/ts_src/script.ts
@@ -1,9 +1,9 @@
+import { ecc } from './ecc';
 import { Stack } from './payments';
 import * as scriptNumber from './script_number';
 import * as scriptSignature from './script_signature';
 import * as types from './types';
 const bip66 = require('bip66');
-const ecc = require('tiny-secp256k1');
 const pushdata = require('pushdata-bitcoin');
 const typeforce = require('typeforce');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2017",
     "module": "commonjs",
     "outDir": "./src",
     "declaration": true,

--- a/types/ecc.d.ts
+++ b/types/ecc.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="node" />
+export interface Secp256k1EccLib {
+    isPoint(derEncodedPoint: Buffer): boolean;
+    isPrivate(privateKey: Buffer): boolean;
+    pointAddScalar(derEncodedPoint: Buffer, scalar32Bytes: Buffer, toCompressed?: boolean): Buffer;
+    pointCompress(derEncodedPoint: Buffer, toCompressed: boolean): Buffer;
+    pointFromScalar(scalar32Bytes: Buffer, toCompressed?: boolean): Buffer;
+    privateAdd(privateKey: Buffer, scalar32Bytes: Buffer): Buffer;
+    sign(hash: Buffer, privateKey: Buffer): Buffer;
+    signWithEntropy(hash: Buffer, privateKey: Buffer, extraEntropy: Buffer): Buffer;
+    verify(hash: Buffer, publicKey: Buffer, signature: Buffer): boolean;
+}
+declare const ecc: Secp256k1EccLib;
+export { ecc };

--- a/types/eccAsync.d.ts
+++ b/types/eccAsync.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="node" />
+export interface Secp256k1EccLibAsync {
+    isPoint(derEncodedPoint: Buffer): Promise<boolean>;
+    isPrivate(privateKey: Buffer): Promise<boolean>;
+    pointAddScalar(derEncodedPoint: Buffer, scalar32Bytes: Buffer, toCompressed?: boolean): Promise<Buffer>;
+    pointCompress(derEncodedPoint: Buffer, toCompressed: boolean): Promise<Buffer>;
+    pointFromScalar(scalar32Bytes: Buffer, toCompressed?: boolean): Promise<Buffer>;
+    privateAdd(privateKey: Buffer, scalar32Bytes: Buffer): Promise<Buffer>;
+    sign(hash: Buffer, privateKey: Buffer): Promise<Buffer>;
+    signWithEntropy(hash: Buffer, privateKey: Buffer, extraEntropy: Buffer): Promise<Buffer>;
+    verify(hash: Buffer, publicKey: Buffer, signature: Buffer): Promise<boolean>;
+}
+declare const ecc: Secp256k1EccLibAsync;
+export { ecc };

--- a/types/ecpair.d.ts
+++ b/types/ecpair.d.ts
@@ -5,17 +5,16 @@ interface ECPairOptions {
     network?: Network;
     rng?(arg0: number): Buffer;
 }
-export interface Signer {
+export interface SignerBase {
     publicKey: Buffer;
     network?: Network;
-    sign(hash: Buffer, lowR?: boolean): Buffer;
     getPublicKey?(): Buffer;
 }
-export interface SignerAsync {
-    publicKey: Buffer;
-    network?: Network;
+export interface Signer extends SignerBase {
+    sign(hash: Buffer, lowR?: boolean): Buffer;
+}
+export interface SignerAsync extends SignerBase {
     sign(hash: Buffer, lowR?: boolean): Promise<Buffer>;
-    getPublicKey?(): Buffer;
 }
 export interface ECPairInterface extends Signer {
     compressed: boolean;

--- a/types/transaction_builder.d.ts
+++ b/types/transaction_builder.d.ts
@@ -28,6 +28,7 @@ export declare class TransactionBuilder {
     build(): Transaction;
     buildIncomplete(): Transaction;
     sign(signParams: number | TxbSignArg, keyPair?: Signer, redeemScript?: Buffer, hashType?: number, witnessValue?: number, witnessScript?: Buffer): void;
+    signAsync(signParams: number | TxbSignArg, keyPair?: Signer, redeemScript?: Buffer, hashType?: number, witnessValue?: number, witnessScript?: Buffer): Promise<void>;
     private __addInputUnsafe;
     private __build;
     private __canModifyInputs;


### PR DESCRIPTION
Separated all the ECC operations out into a single file to make it easier to swap in other methods (WASM, hardware wallets, etc.)

Having this new signAsync method will allow people to create SignerAsync interfaces that use HW wallets etc. to sign.

Changed the target to ES2017 to allow for async await in the JS.
async await has been supported since Node v8.x.x and in browsers for quite a while...

This is just an idea. Extended discussion expected.