### PR TITLE
Fix error TS2339: Property valueBuffer does not exist on type OpenOutput

### DIFF
--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -268,7 +268,7 @@ export class Transaction {
     newTx.outs = this.outs.map(txOut => {
       return {
         script: txOut.script,
-        value: (txOut as Output).value,
+        value: txOut.value,
       };
     });
 
@@ -438,7 +438,7 @@ export class Transaction {
       toffset = 0;
 
       this.outs.forEach(out => {
-        writeUInt64((out as Output).value);
+        writeUInt64(out.value);
         writeVarSlice(out.script);
       });
 
@@ -451,7 +451,7 @@ export class Transaction {
 
       tbuffer = Buffer.allocUnsafe(8 + varSliceSize(output.script));
       toffset = 0;
-      writeUInt64((output as Output).value);
+      writeUInt64(output.value);
       writeVarSlice(output.script);
 
       hashOutputs = bcrypto.hash256(tbuffer);

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -36,26 +36,19 @@ const ONE: Buffer = Buffer.from(
   'hex',
 );
 const VALUE_UINT64_MAX: Buffer = Buffer.from('ffffffffffffffff', 'hex');
-const BLANK_OUTPUT: BlankOutput = {
+const BLANK_OUTPUT = {
   script: EMPTY_SCRIPT,
   valueBuffer: VALUE_UINT64_MAX,
 };
 
-function isOutput(out: Output | BlankOutput): out is Output {
-  return (out as Output).value !== undefined;
-}
-
-export interface BlankOutput {
-  script: Buffer;
-  valueBuffer: Buffer;
+function isOutput(out: Output): boolean {
+  return out.value !== undefined;
 }
 
 export interface Output {
   script: Buffer;
   value: number;
 }
-
-type OpenOutput = Output | BlankOutput;
 
 export interface Input {
   hash: Buffer;
@@ -185,7 +178,7 @@ export class Transaction {
   version: number = 1;
   locktime: number = 0;
   ins: Input[] = [];
-  outs: OpenOutput[] = [];
+  outs: Output[] = [];
 
   isCoinbase(): boolean {
     return (
@@ -333,7 +326,7 @@ export class Transaction {
 
       // "blank" outputs before
       for (let i = 0; i < inIndex; i++) {
-        txTmp.outs[i] = BLANK_OUTPUT;
+        (txTmp.outs as any)[i] = BLANK_OUTPUT;
       }
 
       // ignore sequence numbers (except at inIndex)
@@ -602,7 +595,7 @@ export class Transaction {
       if (isOutput(txOut)) {
         writeUInt64(txOut.value);
       } else {
-        writeSlice(txOut.valueBuffer);
+        writeSlice((txOut as any).valueBuffer);
       }
 
       writeVarSlice(txOut.script);

--- a/types/transaction.d.ts
+++ b/types/transaction.d.ts
@@ -1,12 +1,7 @@
-export interface BlankOutput {
-    script: Buffer;
-    valueBuffer: Buffer;
-}
 export interface Output {
     script: Buffer;
     value: number;
 }
-declare type OpenOutput = Output | BlankOutput;
 export interface Input {
     hash: Buffer;
     index: number;
@@ -28,7 +23,7 @@ export declare class Transaction {
     version: number;
     locktime: number;
     ins: Input[];
-    outs: OpenOutput[];
+    outs: Output[];
     isCoinbase(): boolean;
     addInput(hash: Buffer, index: number, sequence?: number, scriptSig?: Buffer): number;
     addOutput(scriptPubKey: Buffer, value: number): number;
@@ -56,4 +51,3 @@ export declare class Transaction {
     private __byteLength;
     private __toBuffer;
 }
-export {};


### PR DESCRIPTION
- Fix https://github.com/bitcoinjs/bitcoinjs-lib/issues/1505
Accessing property in union of object types fails for properties not defined on all union members.

- Solution:
  Add optional types for each union member https://github.com/microsoft/TypeScript/issues/12815
