### PR TITLE
Add warning to future segwit version address generation/parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/src/address.js
+++ b/src/address.js
@@ -13,6 +13,11 @@ const FUTURE_SEGWIT_MIN_SIZE = 2;
 const FUTURE_SEGWIT_MAX_VERSION = 16;
 const FUTURE_SEGWIT_MIN_VERSION = 1;
 const FUTURE_SEGWIT_VERSION_DIFF = 0x50;
+const FUTURE_SEGWIT_VERSION_WARNING =
+  'WARNING: Sending to a future segwit version address can lead to loss of funds. ' +
+  'End users MUST be warned carefully in the GUI and asked if they wish to proceed ' +
+  'with caution. Wallets should verify the segwit version from the output of fromBech32, ' +
+  'then decide when it is safe to use which version of segwit.';
 function _toFutureSegwitAddress(output, network) {
   const data = output.slice(2);
   if (
@@ -28,6 +33,7 @@ function _toFutureSegwitAddress(output, network) {
     throw new TypeError('Invalid version for segwit address');
   if (output[1] !== data.length)
     throw new TypeError('Invalid script for segwit address');
+  console.warn(FUTURE_SEGWIT_VERSION_WARNING);
   return toBech32(data, version, network.bech32);
 }
 function fromBase58Check(address) {
@@ -128,11 +134,13 @@ function toOutputScript(address, network) {
         decodeBech32.version <= FUTURE_SEGWIT_MAX_VERSION &&
         decodeBech32.data.length >= FUTURE_SEGWIT_MIN_SIZE &&
         decodeBech32.data.length <= FUTURE_SEGWIT_MAX_SIZE
-      )
+      ) {
+        console.warn(FUTURE_SEGWIT_VERSION_WARNING);
         return bscript.compile([
           decodeBech32.version + FUTURE_SEGWIT_VERSION_DIFF,
           decodeBech32.data,
         ]);
+      }
     }
   }
   throw new Error(address + ' has no matching Script');

--- a/ts_src/address.ts
+++ b/ts_src/address.ts
@@ -23,6 +23,11 @@ const FUTURE_SEGWIT_MIN_SIZE: number = 2;
 const FUTURE_SEGWIT_MAX_VERSION: number = 16;
 const FUTURE_SEGWIT_MIN_VERSION: number = 1;
 const FUTURE_SEGWIT_VERSION_DIFF: number = 0x50;
+const FUTURE_SEGWIT_VERSION_WARNING: string =
+  'WARNING: Sending to a future segwit version address can lead to loss of funds. ' +
+  'End users MUST be warned carefully in the GUI and asked if they wish to proceed ' +
+  'with caution. Wallets should verify the segwit version from the output of fromBech32, ' +
+  'then decide when it is safe to use which version of segwit.';
 
 function _toFutureSegwitAddress(output: Buffer, network: Network): string {
   const data = output.slice(2);
@@ -43,6 +48,8 @@ function _toFutureSegwitAddress(output: Buffer, network: Network): string {
 
   if (output[1] !== data.length)
     throw new TypeError('Invalid script for segwit address');
+
+  console.warn(FUTURE_SEGWIT_VERSION_WARNING);
 
   return toBech32(data, version, network.bech32);
 }
@@ -163,11 +170,14 @@ export function toOutputScript(address: string, network?: Network): Buffer {
         decodeBech32.version <= FUTURE_SEGWIT_MAX_VERSION &&
         decodeBech32.data.length >= FUTURE_SEGWIT_MIN_SIZE &&
         decodeBech32.data.length <= FUTURE_SEGWIT_MAX_SIZE
-      )
+      ) {
+        console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+
         return bscript.compile([
           decodeBech32.version + FUTURE_SEGWIT_VERSION_DIFF,
           decodeBech32.data,
         ]);
+      }
     }
   }
 


### PR DESCRIPTION
I am debating whether to revert to the old way of doing things (throw Error if unknown witness version), since this way of doing things allows wallets to be built in a way that lets users shoot themselves in the foot.

Adding the warning should at least catch the attention during development.