### PR TITLE
Add weight and ability to get strippedsize

### DIFF
--- a/src/block.js
+++ b/src/block.js
@@ -127,12 +127,18 @@ class Block {
   hasWitness() {
     return anyTxHasWitness(this.transactions);
   }
-  byteLength(headersOnly) {
+  weight() {
+    const base = this.byteLength(false, false);
+    const total = this.byteLength(false, true);
+    return base * 3 + total;
+  }
+  byteLength(headersOnly, allowWitness = true) {
     if (headersOnly || !this.transactions) return 80;
     return (
       80 +
       varuint.encodingLength(this.transactions.length) +
-      this.transactions.reduce((a, x) => a + x.byteLength(), 0)
+      // @ts-ignore using the __byteLength private method on Transaction
+      this.transactions.reduce((a, x) => a + x.__byteLength(allowWitness), 0)
     );
   }
   getHash() {

--- a/src/block.js
+++ b/src/block.js
@@ -137,8 +137,7 @@ class Block {
     return (
       80 +
       varuint.encodingLength(this.transactions.length) +
-      // @ts-ignore using the __byteLength private method on Transaction
-      this.transactions.reduce((a, x) => a + x.__byteLength(allowWitness), 0)
+      this.transactions.reduce((a, x) => a + x.byteLength(allowWitness), 0)
     );
   }
   getHash() {

--- a/test/block.spec.ts
+++ b/test/block.spec.ts
@@ -48,6 +48,11 @@ describe('Block', () => {
         assert.strictEqual(block.bits, f.bits);
         assert.strictEqual(block.nonce, f.nonce);
         assert.strictEqual(!block.transactions, f.hex.length === 160);
+        if (f.size && f.strippedSize && f.weight) {
+          assert.strictEqual(block.byteLength(false, true), f.size);
+          assert.strictEqual(block.byteLength(false, false), f.strippedSize);
+          assert.strictEqual(block.weight(), f.weight);
+        }
       });
     });
 

--- a/test/fixtures/block.json
+++ b/test/fixtures/block.json
@@ -133,7 +133,10 @@
       "prevHash": "8980ebb11236bacc66c447d5ad961bc546c0f9cc385a08000000000000000000",
       "timestamp": 1537429727,
       "valid": true,
-      "version": 536870912
+      "version": 536870912,
+      "size": 2355,
+      "strippedSize": 2209,
+      "weight": 8982
     }
   ],
   "invalid": [

--- a/ts_src/block.ts
+++ b/ts_src/block.ts
@@ -148,13 +148,20 @@ export class Block {
     return anyTxHasWitness(this.transactions!);
   }
 
-  byteLength(headersOnly?: boolean): number {
+  weight(): number {
+    const base = this.byteLength(false, false);
+    const total = this.byteLength(false, true);
+    return base * 3 + total;
+  }
+
+  byteLength(headersOnly?: boolean, allowWitness: boolean = true): number {
     if (headersOnly || !this.transactions) return 80;
 
     return (
       80 +
       varuint.encodingLength(this.transactions.length) +
-      this.transactions.reduce((a, x) => a + x.byteLength(), 0)
+      // @ts-ignore using the __byteLength private method on Transaction
+      this.transactions.reduce((a, x) => a + x.__byteLength(allowWitness), 0)
     );
   }
 

--- a/ts_src/block.ts
+++ b/ts_src/block.ts
@@ -160,8 +160,7 @@ export class Block {
     return (
       80 +
       varuint.encodingLength(this.transactions.length) +
-      // @ts-ignore using the __byteLength private method on Transaction
-      this.transactions.reduce((a, x) => a + x.__byteLength(allowWitness), 0)
+      this.transactions.reduce((a, x) => a + x.byteLength(allowWitness), 0)
     );
   }
 

--- a/types/block.d.ts
+++ b/types/block.d.ts
@@ -15,7 +15,8 @@ export declare class Block {
     getWitnessCommit(): Buffer | null;
     hasWitnessCommit(): boolean;
     hasWitness(): boolean;
-    byteLength(headersOnly?: boolean): number;
+    weight(): number;
+    byteLength(headersOnly?: boolean, allowWitness?: boolean): number;
     getHash(): Buffer;
     getId(): string;
     getUTCDate(): Date;

--- a/types/transaction.d.ts
+++ b/types/transaction.d.ts
@@ -30,7 +30,7 @@ export declare class Transaction {
     hasWitnesses(): boolean;
     weight(): number;
     virtualSize(): number;
-    byteLength(): number;
+    byteLength(_ALLOW_WITNESS?: boolean): number;
     clone(): Transaction;
     /**
      * Hash transaction for signing a specific input.
@@ -48,6 +48,5 @@ export declare class Transaction {
     toHex(): string;
     setInputScript(index: number, scriptSig: Buffer): void;
     setWitness(index: number, witness: Buffer[]): void;
-    private __byteLength;
     private __toBuffer;
 }


### PR DESCRIPTION
The issue #1509 brought to light that we had no method to get the weight of a Block.

Some questions to ponder:

1. Using Transaction private method is bad.
2. Maybe we should also create a private __byteLength in Block too?
3. Should we (and if so, how?) add examples about gathering info about blocks using our Block class? (The integration test only has one example, and it's not too useful.)