### PR TITLE
#1470 Bring over TransactionInput & TransactionOutputfrom BIP174; update tiny-secp256k1 to v1.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1495,9 +1495,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "node-environment-flags": {
       "version": "1.0.6",
@@ -2246,9 +2246,9 @@
       }
     },
     "tiny-secp256k1": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.1.tgz",
-      "integrity": "sha512-jA9WalQuhKun1svJrAVi9Vu8aUWKMfR7nMV903kHjrHTTY/IFa0petSq+Jk/Mv447dGD9LC8fGsmGRubBbcNng==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
+      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
       "requires": {
         "bindings": "^1.3.0",
         "bn.js": "^4.11.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,9 +2246,9 @@
       }
     },
     "tiny-secp256k1": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
-      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
       "requires": {
         "bindings": "^1.3.0",
         "bn.js": "^4.11.8",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "merkle-lib": "^2.0.10",
     "pushdata-bitcoin": "^1.0.1",
     "randombytes": "^2.0.1",
-    "tiny-secp256k1": "^1.1.1",
+    "tiny-secp256k1": "^1.1.5",
     "typeforce": "^1.11.3",
     "varuint-bitcoin": "^1.0.4",
     "wif": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "merkle-lib": "^2.0.10",
     "pushdata-bitcoin": "^1.0.1",
     "randombytes": "^2.0.1",
-    "tiny-secp256k1": "^1.1.5",
+    "tiny-secp256k1": "^1.1.6",
     "typeforce": "^1.11.3",
     "varuint-bitcoin": "^1.0.4",
     "wif": "^2.0.1"

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -11,8 +11,6 @@ import {
   PsbtOutputUpdate,
   Transaction as ITransaction,
   TransactionFromBuffer,
-  TransactionInput,
-  TransactionOutput,
 } from 'bip174/src/lib/interfaces';
 import { checkForInput, checkForOutput } from 'bip174/src/lib/utils';
 import { fromOutputScript, toOutputScript } from './address';
@@ -28,8 +26,19 @@ import * as payments from './payments';
 import * as bscript from './script';
 import { Output, Transaction } from './transaction';
 
+export interface TransactionInput {
+  hash: string | Buffer;
+  index: number;
+  sequence?: number;
+}
+
 export interface PsbtTxInput extends TransactionInput {
   hash: Buffer;
+}
+
+export interface TransactionOutput {
+  script: Buffer;
+  value: number;
 }
 
 export interface PsbtTxOutput extends TransactionOutput {

--- a/types/psbt.d.ts
+++ b/types/psbt.d.ts
@@ -1,10 +1,19 @@
 import { Psbt as PsbtBase } from 'bip174';
-import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate, TransactionInput, TransactionOutput } from 'bip174/src/lib/interfaces';
+import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate } from 'bip174/src/lib/interfaces';
 import { Signer, SignerAsync } from './ecpair';
 import { Network } from './networks';
 import { Transaction } from './transaction';
+export interface TransactionInput {
+    hash: string | Buffer;
+    index: number;
+    sequence?: number;
+}
 export interface PsbtTxInput extends TransactionInput {
     hash: Buffer;
+}
+export interface TransactionOutput {
+    script: Buffer;
+    value: number;
 }
 export interface PsbtTxOutput extends TransactionOutput {
     address: string | undefined;


### PR DESCRIPTION
- update `tiny-secp256k1` version from `1.1.1` to `1.1.5` (solves the Travis build error)