### PR TITLE
P2PSH - output script name/type missing

### DIFF
--- a/src/payments/p2sh.js
+++ b/src/payments/p2sh.js
@@ -1,5 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+const classify = require('../classify');
 const bcrypto = require('../crypto');
 const networks_1 = require('../networks');
 const bscript = require('../script');
@@ -95,7 +96,11 @@ function p2sh(a, opts) {
   });
   lazy.prop(o, 'name', () => {
     const nameParts = ['p2sh'];
-    if (o.redeem !== undefined) nameParts.push(o.redeem.name);
+    if (o.redeem !== undefined)
+      if (o.redeem.name !== undefined) nameParts.push(o.redeem.name);
+      else if (o.redeem.output !== undefined) {
+        nameParts.push(classify.output(o.redeem.output));
+      }
     return nameParts.join('-');
   });
   if (opts.validate) {

--- a/src/payments/p2wsh.js
+++ b/src/payments/p2wsh.js
@@ -1,5 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+const classify = require('../classify');
 const bcrypto = require('../crypto');
 const networks_1 = require('../networks');
 const bscript = require('../script');
@@ -118,7 +119,11 @@ function p2wsh(a, opts) {
   });
   lazy.prop(o, 'name', () => {
     const nameParts = ['p2wsh'];
-    if (o.redeem !== undefined) nameParts.push(o.redeem.name);
+    if (o.redeem !== undefined)
+      if (o.redeem.name !== undefined) nameParts.push(o.redeem.name);
+      else if (o.redeem.output !== undefined) {
+        nameParts.push(classify.output(o.redeem.output));
+      }
     return nameParts.join('-');
   });
   // extended validation

--- a/test/fixtures/p2sh.json
+++ b/test/fixtures/p2sh.json
@@ -44,7 +44,7 @@
       }
     },
     {
-      "description": "p2sh-p2pkh, out (from redeem)",
+      "description": "p2sh-pubkeyhash, out (from redeem)",
       "arguments": {
         "redeem": {
           "address": "this is P2PKH context, unknown and ignored by P2SH",
@@ -52,7 +52,7 @@
         }
       },
       "expected": {
-        "name": "p2sh-p2pkh",
+        "name": "p2sh-pubkeyhash",
         "address": "3GETYP4cuSesh2zsPEEYVZqnRedwe4FwUT",
         "hash": "9f840a5fc02407ef0ad499c2ec0eb0b942fb0086",
         "output": "OP_HASH160 9f840a5fc02407ef0ad499c2ec0eb0b942fb0086 OP_EQUAL",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "description": "p2sh-p2wpkh, out (from redeem)",
+      "description": "p2sh-witnesspubkeyhash, out (from redeem)",
       "arguments": {
         "redeem": {
           "hash": "this is P2WPKH context, unknown and ignored by P2SH",
@@ -69,7 +69,7 @@
         }
       },
       "expected": {
-        "name": "p2sh-p2wpkh",
+        "name": "p2sh-witnesspubkeyhash",
         "address": "325CuTNSYmvurXaBmhNFer5zDkKnDXZggu",
         "hash": "0432515d8fe8de31be8207987fc6d67b29d5e7cc",
         "output": "OP_HASH160 0432515d8fe8de31be8207987fc6d67b29d5e7cc OP_EQUAL",
@@ -78,7 +78,7 @@
       }
     },
     {
-      "description": "p2sh-p2pk, out (from redeem)",
+      "description": "p2sh-pubkey, out (from redeem)",
       "arguments": {
         "redeem": {
           "output": "03e15819590382a9dd878f01e2f0cbce541564eb415e43b440472d883ecd283058 OP_CHECKSIG",
@@ -86,7 +86,7 @@
         }
       },
       "expected": {
-        "name": "p2sh-p2pk",
+        "name": "p2sh-pubkey",
         "address": "36TibC8RrPB9WrBdPoGXhHqDHJosyFVtVQ",
         "hash": "3454c084887afe854e80221c69d6282926f809c4",
         "output": "OP_HASH160 3454c084887afe854e80221c69d6282926f809c4 OP_EQUAL",
@@ -95,7 +95,7 @@
       }
     },
     {
-      "description": "p2sh-p2pkh, in and out (from redeem)",
+      "description": "p2sh-pubkeyhash, in and out (from redeem)",
       "arguments": {
         "redeem": {
           "output": "OP_DUP OP_HASH160 c30afa58ae0673b00a45b5c17dff4633780f1400 OP_EQUALVERIFY OP_CHECKSIG",
@@ -103,7 +103,7 @@
         }
       },
       "expected": {
-        "name": "p2sh-p2pkh",
+        "name": "p2sh-pubkeyhash",
         "address": "3GETYP4cuSesh2zsPEEYVZqnRedwe4FwUT",
         "hash": "9f840a5fc02407ef0ad499c2ec0eb0b942fb0086",
         "output": "OP_HASH160 9f840a5fc02407ef0ad499c2ec0eb0b942fb0086 OP_EQUAL",
@@ -112,7 +112,7 @@
       }
     },
     {
-      "description": "p2sh-p2wpkh, in and out (from redeem w/ witness)",
+      "description": "p2sh-witnesspubkeyhash, in and out (from redeem w/ witness)",
       "arguments": {
         "redeem": {
           "output": "OP_0 c30afa58ae0673b00a45b5c17dff4633780f1400",
@@ -124,7 +124,7 @@
         }
       },
       "expected": {
-        "name": "p2sh-p2wpkh",
+        "name": "p2sh-witnesspubkeyhash",
         "address": "325CuTNSYmvurXaBmhNFer5zDkKnDXZggu",
         "hash": "0432515d8fe8de31be8207987fc6d67b29d5e7cc",
         "output": "OP_HASH160 0432515d8fe8de31be8207987fc6d67b29d5e7cc OP_EQUAL",
@@ -136,12 +136,12 @@
       }
     },
     {
-      "description": "p2sh-p2pk, in and out (from input)",
+      "description": "p2sh-pubkey, in and out (from input)",
       "arguments": {
         "input": "3045022100e4fce9ec72b609a2df1dc050c20dcf101d27faefb3e686b7a4cb067becdd5e8e022071287fced53806b08cf39b5ad58bbe614775b3776e98a9f8760af0d4d1d47a9501 2103e15819590382a9dd878f01e2f0cbce541564eb415e43b440472d883ecd283058ac"
       },
       "expected": {
-        "name": "p2sh-p2pk",
+        "name": "p2sh-pubkey",
         "address": "36TibC8RrPB9WrBdPoGXhHqDHJosyFVtVQ",
         "hash": "3454c084887afe854e80221c69d6282926f809c4",
         "output": "OP_HASH160 3454c084887afe854e80221c69d6282926f809c4 OP_EQUAL",
@@ -154,7 +154,7 @@
       }
     },
     {
-      "description": "p2sh-p2wpkh, in and out (from input AND witness)",
+      "description": "p2sh-witnesspubkeyhash, in and out (from input AND witness)",
       "arguments": {
         "input": "0014c30afa58ae0673b00a45b5c17dff4633780f1400",
         "witness": [
@@ -163,7 +163,7 @@
         ]
       },
       "expected": {
-        "name": "p2sh-p2wpkh",
+        "name": "p2sh-witnesspubkeyhash",
         "address": "325CuTNSYmvurXaBmhNFer5zDkKnDXZggu",
         "hash": "0432515d8fe8de31be8207987fc6d67b29d5e7cc",
         "output": "OP_HASH160 0432515d8fe8de31be8207987fc6d67b29d5e7cc OP_EQUAL",
@@ -178,7 +178,7 @@
       }
     },
     {
-      "description": "p2sh-p2pkh, out (network derived from redeem)",
+      "description": "p2sh-pubkeyhash, out (network derived from redeem)",
       "arguments": {
         "redeem": {
           "address": "this is P2PKH context, unknown and ignored by P2SH",
@@ -187,7 +187,7 @@
         }
       },
       "expected": {
-        "name": "p2sh-p2pkh",
+        "name": "p2sh-pubkeyhash",
         "address": "2N7nfc7zeWuADtpdR4MrR7Wq3dzr7LxTCgS",
         "hash": "9f840a5fc02407ef0ad499c2ec0eb0b942fb0086",
         "output": "OP_HASH160 9f840a5fc02407ef0ad499c2ec0eb0b942fb0086 OP_EQUAL",
@@ -412,7 +412,7 @@
     },
     "details": [
       {
-        "description": "p2sh-p2pkh",
+        "description": "p2sh-pubkeyhash",
         "address": "3GETYP4cuSesh2zsPEEYVZqnRedwe4FwUT",
         "hash": "9f840a5fc02407ef0ad499c2ec0eb0b942fb0086",
         "output": "OP_HASH160 9f840a5fc02407ef0ad499c2ec0eb0b942fb0086 OP_EQUAL",
@@ -425,7 +425,7 @@
         "witness": []
       },
       {
-        "description": "p2sh-p2wpkh",
+        "description": "p2sh-witnesspubkeyhash",
         "address": "325CuTNSYmvurXaBmhNFer5zDkKnDXZggu",
         "hash": "0432515d8fe8de31be8207987fc6d67b29d5e7cc",
         "output": "OP_HASH160 0432515d8fe8de31be8207987fc6d67b29d5e7cc OP_EQUAL",

--- a/test/fixtures/p2wsh.json
+++ b/test/fixtures/p2wsh.json
@@ -44,7 +44,7 @@
       }
     },
     {
-      "description": "p2wsh-p2pkh, out (from redeem)",
+      "description": "p2wsh-pubkeyhash, out (from redeem)",
       "arguments": {
         "redeem": {
           "address": "this is P2PKH context, unknown and ignored by p2wsh",
@@ -52,7 +52,7 @@
         }
       },
       "expected": {
-        "name": "p2wsh-p2pkh",
+        "name": "p2wsh-pubkeyhash",
         "address": "bc1qusxlgq9quu27ucxs7a2fg8nv0pycdzvxsjk9npyupupxw3y892ss2cq5ar",
         "hash": "e40df400a0e715ee60d0f754941e6c784986898684ac59849c0f026744872aa1",
         "output": "OP_0 e40df400a0e715ee60d0f754941e6c784986898684ac59849c0f026744872aa1",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "description": "p2wsh-p2wpkh, out (from redeem)",
+      "description": "p2wsh-witnesspubkeyhash, out (from redeem)",
       "arguments": {
         "redeem": {
           "hash": "this is P2WPKH context, unknown and ignored by p2wsh",
@@ -69,7 +69,7 @@
         }
       },
       "expected": {
-        "name": "p2wsh-p2wpkh",
+        "name": "p2wsh-witnesspubkeyhash",
         "address": "bc1qpsl7el8wcx22f3fpdt3lm2wmzug7yyx2q3n8wzgtf37kps9tqy7skc7m3e",
         "hash": "0c3fecfceec194a4c5216ae3fda9db1711e210ca046677090b4c7d60c0ab013d",
         "output": "OP_0 0c3fecfceec194a4c5216ae3fda9db1711e210ca046677090b4c7d60c0ab013d",
@@ -78,7 +78,7 @@
       }
     },
     {
-      "description": "p2wsh-p2pk, out (from redeem)",
+      "description": "p2wsh-pubkey, out (from redeem)",
       "arguments": {
         "redeem": {
           "output": "03e15819590382a9dd878f01e2f0cbce541564eb415e43b440472d883ecd283058 OP_CHECKSIG",
@@ -86,7 +86,7 @@
         }
       },
       "expected": {
-        "name": "p2wsh-p2pk",
+        "name": "p2wsh-pubkey",
         "address": "bc1q6rgl33d3s9dugudw7n68yrryajkr3ha9q8q24j20zs62se4q9tsqdy0t2q",
         "hash": "d0d1f8c5b1815bc471aef4f4720c64ecac38dfa501c0aac94f1434a866a02ae0",
         "output": "OP_0 d0d1f8c5b1815bc471aef4f4720c64ecac38dfa501c0aac94f1434a866a02ae0",
@@ -95,7 +95,7 @@
       }
     },
     {
-      "description": "p2wsh-p2pkh, in and out (from redeem, transformed to witness)",
+      "description": "p2wsh-pubkeyhash, in and out (from redeem, transformed to witness)",
       "arguments": {
         "redeem": {
           "output": "OP_DUP OP_HASH160 c30afa58ae0673b00a45b5c17dff4633780f1400 OP_EQUALVERIFY OP_CHECKSIG",
@@ -103,7 +103,7 @@
         }
       },
       "expected": {
-        "name": "p2wsh-p2pkh",
+        "name": "p2wsh-pubkeyhash",
         "address": "bc1qusxlgq9quu27ucxs7a2fg8nv0pycdzvxsjk9npyupupxw3y892ss2cq5ar",
         "hash": "e40df400a0e715ee60d0f754941e6c784986898684ac59849c0f026744872aa1",
         "output": "OP_0 e40df400a0e715ee60d0f754941e6c784986898684ac59849c0f026744872aa1",
@@ -119,7 +119,7 @@
       }
     },
     {
-      "description": "p2wsh-p2wpkh, in and out (from redeem w/ witness)",
+      "description": "p2wsh-witnesspubkeyhash, in and out (from redeem w/ witness)",
       "arguments": {
         "redeem": {
           "output": "OP_0 c30afa58ae0673b00a45b5c17dff4633780f1400",
@@ -131,7 +131,7 @@
         }
       },
       "expected": {
-        "name": "p2wsh-p2wpkh",
+        "name": "p2wsh-witnesspubkeyhash",
         "address": "bc1qpsl7el8wcx22f3fpdt3lm2wmzug7yyx2q3n8wzgtf37kps9tqy7skc7m3e",
         "hash": "0c3fecfceec194a4c5216ae3fda9db1711e210ca046677090b4c7d60c0ab013d",
         "output": "OP_0 0c3fecfceec194a4c5216ae3fda9db1711e210ca046677090b4c7d60c0ab013d",
@@ -144,7 +144,7 @@
       }
     },
     {
-      "description": "p2wsh-p2pk, in and out (from witness)",
+      "description": "p2wsh-pubkey, in and out (from witness)",
       "arguments": {
         "witness": [
           "3045022100e4fce9ec72b609a2df1dc050c20dcf101d27faefb3e686b7a4cb067becdd5e8e022071287fced53806b08cf39b5ad58bbe614775b3776e98a9f8760af0d4d1d47a9501",
@@ -152,7 +152,7 @@
         ]
       },
       "expected": {
-        "name": "p2wsh-p2pk",
+        "name": "p2wsh-pubkey",
         "address": "bc1q6rgl33d3s9dugudw7n68yrryajkr3ha9q8q24j20zs62se4q9tsqdy0t2q",
         "hash": "d0d1f8c5b1815bc471aef4f4720c64ecac38dfa501c0aac94f1434a866a02ae0",
         "output": "OP_0 d0d1f8c5b1815bc471aef4f4720c64ecac38dfa501c0aac94f1434a866a02ae0",
@@ -167,7 +167,7 @@
       }
     },
     {
-      "description": "p2wsh-p2wpkh, in and out (from witness)",
+      "description": "p2wsh-witnesspubkeyhash, in and out (from witness)",
       "arguments": {
         "witness": [
           "3045022100e4fce9ec72b609a2df1dc050c20dcf101d27faefb3e686b7a4cb067becdd5e8e022071287fced53806b08cf39b5ad58bbe614775b3776e98a9f8760af0d4d1d47a9501",
@@ -176,7 +176,7 @@
         ]
       },
       "expected": {
-        "name": "p2wsh-p2wpkh",
+        "name": "p2wsh-witnesspubkeyhash",
         "address": "bc1qpsl7el8wcx22f3fpdt3lm2wmzug7yyx2q3n8wzgtf37kps9tqy7skc7m3e",
         "hash": "0c3fecfceec194a4c5216ae3fda9db1711e210ca046677090b4c7d60c0ab013d",
         "output": "OP_0 0c3fecfceec194a4c5216ae3fda9db1711e210ca046677090b4c7d60c0ab013d",
@@ -191,7 +191,7 @@
       }
     },
     {
-      "description": "p2wsh-p2pkh, out (network derived from redeem)",
+      "description": "p2wsh-pubkeyhash, out (network derived from redeem)",
       "arguments": {
         "redeem": {
           "address": "this is P2PKH context, unknown and ignored by p2wsh",
@@ -200,7 +200,7 @@
         }
       },
       "expected": {
-        "name": "p2wsh-p2pkh",
+        "name": "p2wsh-pubkeyhash",
         "address": "tb1qusxlgq9quu27ucxs7a2fg8nv0pycdzvxsjk9npyupupxw3y892ssaskm8v",
         "hash": "e40df400a0e715ee60d0f754941e6c784986898684ac59849c0f026744872aa1",
         "output": "OP_0 e40df400a0e715ee60d0f754941e6c784986898684ac59849c0f026744872aa1",
@@ -399,7 +399,7 @@
     },
     "details": [
       {
-        "description": "p2wsh-p2pkh",
+        "description": "p2wsh-pubkeyhash",
         "disabled": [
           "redeem.input"
         ],
@@ -419,7 +419,7 @@
         ]
       },
       {
-        "description": "p2wsh-p2wpkh",
+        "description": "p2wsh-witnesspubkeyhash",
         "address": "bc1qpsl7el8wcx22f3fpdt3lm2wmzug7yyx2q3n8wzgtf37kps9tqy7skc7m3e",
         "hash": "0c3fecfceec194a4c5216ae3fda9db1711e210ca046677090b4c7d60c0ab013d",
         "output": "OP_0 0c3fecfceec194a4c5216ae3fda9db1711e210ca046677090b4c7d60c0ab013d",

--- a/test/payments.utils.ts
+++ b/test/payments.utils.ts
@@ -81,6 +81,7 @@ export function equate(a: any, b: any, args?: any): void {
   if (b.signature === null) b.signature = undefined;
   if (b.signatures === null) b.signatures = undefined;
   if ('address' in b) t.strictEqual(a.address, b.address, 'Inequal *.address');
+  if ('name' in b) t.strictEqual(a.name, b.name, 'Inequal *.name');
   if ('hash' in b)
     t.strictEqual(tryHex(a.hash), tryHex(b.hash), 'Inequal *.hash');
   if ('pubkey' in b)

--- a/ts_src/payments/p2sh.ts
+++ b/ts_src/payments/p2sh.ts
@@ -1,3 +1,4 @@
+import * as classify from '../classify';
 import * as bcrypto from '../crypto';
 import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as bscript from '../script';
@@ -118,7 +119,11 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
   });
   lazy.prop(o, 'name', () => {
     const nameParts = ['p2sh'];
-    if (o.redeem !== undefined) nameParts.push(o.redeem.name!);
+    if (o.redeem !== undefined)
+      if (o.redeem.name !== undefined) nameParts.push(o.redeem.name);
+      else if (o.redeem.output !== undefined) {
+        nameParts.push(classify.output(o.redeem.output));
+      }
     return nameParts.join('-');
   });
 

--- a/ts_src/payments/p2wsh.ts
+++ b/ts_src/payments/p2wsh.ts
@@ -1,3 +1,4 @@
+import * as classify from '../classify';
 import * as bcrypto from '../crypto';
 import { bitcoin as BITCOIN_NETWORK } from '../networks';
 import * as bscript from '../script';
@@ -132,7 +133,11 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
   });
   lazy.prop(o, 'name', () => {
     const nameParts = ['p2wsh'];
-    if (o.redeem !== undefined) nameParts.push(o.redeem.name!);
+    if (o.redeem !== undefined)
+      if (o.redeem.name !== undefined) nameParts.push(o.redeem.name);
+      else if (o.redeem.output !== undefined) {
+        nameParts.push(classify.output(o.redeem.output));
+      }
     return nameParts.join('-');
   });
 


### PR DESCRIPTION
### Curent State

- the unit tests fixures (p2sh.json) expect a name (for the payment) that indicates the type of the wrapped script:
```
      "expected": {
        "name": "p2sh-p2pk",
```

- `payment.utils.ts `currently does **not** check the name in the `equate()` method
    - `  if ('name' in b) t.strictEqual(a.name, b.name, 'Inequal *.name');` <-- **not present**

- **p2sh.ts** & **p2wsh** does not try to match the redeem scripts with an existing template (p2pk, p2pkh, etc)

### Expected State
 - **p2sh** & **p2wsh** should return the name of the wrapped script (when it is the case). Eg: `p2sh-p2pkh`

### Other Considerations
  - the `classify` functions can perform some heavy operations like `isCanonicalScriptSignature`, `isCanonicalPubKey` etc
      - this might be a problem, however the value for the `name` field is lazy computed
  - the names returned by the `clasify` functions differ from the ones used in the unit test fixures (eg: `pubkeyhash` vs`p2pkh`)
     - the unit test fixures have been changed