### PR TITLE
PSBT internal transaction property getters

### DIFF
--- a/src/bufferutils.js
+++ b/src/bufferutils.js
@@ -41,6 +41,12 @@ function reverseBuffer(buffer) {
   return buffer;
 }
 exports.reverseBuffer = reverseBuffer;
+function cloneBuffer(buffer) {
+  const clone = Buffer.alloc(buffer.length);
+  buffer.copy(clone);
+  return buffer;
+}
+exports.cloneBuffer = cloneBuffer;
 /**
  * Helper class for serialization of bitcoin data types into a pre-allocated buffer.
  */

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -100,8 +100,14 @@ class Psbt {
   get version() {
     return this.__CACHE.__TX.version;
   }
+  set version(version) {
+    this.setVersion(version);
+  }
   get locktime() {
     return this.__CACHE.__TX.locktime;
+  }
+  set locktime(locktime) {
+    this.setLocktime(locktime);
   }
   get inputs() {
     return this.__CACHE.__TX.ins.map(input => ({

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -115,7 +115,6 @@ class Psbt {
       index: input.index,
       script: bufferutils_1.cloneBuffer(input.script),
       sequence: input.sequence,
-      witness: input.witness.map(buffer => bufferutils_1.cloneBuffer(buffer)),
     }));
   }
   get txOutputs() {

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -109,7 +109,7 @@ class Psbt {
   set locktime(locktime) {
     this.setLocktime(locktime);
   }
-  get inputs() {
+  get txInputs() {
     return this.__CACHE.__TX.ins.map(input => ({
       hash: bufferutils_1.cloneBuffer(input.hash),
       index: input.index,
@@ -118,7 +118,7 @@ class Psbt {
       witness: input.witness.map(buffer => bufferutils_1.cloneBuffer(buffer)),
     }));
   }
-  get outputs() {
+  get txOutputs() {
     return this.__CACHE.__TX.outs.map(output => ({
       script: bufferutils_1.cloneBuffer(output.script),
       value: output.value,

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -104,10 +104,23 @@ class Psbt {
     return this.__CACHE.__TX.locktime;
   }
   get txInputs() {
-    return deepClone(this.__CACHE.__TX.ins);
+    return this.__CACHE.__TX.ins.map(input => {
+      return {
+        hash: bufferutils_1.cloneBuffer(input.hash),
+        index: input.index,
+        script: bufferutils_1.cloneBuffer(input.script),
+        sequence: input.sequence,
+        witness: input.witness.map(buffer => bufferutils_1.cloneBuffer(buffer)),
+      };
+    });
   }
   get txOutputs() {
-    return deepClone(this.__CACHE.__TX.outs);
+    return this.__CACHE.__TX.outs.map(output => {
+      return {
+        script: bufferutils_1.cloneBuffer(output.script),
+        value: output.value,
+      };
+    });
   }
   combine(...those) {
     this.data.combine(...those.map(o => o.data));
@@ -590,11 +603,6 @@ class PsbtTransaction {
   toBuffer() {
     return this.tx.toBuffer();
   }
-}
-function deepClone(obj) {
-  return JSON.parse(JSON.stringify(obj), (_, value) =>
-    value.type === 'Buffer' ? Buffer.from(value.data) : value,
-  );
 }
 function canFinalize(input, script, scriptType) {
   switch (scriptType) {

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -97,13 +97,13 @@ class Psbt {
   get inputCount() {
     return this.data.inputs.length;
   }
-  get txVersion() {
+  get version() {
     return this.__CACHE.__TX.version;
   }
-  get txLocktime() {
+  get locktime() {
     return this.__CACHE.__TX.locktime;
   }
-  get txInputs() {
+  get inputs() {
     return this.__CACHE.__TX.ins.map(input => {
       return {
         hash: bufferutils_1.cloneBuffer(input.hash),
@@ -114,7 +114,7 @@ class Psbt {
       };
     });
   }
-  get txOutputs() {
+  get outputs() {
     return this.__CACHE.__TX.outs.map(output => {
       return {
         script: bufferutils_1.cloneBuffer(output.script),

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -113,7 +113,6 @@ class Psbt {
     return this.__CACHE.__TX.ins.map(input => ({
       hash: bufferutils_1.cloneBuffer(input.hash),
       index: input.index,
-      script: bufferutils_1.cloneBuffer(input.script),
       sequence: input.sequence,
     }));
   }

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -97,6 +97,18 @@ class Psbt {
   get inputCount() {
     return this.data.inputs.length;
   }
+  get txVersion() {
+    return this.__CACHE.__TX.version;
+  }
+  get txLocktime() {
+    return this.__CACHE.__TX.locktime;
+  }
+  get txInputs() {
+    return deepClone(this.__CACHE.__TX.ins);
+  }
+  get txOutputs() {
+    return deepClone(this.__CACHE.__TX.outs);
+  }
   combine(...those) {
     this.data.combine(...those.map(o => o.data));
     return this;
@@ -578,6 +590,11 @@ class PsbtTransaction {
   toBuffer() {
     return this.tx.toBuffer();
   }
+}
+function deepClone(obj) {
+  return JSON.parse(JSON.stringify(obj), (_, value) =>
+    value.type === 'Buffer' ? Buffer.from(value.data) : value,
+  );
 }
 function canFinalize(input, script, scriptType) {
   switch (scriptType) {

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -104,23 +104,19 @@ class Psbt {
     return this.__CACHE.__TX.locktime;
   }
   get inputs() {
-    return this.__CACHE.__TX.ins.map(input => {
-      return {
-        hash: bufferutils_1.cloneBuffer(input.hash),
-        index: input.index,
-        script: bufferutils_1.cloneBuffer(input.script),
-        sequence: input.sequence,
-        witness: input.witness.map(buffer => bufferutils_1.cloneBuffer(buffer)),
-      };
-    });
+    return this.__CACHE.__TX.ins.map(input => ({
+      hash: bufferutils_1.cloneBuffer(input.hash),
+      index: input.index,
+      script: bufferutils_1.cloneBuffer(input.script),
+      sequence: input.sequence,
+      witness: input.witness.map(buffer => bufferutils_1.cloneBuffer(buffer)),
+    }));
   }
   get outputs() {
-    return this.__CACHE.__TX.outs.map(output => {
-      return {
-        script: bufferutils_1.cloneBuffer(output.script),
-        value: output.value,
-      };
-    });
+    return this.__CACHE.__TX.outs.map(output => ({
+      script: bufferutils_1.cloneBuffer(output.script),
+      value: output.value,
+    }));
   }
   combine(...those) {
     this.data.combine(...those.map(o => o.data));

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -122,6 +122,7 @@ class Psbt {
     return this.__CACHE.__TX.outs.map(output => ({
       script: bufferutils_1.cloneBuffer(output.script),
       value: output.value,
+      address: address_1.fromOutputScript(output.script, this.opts.network),
     }));
   }
   combine(...those) {

--- a/test/psbt.spec.ts
+++ b/test/psbt.spec.ts
@@ -523,12 +523,9 @@ describe(`Psbt`, () => {
       });
 
       assert.strictEqual(psbt.inputCount, 1);
-      assert.strictEqual(
-        (psbt as any).__CACHE.__TX.ins[0].sequence,
-        0xffffffff,
-      );
+      assert.strictEqual(psbt.txInputs[0].sequence, 0xffffffff);
       psbt.setInputSequence(0, 0);
-      assert.strictEqual((psbt as any).__CACHE.__TX.ins[0].sequence, 0);
+      assert.strictEqual(psbt.txInputs[0].sequence, 0);
     });
 
     it('throws if input index is too high', () => {

--- a/test/psbt.spec.ts
+++ b/test/psbt.spec.ts
@@ -523,9 +523,9 @@ describe(`Psbt`, () => {
       });
 
       assert.strictEqual(psbt.inputCount, 1);
-      assert.strictEqual(psbt.txInputs[0].sequence, 0xffffffff);
+      assert.strictEqual(psbt.inputs[0].sequence, 0xffffffff);
       psbt.setInputSequence(0, 0);
-      assert.strictEqual(psbt.txInputs[0].sequence, 0);
+      assert.strictEqual(psbt.inputs[0].sequence, 0);
     });
 
     it('throws if input index is too high', () => {

--- a/test/psbt.spec.ts
+++ b/test/psbt.spec.ts
@@ -523,9 +523,9 @@ describe(`Psbt`, () => {
       });
 
       assert.strictEqual(psbt.inputCount, 1);
-      assert.strictEqual(psbt.inputs[0].sequence, 0xffffffff);
+      assert.strictEqual(psbt.txInputs[0].sequence, 0xffffffff);
       psbt.setInputSequence(0, 0);
-      assert.strictEqual(psbt.inputs[0].sequence, 0);
+      assert.strictEqual(psbt.txInputs[0].sequence, 0);
     });
 
     it('throws if input index is too high', () => {

--- a/ts_src/bufferutils.ts
+++ b/ts_src/bufferutils.ts
@@ -48,6 +48,12 @@ export function reverseBuffer(buffer: Buffer): Buffer {
   return buffer;
 }
 
+export function cloneBuffer(buffer: Buffer): Buffer {
+  const clone = Buffer.alloc(buffer.length);
+  buffer.copy(clone);
+  return buffer;
+}
+
 /**
  * Helper class for serialization of bitcoin data types into a pre-allocated buffer.
  */

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -11,6 +11,7 @@ import {
   Transaction as ITransaction,
   TransactionFromBuffer,
   TransactionInput,
+  TransactionOutput,
 } from 'bip174/src/lib/interfaces';
 import { checkForInput } from 'bip174/src/lib/utils';
 import { fromOutputScript, toOutputScript } from './address';
@@ -24,7 +25,7 @@ import {
 import { bitcoin as btcNetwork, Network } from './networks';
 import * as payments from './payments';
 import * as bscript from './script';
-import { Input, Output, Transaction } from './transaction';
+import { Output, Transaction } from './transaction';
 
 /**
  * These are the default arguments for a Psbt instance.
@@ -145,17 +146,16 @@ export class Psbt {
     this.setLocktime(locktime);
   }
 
-  get txInputs(): Input[] {
+  get txInputs(): TransactionInput[] {
     return this.__CACHE.__TX.ins.map(input => ({
       hash: cloneBuffer(input.hash),
       index: input.index,
       script: cloneBuffer(input.script),
       sequence: input.sequence,
-      witness: input.witness.map(buffer => cloneBuffer(buffer)),
     }));
   }
 
-  get txOutputs(): Output[] {
+  get txOutputs(): TransactionOutput[] {
     return this.__CACHE.__TX.outs.map(output => ({
       script: cloneBuffer(output.script),
       value: output.value,

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -150,7 +150,6 @@ export class Psbt {
     return this.__CACHE.__TX.ins.map(input => ({
       hash: cloneBuffer(input.hash),
       index: input.index,
-      script: cloneBuffer(input.script),
       sequence: input.sequence,
     }));
   }

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -13,7 +13,7 @@ import {
   TransactionInput,
 } from 'bip174/src/lib/interfaces';
 import { checkForInput } from 'bip174/src/lib/utils';
-import { toOutputScript } from './address';
+import { fromOutputScript, toOutputScript } from './address';
 import { cloneBuffer, reverseBuffer } from './bufferutils';
 import { hash160 } from './crypto';
 import {
@@ -159,6 +159,7 @@ export class Psbt {
     return this.__CACHE.__TX.outs.map(output => ({
       script: cloneBuffer(output.script),
       value: output.value,
+      address: fromOutputScript(output.script, this.opts.network),
     }));
   }
 

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -133,8 +133,16 @@ export class Psbt {
     return this.__CACHE.__TX.version;
   }
 
+  set version(version: number) {
+    this.setVersion(version);
+  }
+
   get locktime(): number {
     return this.__CACHE.__TX.locktime;
+  }
+
+  set locktime(locktime: number) {
+    this.setLocktime(locktime);
   }
 
   get inputs(): Input[] {

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -129,6 +129,22 @@ export class Psbt {
     return this.data.inputs.length;
   }
 
+  get txVersion(): number {
+    return this.__CACHE.__TX.version;
+  }
+
+  get txLocktime(): number {
+    return this.__CACHE.__TX.locktime;
+  }
+
+  get txInputs(): TransactionInput[] {
+    return deepClone(this.__CACHE.__TX.ins);
+  }
+
+  get txOutputs(): TransactionInput[] {
+    return deepClone(this.__CACHE.__TX.outs);
+  }
+
   combine(...those: Psbt[]): this {
     this.data.combine(...those.map(o => o.data));
     return this;
@@ -755,6 +771,12 @@ class PsbtTransaction implements ITransaction {
   toBuffer(): Buffer {
     return this.tx.toBuffer();
   }
+}
+
+function deepClone(obj: any): any {
+  return JSON.parse(JSON.stringify(obj), (_, value) =>
+    value.type === 'Buffer' ? Buffer.from(value.data) : value,
+  );
 }
 
 function canFinalize(

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -145,7 +145,7 @@ export class Psbt {
     this.setLocktime(locktime);
   }
 
-  get inputs(): Input[] {
+  get txInputs(): Input[] {
     return this.__CACHE.__TX.ins.map(input => ({
       hash: cloneBuffer(input.hash),
       index: input.index,
@@ -155,7 +155,7 @@ export class Psbt {
     }));
   }
 
-  get outputs(): Output[] {
+  get txOutputs(): Output[] {
     return this.__CACHE.__TX.outs.map(output => ({
       script: cloneBuffer(output.script),
       value: output.value,

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -129,15 +129,15 @@ export class Psbt {
     return this.data.inputs.length;
   }
 
-  get txVersion(): number {
+  get version(): number {
     return this.__CACHE.__TX.version;
   }
 
-  get txLocktime(): number {
+  get locktime(): number {
     return this.__CACHE.__TX.locktime;
   }
 
-  get txInputs(): Input[] {
+  get inputs(): Input[] {
     return this.__CACHE.__TX.ins.map(input => {
       return {
         hash: cloneBuffer(input.hash),
@@ -149,7 +149,7 @@ export class Psbt {
     });
   }
 
-  get txOutputs(): Output[] {
+  get outputs(): Output[] {
     return this.__CACHE.__TX.outs.map(output => {
       return {
         script: cloneBuffer(output.script),

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -138,24 +138,20 @@ export class Psbt {
   }
 
   get inputs(): Input[] {
-    return this.__CACHE.__TX.ins.map(input => {
-      return {
-        hash: cloneBuffer(input.hash),
-        index: input.index,
-        script: cloneBuffer(input.script),
-        sequence: input.sequence,
-        witness: input.witness.map(buffer => cloneBuffer(buffer)),
-      };
-    });
+    return this.__CACHE.__TX.ins.map(input => ({
+      hash: cloneBuffer(input.hash),
+      index: input.index,
+      script: cloneBuffer(input.script),
+      sequence: input.sequence,
+      witness: input.witness.map(buffer => cloneBuffer(buffer)),
+    }));
   }
 
   get outputs(): Output[] {
-    return this.__CACHE.__TX.outs.map(output => {
-      return {
-        script: cloneBuffer(output.script),
-        value: output.value,
-      };
-    });
+    return this.__CACHE.__TX.outs.map(output => ({
+      script: cloneBuffer(output.script),
+      value: output.value,
+    }));
   }
 
   combine(...those: Psbt[]): this {

--- a/types/bufferutils.d.ts
+++ b/types/bufferutils.d.ts
@@ -1,6 +1,7 @@
 export declare function readUInt64LE(buffer: Buffer, offset: number): number;
 export declare function writeUInt64LE(buffer: Buffer, value: number, offset: number): number;
 export declare function reverseBuffer(buffer: Buffer): Buffer;
+export declare function cloneBuffer(buffer: Buffer): Buffer;
 /**
  * Helper class for serialization of bitcoin data types into a pre-allocated buffer.
  */

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -44,6 +44,10 @@ export declare class Psbt {
     private opts;
     constructor(opts?: PsbtOptsOptional, data?: PsbtBase);
     readonly inputCount: number;
+    readonly txVersion: number;
+    readonly txLocktime: number;
+    readonly txInputs: TransactionInput[];
+    readonly txOutputs: TransactionInput[];
     combine(...those: Psbt[]): this;
     clone(): Psbt;
     setMaximumFeeRate(satoshiPerByte: number): void;

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -2,7 +2,7 @@ import { Psbt as PsbtBase } from 'bip174';
 import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput } from 'bip174/src/lib/interfaces';
 import { Signer, SignerAsync } from './ecpair';
 import { Network } from './networks';
-import { Transaction } from './transaction';
+import { Input, Output, Transaction } from './transaction';
 /**
  * Psbt class can parse and generate a PSBT binary based off of the BIP174.
  * There are 6 roles that this class fulfills. (Explained in BIP174)
@@ -46,8 +46,8 @@ export declare class Psbt {
     readonly inputCount: number;
     readonly txVersion: number;
     readonly txLocktime: number;
-    readonly txInputs: TransactionInput[];
-    readonly txOutputs: TransactionInput[];
+    readonly txInputs: Input[];
+    readonly txOutputs: Output[];
     combine(...those: Psbt[]): this;
     clone(): Psbt;
     setMaximumFeeRate(satoshiPerByte: number): void;

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -44,10 +44,10 @@ export declare class Psbt {
     private opts;
     constructor(opts?: PsbtOptsOptional, data?: PsbtBase);
     readonly inputCount: number;
-    readonly txVersion: number;
-    readonly txLocktime: number;
-    readonly txInputs: Input[];
-    readonly txOutputs: Output[];
+    readonly version: number;
+    readonly locktime: number;
+    readonly inputs: Input[];
+    readonly outputs: Output[];
     combine(...those: Psbt[]): this;
     clone(): Psbt;
     setMaximumFeeRate(satoshiPerByte: number): void;

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -44,8 +44,8 @@ export declare class Psbt {
     private opts;
     constructor(opts?: PsbtOptsOptional, data?: PsbtBase);
     readonly inputCount: number;
-    readonly version: number;
-    readonly locktime: number;
+    version: number;
+    locktime: number;
     readonly inputs: Input[];
     readonly outputs: Output[];
     combine(...those: Psbt[]): this;

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -46,8 +46,8 @@ export declare class Psbt {
     readonly inputCount: number;
     version: number;
     locktime: number;
-    readonly inputs: Input[];
-    readonly outputs: Output[];
+    readonly txInputs: Input[];
+    readonly txOutputs: Output[];
     combine(...those: Psbt[]): this;
     clone(): Psbt;
     setMaximumFeeRate(satoshiPerByte: number): void;

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -1,8 +1,8 @@
 import { Psbt as PsbtBase } from 'bip174';
-import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput } from 'bip174/src/lib/interfaces';
+import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput, TransactionOutput } from 'bip174/src/lib/interfaces';
 import { Signer, SignerAsync } from './ecpair';
 import { Network } from './networks';
-import { Input, Output, Transaction } from './transaction';
+import { Transaction } from './transaction';
 /**
  * Psbt class can parse and generate a PSBT binary based off of the BIP174.
  * There are 6 roles that this class fulfills. (Explained in BIP174)
@@ -46,8 +46,8 @@ export declare class Psbt {
     readonly inputCount: number;
     version: number;
     locktime: number;
-    readonly txInputs: Input[];
-    readonly txOutputs: Output[];
+    readonly txInputs: TransactionInput[];
+    readonly txOutputs: TransactionOutput[];
     combine(...those: Psbt[]): this;
     clone(): Psbt;
     setMaximumFeeRate(satoshiPerByte: number): void;


### PR DESCRIPTION
This PR exposes some properties of the transaction internal to the PSBT in a readonly way that prevents mutation.

```js
const psbt = bitcoin.Psbt.fromBase64("cHNidP8BAFUCAAAAASeaIyOl37UfxF8iD6WLD8E+HjNCeSqF1+Ns1jM7XLw5AAAAAAD/////AaBa6gsAAAAAGXapFP/pwAYQl8w7Y28ssEYPpPxCfStFiKwAAAAAAAEBIJVe6gsAAAAAF6kUY0UgD2jRieGtwN8cTRbqjxTA2+uHIgIDsTQcy6doO2r08SOM1ul+cWfVafrEfx5I1HVBhENVvUZGMEMCIAQktY7/qqaU4VWepck7v9SokGQiQFXN8HC2dxRpRC0HAh9cjrD+plFtYLisszrWTt5g6Hhb+zqpS5m9+GFR25qaAQEEIgAgdx/RitRZZm3Unz1WTj28QvTIR3TjYK2haBao7UiNVoEBBUdSIQOxNBzLp2g7avTxI4zW6X5xZ9Vp+sR/HkjUdUGEQ1W9RiED3lXR4drIBeP4pYwfv5uUwC89uq/hJ/78pJlfJvggg71SriIGA7E0HMunaDtq9PEjjNbpfnFn1Wn6xH8eSNR1QYRDVb1GELSmumcAAACAAAAAgAQAAIAiBgPeVdHh2sgF4/iljB+/m5TALz26r+En/vykmV8m+CCDvRC0prpnAAAAgAAAAIAFAACAAAA=");

psbt.version
// 2
psbt.locktime
// 0
psbt.inputs
// [
//   {
//     hash: <Buffer 27 9a 23 23 a5 df b5 1f c4 5f 22 0f a5 8b 0f c1 3e 1e 33 42 79 2a 85 d7 e3 6c d6 33 3b 5c bc 39>,
//     index: 0,
//     script: <Buffer >,
//     sequence: 4294967295,
//     witness: []
//   }
// ]
psbt.outputs
// [
//   {
//     script: <Buffer 76 a9 14 ff e9 c0 06 10 97 cc 3b 63 6f 2c b0 46 0f a4 fc // 42 7d 2b 45 88 ac>,
//     value: 199908000
//   }
// ]
```

One issue is that it's a little confusing that we now have two sets of `inputs`/`outputs` arrays. One for the PSBT data and one for the internal transaction data:

```js
psbt.inputs
// [
//   {
//     hash: <Buffer 27 9a 23 23 a5 df b5 1f c4 5f 22 0f a5 8b 0f c1 3e 1e 33 42 79 2a 85 d7 e3 6c d6 33 3b 5c bc 39>,
//     index: 0,
//     script: <Buffer >,
//     sequence: 4294967295,
//     witness: []
//   }
// ]
psbt.data.inputs
// [
//   {
//     witnessUtxo: {
//       script: <Buffer a9 14 63 45 20 0f 68 d1 89 e1 ad c0 df 1c 4d 16 ea 8f 14 c0 db eb 87>,
//       value: 199909013
//     },
//     partialSig: [ [Object] ],
//     redeemScript: <Buffer 00 20 77 1f d1 8a d4 59 66 6d d4 9f 3d 56 4e 3d bc 42 f4 c8 47 74 e3 60 ad a1 68 16 a8 ed 48 8d 56 81>,
//     witnessScript: <Buffer 52 21 03 b1 34 1c cb a7 68 3b 6a f4 f1 23 8c d6 e9 7e 71 67 d5 69 fa c4 7f 1e 48 d4 75 41 84 43 55 bd 46 21 03 de 55 d1 e1 da c8 05 e3 f8 a5 8c 1f bf ... 21 more bytes>,
//     bip32Derivation: [ [Object], [Object] ]
//   }
// ]
```

Maybe that's ok or maybe we should call it `psbt.txInputs` to make it a little clearer?