### PR TITLE
fix(transaction): use writeInt32 to write version

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -316,7 +316,7 @@ class Transaction {
     tbuffer = Buffer.allocUnsafe(156 + varSliceSize(prevOutScript));
     bufferWriter = new bufferutils_1.BufferWriter(tbuffer, 0);
     const input = this.ins[inIndex];
-    bufferWriter.writeUInt32(this.version);
+    bufferWriter.writeInt32(this.version);
     bufferWriter.writeSlice(hashPrevouts);
     bufferWriter.writeSlice(hashSequence);
     bufferWriter.writeSlice(input.hash);

--- a/test/bitcoin.core.spec.ts
+++ b/test/bitcoin.core.spec.ts
@@ -214,6 +214,16 @@ describe('Bitcoin-core', () => {
             (hash.reverse() as Buffer).toString('hex'),
             expectedHash,
           );
+
+          assert.doesNotThrow(() =>
+            transaction.hashForWitnessV0(
+              inIndex,
+              script,
+              0,
+              // convert to UInt32
+              hashType < 0 ? 0xffffffff + hashType : hashType,
+            ),
+          );
         },
       );
     });

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -416,7 +416,7 @@ export class Transaction {
     bufferWriter = new BufferWriter(tbuffer, 0);
 
     const input = this.ins[inIndex];
-    bufferWriter.writeUInt32(this.version);
+    bufferWriter.writeInt32(this.version);
     bufferWriter.writeSlice(hashPrevouts);
     bufferWriter.writeSlice(hashSequence);
     bufferWriter.writeSlice(input.hash);


### PR DESCRIPTION
We are reading `version` as `int32` so we should write it as that as
well.