### PR TITLE
Add "no user generated mnemonics" explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We are not an authorative source of best practice, but, at the very least:
 * Don't share BIP32 extended public keys ('xpubs'). [They are a liability](https://bitcoin.stackexchange.com/questions/56916/derivation-of-parent-private-key-from-non-hardened-child), and it only takes 1 misplaced private key (or a buggy implementation!) and you are vulnerable to **catastrophic fund loss**.
 * [Don't use `Math.random`](https://security.stackexchange.com/questions/181580/why-is-math-random-not-designed-to-be-cryptographically-secure) - in any way - don't.
 * Enforce that users always verify (manually) a freshly-decoded human-readable version of their intended transaction before broadcast.
-* Don't *ask* users to generate mnemonics, or 'brain wallets',  humans are terrible random number generators.
+* [Don't *ask* users to generate mnemonics](https://en.bitcoin.it/wiki/Brainwallet#cite_note-1), or 'brain wallets',  humans are terrible random number generators.
 * Lastly, if you can, use [Typescript](https://www.typescriptlang.org/) or similar.
 
 


### PR DESCRIPTION
Almost every dot in the paragraph has an explanation. I thought it was useful to stress the importance of the topic for security reasons.