### PR TITLE
Add more unit tests, improve test coverage

### DIFF
--- a/test/bufferutils.spec.ts
+++ b/test/bufferutils.spec.ts
@@ -42,7 +42,7 @@ describe('bufferutils', () => {
       });
     });
 
-    fixtures.invalid.readUInt64LE.forEach(f => {
+    fixtures.invalid.writeUInt64LE.forEach(f => {
       it('throws on ' + f.description, () => {
         const buffer = Buffer.alloc(8, 0);
 

--- a/test/ecpair.spec.ts
+++ b/test/ecpair.spec.ts
@@ -146,6 +146,13 @@ describe('ECPair', () => {
         assert.strictEqual(result, f.WIF);
       });
     });
+    it('throws if no private key is found', () => {
+      assert.throws(() => {
+        const keyPair = ECPair.makeRandom();
+        delete (keyPair as any).__D;
+        keyPair.toWIF();
+      }, /Missing private key/);
+    });
   });
 
   describe('makeRandom', () => {

--- a/test/fixtures/address.json
+++ b/test/fixtures/address.json
@@ -189,6 +189,14 @@
       {
         "exception": "has no matching Script",
         "address": "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2"
+      },
+      {
+        "exception": "has no matching Script",
+        "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5"
+      },
+      {
+        "exception": "has no matching Script",
+        "address": "bc1qqqqqqqqqqv9qus"
       }
     ]
   }

--- a/test/fixtures/bufferutils.json
+++ b/test/fixtures/bufferutils.json
@@ -71,6 +71,32 @@
         "hex": "0100000000002000",
         "dec": 9007199254740993
       }
+    ],
+    "writeUInt64LE": [
+      {
+        "description": "n === 2^53",
+        "exception": "RangeError: value out of range",
+        "hex": "0000000000002000",
+        "dec": 9007199254740992
+      },
+      {
+        "description": "n > 2^53",
+        "exception": "RangeError: value out of range",
+        "hex": "0100000000002000",
+        "dec": 9007199254740993
+      },
+      {
+        "description": "n < 0",
+        "exception": "specified a negative value for writing an unsigned value",
+        "hex": "",
+        "dec": -1
+      },
+      {
+        "description": "0 < n < 1",
+        "exception": "value has a fractional component",
+        "hex": "",
+        "dec": 0.1
+      }
     ]
   }
 }

--- a/test/fixtures/embed.json
+++ b/test/fixtures/embed.json
@@ -44,6 +44,36 @@
       "arguments": {
         "output": "OP_1 OP_2 OP_ADD"
       }
+    },
+    {
+      "description": "Return value and data do not match",
+      "exception": "Data mismatch",
+      "options": {},
+      "arguments": {
+        "output": "OP_RETURN a3b147dbe4a85579fc4b5a1811e76620560e07267e62b9a0d6858f9127735cadd82f67e06c24dbc4",
+        "data": [
+          "a3b147dbe4a85579fc4b5a1855555555555555555555555555555555555555555555555555555555"
+        ]
+      }
+    },
+    {
+      "description": "Script length incorrect",
+      "exception": "Data mismatch",
+      "options": {},
+      "arguments": {
+        "output": "OP_RETURN a3b1 47db",
+        "data": [
+          "a3b1"
+        ]
+      }
+    },
+    {
+      "description": "Return data is not buffer",
+      "exception": "Output is invalid",
+      "options": {},
+      "arguments": {
+        "output": "OP_RETURN OP_1"
+      }
     }
   ],
   "dynamic": {

--- a/test/fixtures/p2sh.json
+++ b/test/fixtures/p2sh.json
@@ -324,6 +324,26 @@
       }
     },
     {
+      "exception": "Input and witness provided",
+      "arguments": {
+        "redeem": {
+          "input": "OP_0",
+          "witness": [
+            "030000000000000000000000000000000000000000000000000000000000000001"
+          ]
+        }
+      }
+    },
+    {
+      "exception": "Non push-only scriptSig",
+      "arguments": {
+        "redeem": {
+          "input": "OP_RETURN",
+          "output": "OP_1"
+        }
+      }
+    },
+    {
       "exception": "Redeem.output too short",
       "arguments": {
         "inputHex": "021000"

--- a/test/fixtures/p2wpkh.json
+++ b/test/fixtures/p2wpkh.json
@@ -142,6 +142,16 @@
       }
     },
     {
+      "exception": "Signature mismatch",
+      "arguments": {
+        "signature": "300602010002010002",
+        "witness": [
+          "300602010002010001",
+          "030000000000000000000000000000000000000000000000000000000000000001"
+        ]
+      }
+    },
+    {
       "exception": "Invalid prefix or Network mismatch",
       "arguments": {
         "address": "foo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqs30dvv"

--- a/test/script.spec.ts
+++ b/test/script.spec.ts
@@ -41,6 +41,21 @@ describe('script', () => {
     });
   });
 
+  describe('toASM', () => {
+    const OP_RETURN = bscript.OPS.OP_RETURN;
+    it('encodes empty buffer as OP_0', () => {
+      const chunks = [OP_RETURN, Buffer.from([])];
+      assert.strictEqual(bscript.toASM(chunks), 'OP_RETURN OP_0');
+    });
+
+    for (let i = 1; i <= 16; i++) {
+      it(`encodes one byte buffer [${i}] as OP_${i}`, () => {
+        const chunks = [OP_RETURN, Buffer.from([i])];
+        assert.strictEqual(bscript.toASM(chunks), 'OP_RETURN OP_' + i);
+      });
+    }
+  });
+
   describe('fromASM/toASM (templates)', () => {
     fixtures2.valid.forEach(f => {
       if (f.inputHex) {

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -54,4 +54,41 @@ describe('types', () => {
       });
     });
   });
+
+  describe('UInt31', () => {
+    const UINT31_MAX = Math.pow(2, 31) - 1;
+    it('return true for valid values', () => {
+      assert.strictEqual(types.UInt31(0), true);
+      assert.strictEqual(types.UInt31(1000), true);
+      assert.strictEqual(types.UInt31(UINT31_MAX), true);
+    });
+
+    it('return false for negative values', () => {
+      assert.strictEqual(types.UInt31(-1), false);
+      assert.strictEqual(types.UInt31(-UINT31_MAX), false);
+    });
+
+    it('return false for values > UINT31_MAX', () => {
+      assert.strictEqual(types.UInt31(UINT31_MAX + 1), false);
+    });
+  });
+
+  describe('BIP32Path', () => {
+    it('return true for valid paths', () => {
+      assert.strictEqual(types.BIP32Path("m/0'/0'"), true);
+      assert.strictEqual(types.BIP32Path("m/0'/0"), true);
+      assert.strictEqual(types.BIP32Path("m/0'/1'/2'/3/4'"), true);
+    });
+
+    it('return false for invalid paths', () => {
+      assert.strictEqual(types.BIP32Path('m'), false);
+      assert.strictEqual(types.BIP32Path("n/0'/0'"), false);
+      assert.strictEqual(types.BIP32Path("m/0'/x"), false);
+    });
+
+    it('return "BIP32 derivation path" for JSON.strigify()', () => {
+      const toJsonValue = JSON.stringify(types.BIP32Path);
+      assert.equal(toJsonValue, '"BIP32 derivation path"');
+    });
+  });
 });

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -68,7 +68,7 @@ describe('types', () => {
       assert.strictEqual(types.UInt31(-UINT31_MAX), false);
     });
 
-    it('return false for values > UINT31_MAX', () => {
+    it(`return false for value > ${UINT31_MAX}`, () => {
       assert.strictEqual(types.UInt31(UINT31_MAX + 1), false);
     });
   });


### PR DESCRIPTION
Check paths that are not covered by the current unit tests and cover them.
Each new test covers a line/branch that was previously not covered/partially covered.

- [x] bufferutils.ts
- [x] ecpair
- [x] script
- [x] address
- [x] types
  -  BIP32Path - is this type still being used?
- [x] embed
- [x] p2sh
- [x] p2wpkh

### Before
```
=============================== Coverage summary ===============================
Statements   : 94.23% ( 2662/2825 )
Branches     : 91.74% ( 1611/1756 )
Functions    : 92.11% ( 420/456 )
Lines        : 95.93% ( 2451/2555 )
================================================================================
```
### After

```
=============================== Coverage summary ===============================
Statements   : 94.8% ( 2678/2825 )
Branches     : 92.82% ( 1630/1756 )
Functions    : 93.2% ( 425/456 )
Lines        : 96.48% ( 2465/2555 )
===========================
=====================================================
```