### PR TITLE
Fix: Interpret P2SH redeemscript === OP_FALSE as empty Buffer.

### DIFF
--- a/src/payments/p2sh.js
+++ b/src/payments/p2sh.js
@@ -58,9 +58,10 @@ function p2sh(a, opts) {
   });
   const _redeem = lazy.value(() => {
     const chunks = _chunks();
+    const lastChunk = chunks[chunks.length - 1];
     return {
       network,
-      output: chunks[chunks.length - 1],
+      output: lastChunk === OPS.OP_FALSE ? Buffer.from([]) : lastChunk,
       input: bscript.compile(chunks.slice(0, -1)),
       witness: a.witness || [],
     };

--- a/test/fixtures/p2sh.json
+++ b/test/fixtures/p2sh.json
@@ -289,9 +289,15 @@
       }
     },
     {
-      "exception": "Input is invalid",
+      "exception": "Redeem.output too short",
       "arguments": {
         "input": "OP_0 OP_0"
+      }
+    },
+    {
+      "exception": "Input is invalid",
+      "arguments": {
+        "input": "OP_0 OP_3"
       }
     },
     {

--- a/ts_src/payments/p2sh.ts
+++ b/ts_src/payments/p2sh.ts
@@ -68,9 +68,11 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
   const _redeem = lazy.value(
     (): Payment => {
       const chunks = _chunks();
+      const lastChunk = chunks[chunks.length - 1];
       return {
         network,
-        output: chunks[chunks.length - 1] as Buffer,
+        output:
+          lastChunk === OPS.OP_FALSE ? Buffer.from([]) : (lastChunk as Buffer),
         input: bscript.compile(chunks.slice(0, -1)),
         witness: a.witness || [],
       };


### PR DESCRIPTION
Fixes #1801

Note: the parsing for the specific example in the issue will still throw with `Redeem.output too short` but this can be skipped by using `validate: false` option.