### PR TITLE
Fix Signer interface

### DIFF
--- a/ts_src/ecpair.ts
+++ b/ts_src/ecpair.ts
@@ -21,14 +21,14 @@ interface ECPairOptions {
 
 export interface Signer {
   publicKey: Buffer;
-  network?: Network;
+  network?: any;
   sign(hash: Buffer, lowR?: boolean): Buffer;
   getPublicKey?(): Buffer;
 }
 
 export interface SignerAsync {
   publicKey: Buffer;
-  network?: Network;
+  network?: any;
   sign(hash: Buffer, lowR?: boolean): Promise<Buffer>;
   getPublicKey?(): Buffer;
 }

--- a/types/ecpair.d.ts
+++ b/types/ecpair.d.ts
@@ -7,13 +7,13 @@ interface ECPairOptions {
 }
 export interface Signer {
     publicKey: Buffer;
-    network?: Network;
+    network?: any;
     sign(hash: Buffer, lowR?: boolean): Buffer;
     getPublicKey?(): Buffer;
 }
 export interface SignerAsync {
     publicKey: Buffer;
-    network?: Network;
+    network?: any;
     sign(hash: Buffer, lowR?: boolean): Promise<Buffer>;
     getPublicKey?(): Buffer;
 }


### PR DESCRIPTION
Passing bip32 object in gave TypeScript error...

since network is only left in for TransactionBuilder, and TXB only checks equivalency, and Signer is only ever an argument and never a return value...

So make it looser to accommodate.

This way bip32 can be used in Psbt signing etc...

(I really need to rewrite the tests for bitcoinjs in TypeScript to catch all of these TypeScript errors in my IDE)