### PR TITLE
refactor: remove unneed flags from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,13 +10,6 @@
     ],
     "allowJs": false,
     "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
     "esModuleInterop": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true


### PR DESCRIPTION
This is small refactoring for tsconfig.json.

If the strict flag is toggled to true, several type-checking strictness flags will be toggled to true at the same time.
(FYI. https://www.typescriptlang.org/docs/handbook/2/basic-types.html#strictness)
Thus, if the strict flag is true, these flags are only needed when opting out. In this case, deleting these will not change anything.

- [noImplicitAny](https://www.typescriptlang.org/tsconfig#noImplicitAny)
- [strictNullChecks](https://www.typescriptlang.org/tsconfig#strictNullChecks)
- [strictFunctionTypes](https://www.typescriptlang.org/tsconfig#strictFunctionTypes)
- [strictBindCallApply](https://www.typescriptlang.org/tsconfig#strictBindCallApply)
- [strictPropertyInitialization](https://www.typescriptlang.org/tsconfig#strictPropertyInitialization)
- [noImplicitThis](https://www.typescriptlang.org/tsconfig#noImplicitThis)
- [alwaysStrict](https://www.typescriptlang.org/tsconfig#alwaysStrict)