### PR TITLE
Throw errors when p2wsh or p2wpkh contain uncompressed pubkeys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 5.1.8
+__fixed__
+- Throw errors when p2wsh or p2wpkh contain uncompressed pubkeys (#1573)
+
+__added__
+- Add txInputs and txOutputs for Psbt (#1561)
+
+__changed__
+- (Not exposed) Added BufferWriter to help ease maintenance of certain forks of this library (#1533)
+
 # 5.1.7
 __fixed__
 - Fixed Transaction class Output interface typing for TypeScript (#1506)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "types": "./types/index.d.ts",

--- a/src/payments/p2wpkh.js
+++ b/src/payments/p2wpkh.js
@@ -107,12 +107,14 @@ function p2wpkh(a, opts) {
       if (hash.length > 0 && !hash.equals(pkh))
         throw new TypeError('Hash mismatch');
       else hash = pkh;
+      if (!ecc.isPoint(a.pubkey) || a.pubkey.length !== 33)
+        throw new TypeError('Invalid pubkey for p2wpkh');
     }
     if (a.witness) {
       if (a.witness.length !== 2) throw new TypeError('Witness is invalid');
       if (!bscript.isCanonicalScriptSignature(a.witness[0]))
         throw new TypeError('Witness has invalid signature');
-      if (!ecc.isPoint(a.witness[1]))
+      if (!ecc.isPoint(a.witness[1]) || a.witness[1].length !== 33)
         throw new TypeError('Witness has invalid pubkey');
       if (a.signature && !a.signature.equals(a.witness[0]))
         throw new TypeError('Signature mismatch');

--- a/test/fixtures/p2wpkh.json
+++ b/test/fixtures/p2wpkh.json
@@ -114,6 +114,23 @@
       }
     },
     {
+      "exception": "Invalid pubkey for p2wpkh",
+      "description": "Uncompressed pubkey in pubkey",
+      "arguments": {
+        "pubkey": "049fa211b0fca342589ca381cc96520c3d0e3924832158d9f29891936cac091e80687acdca51868ee1f89a3bb36bb16f186262938e1f94c1e7692924935b9b1457"
+      }
+    },
+    {
+      "exception": "Witness has invalid pubkey",
+      "description": "Uncompressed pubkey in witness",
+      "arguments": {
+        "witness": [
+          "300602010002010001",
+          "049fa211b0fca342589ca381cc96520c3d0e3924832158d9f29891936cac091e80687acdca51868ee1f89a3bb36bb16f186262938e1f94c1e7692924935b9b1457"
+        ]
+      }
+    },
+    {
       "exception": "Pubkey mismatch",
       "options": {},
       "arguments": {

--- a/test/fixtures/p2wsh.json
+++ b/test/fixtures/p2wsh.json
@@ -345,6 +345,30 @@
       }
     },
     {
+      "exception": "redeem.input or redeem.output contains uncompressed pubkey",
+      "arguments": {
+        "redeem": {
+          "output": "049fa211b0fca342589ca381cc96520c3d0e3924832158d9f29891936cac091e80687acdca51868ee1f89a3bb36bb16f186262938e1f94c1e7692924935b9b1457 OP_CHECKSIG"
+        }
+      }
+    },
+    {
+      "exception": "redeem.input or redeem.output contains uncompressed pubkey",
+      "arguments": {
+        "redeem": {
+          "input": "049fa211b0fca342589ca381cc96520c3d0e3924832158d9f29891936cac091e80687acdca51868ee1f89a3bb36bb16f186262938e1f94c1e7692924935b9b1457"
+        }
+      }
+    },
+    {
+      "exception": "Witness contains uncompressed pubkey",
+      "arguments": {
+        "witness": [
+          "049fa211b0fca342589ca381cc96520c3d0e3924832158d9f29891936cac091e80687acdca51868ee1f89a3bb36bb16f186262938e1f94c1e7692924935b9b1457"
+        ]
+      }
+    },
+    {
       "exception": "Invalid prefix or Network mismatch",
       "arguments": {
         "address": "foo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs30dvv"

--- a/test/fixtures/transaction_builder.json
+++ b/test/fixtures/transaction_builder.json
@@ -2122,7 +2122,7 @@
       },
       {
         "description": "Transaction w/ P2WSH(P2PK), signing with uncompressed public key",
-        "exception": "BIP143 rejects uncompressed public keys in P2WPKH or P2WSH",
+        "exception": "redeem.input or redeem.output contains uncompressed pubkey",
         "inputs": [
           {
             "txId": "2fddebc1a7e67e04fc6b77645ae9ae10eeaa35e168606587d79b031ebca33345",
@@ -2148,7 +2148,7 @@
       },
       {
         "description": "Transaction w/ P2SH(P2WSH(P2PK)), signing with uncompressed public key",
-        "exception": "BIP143 rejects uncompressed public keys in P2WPKH or P2WSH",
+        "exception": "redeem.input or redeem.output contains uncompressed pubkey",
         "inputs": [
           {
             "txId": "2fddebc1a7e67e04fc6b77645ae9ae10eeaa35e168606587d79b031ebca33345",

--- a/ts_src/payments/p2wpkh.ts
+++ b/ts_src/payments/p2wpkh.ts
@@ -118,13 +118,15 @@ export function p2wpkh(a: Payment, opts?: PaymentOpts): Payment {
       if (hash.length > 0 && !hash.equals(pkh))
         throw new TypeError('Hash mismatch');
       else hash = pkh;
+      if (!ecc.isPoint(a.pubkey) || a.pubkey.length !== 33)
+        throw new TypeError('Invalid pubkey for p2wpkh');
     }
 
     if (a.witness) {
       if (a.witness.length !== 2) throw new TypeError('Witness is invalid');
       if (!bscript.isCanonicalScriptSignature(a.witness[0]))
         throw new TypeError('Witness has invalid signature');
-      if (!ecc.isPoint(a.witness[1]))
+      if (!ecc.isPoint(a.witness[1]) || a.witness[1].length !== 33)
         throw new TypeError('Witness has invalid pubkey');
 
       if (a.signature && !a.signature.equals(a.witness[0]))

--- a/ts_src/payments/p2wsh.ts
+++ b/ts_src/payments/p2wsh.ts
@@ -1,10 +1,11 @@
 import * as bcrypto from '../crypto';
 import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as bscript from '../script';
-import { Payment, PaymentOpts, StackFunction } from './index';
+import { Payment, PaymentOpts, StackElement, StackFunction } from './index';
 import * as lazy from './lazy';
 const typef = require('typeforce');
 const OPS = bscript.OPS;
+const ecc = require('tiny-secp256k1');
 
 const bech32 = require('bech32');
 
@@ -16,6 +17,15 @@ function stacksEqual(a: Buffer[], b: Buffer[]): boolean {
   return a.every((x, i) => {
     return x.equals(b[i]);
   });
+}
+
+function chunkHasUncompressedPubkey(chunk: StackElement): boolean {
+  if (Buffer.isBuffer(chunk) && chunk.length === 65) {
+    if (ecc.isPoint(chunk)) return true;
+    else return false;
+  } else {
+    return false;
+  }
 }
 
 // input: <>
@@ -58,6 +68,9 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
   });
   const _rchunks = lazy.value(() => {
     return bscript.decompile(a.redeem!.input!);
+  }) as StackFunction;
+  const _rochunks = lazy.value(() => {
+    return bscript.decompile(a.redeem!.output!);
   }) as StackFunction;
 
   let network = a.network;
@@ -187,15 +200,25 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
         !stacksEqual(a.witness, a.redeem.witness)
       )
         throw new TypeError('Witness and redeem.witness mismatch');
+      if (
+        (a.redeem.input && _rchunks().some(chunkHasUncompressedPubkey)) ||
+        (a.redeem.output && _rochunks().some(chunkHasUncompressedPubkey))
+      ) {
+        throw new TypeError(
+          'redeem.input or redeem.output contains uncompressed pubkey',
+        );
+      }
     }
 
-    if (a.witness) {
-      if (
-        a.redeem &&
-        a.redeem.output &&
-        !a.redeem.output.equals(a.witness[a.witness.length - 1])
-      )
+    if (a.witness && a.witness.length > 0) {
+      const wScript = a.witness[a.witness.length - 1];
+      if (a.redeem && a.redeem.output && !a.redeem.output.equals(wScript))
         throw new TypeError('Witness and redeem.output mismatch');
+      if (
+        a.witness.some(chunkHasUncompressedPubkey) ||
+        (bscript.decompile(wScript) || []).some(chunkHasUncompressedPubkey)
+      )
+        throw new TypeError('Witness contains uncompressed pubkey');
     }
   }
 


### PR DESCRIPTION
This will enforce BIP143 compressed pubkey rules on an address generation level.

Fixes #1572