### PR TITLE
fix(docs): corrects typo in project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ It can do this through undermining your random number generation, accidentally p
 Running tests in your target environment is important and a recommended step to verify continuously.
 
 Finally, **adhere to best practice**.
-We are not an authorative source of best practice, but, at the very least:
+We are not an authoritative source of best practice, but, at the very least:
 
 * [Don't re-use addresses](https://en.bitcoin.it/wiki/Address_reuse).
 * Don't share BIP32 extended public keys ('xpubs'). [They are a liability](https://bitcoin.stackexchange.com/questions/56916/derivation-of-parent-private-key-from-non-hardened-child), and it only takes 1 misplaced private key (or a buggy implementation!) and you are vulnerable to **catastrophic fund loss**.


### PR DESCRIPTION
Scope of changes is restricted to docs only.