### PR TITLE
Allow custom implementations of finalizers

### DIFF
--- a/src/psbt.js
+++ b/src/psbt.js
@@ -204,7 +204,18 @@ class Psbt {
     range(this.data.inputs.length).forEach(idx => this.finalizeInput(idx));
     return this;
   }
-  finalizeInput(inputIndex) {
+  finalizeInput(
+    inputIndex,
+    {
+      classifyScript: classifyScriptF,
+      canFinalize: canFinalizeF,
+      getFinalScripts: getFinalScriptsF,
+    } = {
+      classifyScript,
+      canFinalize,
+      getFinalScripts,
+    },
+  ) {
     const input = utils_1.checkForInput(this.data.inputs, inputIndex);
     const { script, isP2SH, isP2WSH, isSegwit } = getScriptFromInput(
       inputIndex,
@@ -212,11 +223,11 @@ class Psbt {
       this.__CACHE,
     );
     if (!script) throw new Error(`No script found for input #${inputIndex}`);
-    const scriptType = classifyScript(script);
-    if (!canFinalize(input, script, scriptType))
+    const scriptType = classifyScriptF(script);
+    if (!canFinalizeF(input, script, scriptType))
       throw new Error(`Can not finalize input #${inputIndex}`);
     checkPartialSigSighashes(input);
-    const { finalScriptSig, finalScriptWitness } = getFinalScripts(
+    const { finalScriptSig, finalScriptWitness } = getFinalScriptsF(
       script,
       scriptType,
       input.partialSig,

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -204,18 +204,7 @@ class Psbt {
     range(this.data.inputs.length).forEach(idx => this.finalizeInput(idx));
     return this;
   }
-  finalizeInput(
-    inputIndex,
-    {
-      classifyScript: classifyScriptF,
-      canFinalize: canFinalizeF,
-      getFinalScripts: getFinalScriptsF,
-    } = {
-      classifyScript,
-      canFinalize,
-      getFinalScripts,
-    },
-  ) {
+  finalizeInput(inputIndex, finalScriptsFunc = getFinalScripts) {
     const input = utils_1.checkForInput(this.data.inputs, inputIndex);
     const { script, isP2SH, isP2WSH, isSegwit } = getScriptFromInput(
       inputIndex,
@@ -223,14 +212,11 @@ class Psbt {
       this.__CACHE,
     );
     if (!script) throw new Error(`No script found for input #${inputIndex}`);
-    const scriptType = classifyScriptF(script);
-    if (!canFinalizeF(input, script, scriptType))
-      throw new Error(`Can not finalize input #${inputIndex}`);
     checkPartialSigSighashes(input);
-    const { finalScriptSig, finalScriptWitness } = getFinalScriptsF(
+    const { finalScriptSig, finalScriptWitness } = finalScriptsFunc(
+      inputIndex,
+      input,
       script,
-      scriptType,
-      input.partialSig,
       isSegwit,
       isP2SH,
       isP2WSH,
@@ -749,7 +735,20 @@ function getTxCacheValue(key, name, inputs, c) {
   if (key === '__FEE_RATE') return c.__FEE_RATE;
   else if (key === '__FEE') return c.__FEE;
 }
-function getFinalScripts(
+function getFinalScripts(inputIndex, input, script, isSegwit, isP2SH, isP2WSH) {
+  const scriptType = classifyScript(script);
+  if (!canFinalize(input, script, scriptType))
+    throw new Error(`Can not finalize input #${inputIndex}`);
+  return prepareFinalScripts(
+    script,
+    scriptType,
+    input.partialSig,
+    isSegwit,
+    isP2SH,
+    isP2WSH,
+  );
+}
+function prepareFinalScripts(
   script,
   scriptType,
   partialSig,

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -1,5 +1,5 @@
 import { Psbt as PsbtBase } from 'bip174';
-import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput } from 'bip174/src/lib/interfaces';
+import { KeyValue, PartialSig, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput } from 'bip174/src/lib/interfaces';
 import { Signer, SignerAsync } from './ecpair';
 import { Network } from './networks';
 import { Transaction } from './transaction';
@@ -58,7 +58,7 @@ export declare class Psbt {
     getFeeRate(): number;
     getFee(): number;
     finalizeAllInputs(): this;
-    finalizeInput(inputIndex: number): this;
+    finalizeInput(inputIndex: number, { classifyScript: classifyScriptF, canFinalize: canFinalizeF, getFinalScripts: getFinalScriptsF, }?: IFinalizeFuncs): this;
     validateSignaturesOfAllInputs(): boolean;
     validateSignaturesOfInput(inputIndex: number, pubkey?: Buffer): boolean;
     signAllInputsHD(hdKeyPair: HDSigner, sighashTypes?: number[]): this;
@@ -124,4 +124,15 @@ interface HDSignerAsync extends HDSignerBase {
     derivePath(path: string): HDSignerAsync;
     sign(hash: Buffer): Promise<Buffer>;
 }
+interface IFinalizeFuncs {
+    classifyScript: FinalizeFuncClassifyScript;
+    canFinalize: FinalizeFuncCanFinalize;
+    getFinalScripts: FinalizeFuncGetFinalScripts;
+}
+declare type FinalizeFuncClassifyScript = (script: Buffer) => string;
+declare type FinalizeFuncCanFinalize = (input: PsbtInput, script: Buffer, scriptType: string) => boolean;
+declare type FinalizeFuncGetFinalScripts = (script: Buffer, scriptType: string, partialSig: PartialSig[], isSegwit: boolean, isP2SH: boolean, isP2WSH: boolean) => {
+    finalScriptSig: Buffer | undefined;
+    finalScriptWitness: Buffer | undefined;
+};
 export {};


### PR DESCRIPTION
Currently, PSBT class is unusable for non-standard scripts.

Exposing the three major functions used for finalization to be passed in will at least give people a way to implement their own scripts. (ie. timelock, etc.)

Maybe I should also try implementing one in the integration tests.

Should help with issues like: https://github.com/bitcoinjs/bitcoinjs-lib/issues/1479#issuecomment-539976906