### PR TITLE
Handle non-standard output types in Psbt.txOutputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.9
+__fixed__
+- Fixed errors for psbt.txOutputs getter (#1578)
+
 # 5.1.8
 __fixed__
 - Throw errors when p2wsh or p2wpkh contain uncompressed pubkeys (#1573)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "types": "./types/index.d.ts",

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -117,11 +117,17 @@ class Psbt {
     }));
   }
   get txOutputs() {
-    return this.__CACHE.__TX.outs.map(output => ({
-      script: bufferutils_1.cloneBuffer(output.script),
-      value: output.value,
-      address: address_1.fromOutputScript(output.script, this.opts.network),
-    }));
+    return this.__CACHE.__TX.outs.map(output => {
+      let address;
+      try {
+        address = address_1.fromOutputScript(output.script, this.opts.network);
+      } catch (_) {}
+      return {
+        script: bufferutils_1.cloneBuffer(output.script),
+        value: output.value,
+        address,
+      };
+    });
   }
   combine(...those) {
     this.data.combine(...those.map(o => o.data));

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -155,11 +155,17 @@ export class Psbt {
   }
 
   get txOutputs(): TransactionOutput[] {
-    return this.__CACHE.__TX.outs.map(output => ({
-      script: cloneBuffer(output.script),
-      value: output.value,
-      address: fromOutputScript(output.script, this.opts.network),
-    }));
+    return this.__CACHE.__TX.outs.map(output => {
+      let address;
+      try {
+        address = fromOutputScript(output.script, this.opts.network);
+      } catch (_) {}
+      return {
+        script: cloneBuffer(output.script),
+        value: output.value,
+        address,
+      };
+    });
   }
 
   combine(...those: Psbt[]): this {


### PR DESCRIPTION
Resolves #1577.

We can add a regression test for this but maybe best to add it in https://github.com/bitcoinjs/bitcoinjs-lib/pull/1563 since that's where all the other tests are.