### PR TITLE
Silent payments v1

### DIFF
--- a/test/integration/silent-payments.spec.ts
+++ b/test/integration/silent-payments.spec.ts
@@ -1,0 +1,91 @@
+import BIP32Factory from 'bip32';
+import * as ecc from 'tiny-secp256k1';
+import { describe, it } from 'mocha';
+
+import { regtestUtils } from './_regtest';
+import * as bitcoin from '../..';
+import { toXOnly } from '../../src/psbt/bip371';
+
+const rng = require('randombytes');
+const regtest = regtestUtils.network;
+bitcoin.initEccLib(ecc);
+const bip32 = BIP32Factory(ecc);
+
+describe('bitcoinjs-lib (silent payments)', () => {
+  it('can create (and broadcast via 3PBP) a simple silent payment', async () => {
+    const { senderKeyPair, receiverKeyPair, sharedSecret } = initParticipants();
+    // this is what the sender sees/scans
+    const silentPublicKey = toXOnly(receiverKeyPair.publicKey);
+
+    // the input being spent
+    const { output: p2wpkhOutput } = bitcoin.payments.p2wpkh({
+      pubkey: senderKeyPair.publicKey,
+      network: regtest,
+    });
+
+    // amount from faucet
+    const amount = 42e4;
+    // amount to send
+    const sendAmount = amount - 1e4;
+    // get faucet
+    const unspent = await regtestUtils.faucetComplex(p2wpkhOutput!, amount);
+
+    const psbt = new bitcoin.Psbt({ network: regtest });
+    psbt.addInput({
+      hash: unspent.txId,
+      index: 0,
+      witnessUtxo: { value: amount, script: p2wpkhOutput! },
+    });
+
+    // destination
+    const { address } = bitcoin.payments.p2tr({
+      internalPubkey: silentPublicKey,
+      hash: sharedSecret,
+      network: regtest,
+    });
+    psbt.addOutput({ value: sendAmount, address: address! });
+
+    psbt.signInput(0, senderKeyPair);
+
+    psbt.finalizeAllInputs();
+    const tx = psbt.extractTransaction();
+    const rawTx = tx.toBuffer();
+
+    const hex = rawTx.toString('hex');
+
+    await regtestUtils.broadcast(hex);
+    await regtestUtils.verify({
+      txId: tx.getId(),
+      address: address!,
+      vout: 0,
+      value: sendAmount,
+    });
+  });
+});
+
+function initParticipants() {
+  const receiverKeyPair = bip32.fromSeed(rng(64), regtest);
+  const senderKeyPair = bip32.fromSeed(rng(64), regtest);
+
+
+  const senderSharedSecret = ecc.pointMultiply(
+    receiverKeyPair.publicKey,
+    senderKeyPair.privateKey!,
+  );
+
+  const receiverSharedSecred = ecc.pointMultiply(
+    senderKeyPair.publicKey,
+    receiverKeyPair.privateKey!,
+  );
+
+  if (!toBuffer(receiverSharedSecred!).equals(toBuffer(senderSharedSecret!)))
+    throw new Error('Shared secret missmatch.');
+
+  return {
+    receiverKeyPair,
+    senderKeyPair,
+    sharedSecret: toXOnly(Buffer.from(receiverSharedSecred!)),
+  };
+}
+
+const toBuffer = (a: Uint8Array) => Buffer.from(a);

--- a/test/integration/silent-payments.spec.ts
+++ b/test/integration/silent-payments.spec.ts
@@ -6,6 +6,8 @@ import { regtestUtils } from './_regtest';
 import * as bitcoin from '../..';
 import { toXOnly } from '../../src/psbt/bip371';
 
+import { tweakSigner } from './taproot.utils';
+
 const rng = require('randombytes');
 const regtest = regtestUtils.network;
 bitcoin.initEccLib(ecc);
@@ -13,60 +15,89 @@ const bip32 = BIP32Factory(ecc);
 
 describe('bitcoinjs-lib (silent payments)', () => {
   it('can create (and broadcast via 3PBP) a simple silent payment', async () => {
+    // for simplicity the transactions in this test have only one input and one output
+
     const { senderKeyPair, receiverKeyPair, sharedSecret } = initParticipants();
-    // this is what the sender sees/scans
+
+    // this is what the sender sees/scans (from twitter bio, public forum, truck door)
     const silentPublicKey = toXOnly(receiverKeyPair.publicKey);
 
-    // the input being spent
-    const { output: p2wpkhOutput } = bitcoin.payments.p2wpkh({
-      pubkey: senderKeyPair.publicKey,
+    const senderUtxo = await fundP2pkhUtxo(senderKeyPair.publicKey);
+
+    // amount to pay the silent address
+    const payAmount = senderUtxo.value - 1e4;
+    const {
+      psbt: payPsbt,
+      address: tweakedSilentAddress,
+    } = buildPayToSilentAddress(
+      senderUtxo.txId,
+      senderUtxo,
+      silentPublicKey,
+      payAmount,
+      sharedSecret,
+    );
+    payPsbt.signInput(0, senderKeyPair).finalizeAllInputs();
+
+    // the transaction paying to the silent address
+    const payTx = payPsbt.extractTransaction();
+    await broadcastAndVerifyTx(payTx, tweakedSilentAddress!, payAmount);
+
+    // the amount the receiver will spend
+    const sendAmount = payAmount - 1e4;
+    // the utxo with the tweaked silent address
+    const receiverUtxo = { value: payAmount, script: payTx.outs[0].script };
+    const { psbt: spendPsbt, address } = buildSpendFromSilentAddress(
+      payTx.getId(),
+      receiverUtxo,
+      silentPublicKey,
+      sendAmount,
+      sharedSecret,
+    );
+
+    const tweakedSigner = tweakSigner(receiverKeyPair!, {
+      tweakHash: sharedSecret,
       network: regtest,
     });
+    spendPsbt.signInput(0, tweakedSigner).finalizeAllInputs();
 
-    // amount from faucet
-    const amount = 42e4;
-    // amount to send
-    const sendAmount = amount - 1e4;
-    // get faucet
-    const unspent = await regtestUtils.faucetComplex(p2wpkhOutput!, amount);
-
-    const psbt = new bitcoin.Psbt({ network: regtest });
-    psbt.addInput({
-      hash: unspent.txId,
-      index: 0,
-      witnessUtxo: { value: amount, script: p2wpkhOutput! },
-    });
-
-    // destination
-    const { address } = bitcoin.payments.p2tr({
-      internalPubkey: silentPublicKey,
-      hash: sharedSecret,
-      network: regtest,
-    });
-    psbt.addOutput({ value: sendAmount, address: address! });
-
-    psbt.signInput(0, senderKeyPair);
-
-    psbt.finalizeAllInputs();
-    const tx = psbt.extractTransaction();
-    const rawTx = tx.toBuffer();
-
-    const hex = rawTx.toString('hex');
-
-    await regtestUtils.broadcast(hex);
-    await regtestUtils.verify({
-      txId: tx.getId(),
-      address: address!,
-      vout: 0,
-      value: sendAmount,
-    });
+    // the transaction spending from the silent address
+    const spendTx = spendPsbt.extractTransaction();
+    await broadcastAndVerifyTx(spendTx, address!, sendAmount);
   });
 });
+
+async function fundP2pkhUtxo(senderPubKey: Buffer) {
+  // the input being spent
+  const { output: p2wpkhOutput } = bitcoin.payments.p2wpkh({
+    pubkey: senderPubKey,
+    network: regtest,
+  });
+
+  // amount from faucet
+  const amount = 42e4;
+  // get faucet
+  const unspent = await regtestUtils.faucetComplex(p2wpkhOutput!, amount);
+
+  return { value: amount, script: p2wpkhOutput!, txId: unspent.txId };
+}
+
+async function broadcastAndVerifyTx(
+  tx: bitcoin.Transaction,
+  address: string,
+  value: number,
+) {
+  await regtestUtils.broadcast(tx.toBuffer().toString('hex'));
+  await regtestUtils.verify({
+    txId: tx.getId(),
+    address: address!,
+    vout: 0,
+    value,
+  });
+}
 
 function initParticipants() {
   const receiverKeyPair = bip32.fromSeed(rng(64), regtest);
   const senderKeyPair = bip32.fromSeed(rng(64), regtest);
-
 
   const senderSharedSecret = ecc.pointMultiply(
     receiverKeyPair.publicKey,
@@ -88,4 +119,55 @@ function initParticipants() {
   };
 }
 
+function buildPayToSilentAddress(
+  prevOutTxId: string,
+  witnessUtxo: { value: number; script: Buffer },
+  silentPublicKey: Buffer,
+  sendAmount: number,
+  sharedSecret: Buffer,
+) {
+  const psbt = new bitcoin.Psbt({ network: regtest });
+  psbt.addInput({
+    hash: prevOutTxId,
+    index: 0,
+    witnessUtxo,
+  });
+
+  // destination
+  const { address } = bitcoin.payments.p2tr({
+    internalPubkey: silentPublicKey,
+    hash: sharedSecret,
+    network: regtest,
+  });
+  psbt.addOutput({ value: sendAmount, address: address! });
+
+  return { psbt, address };
+}
+
+function buildSpendFromSilentAddress(
+  prevOutTxId: string,
+  witnessUtxo: { value: number; script: Buffer },
+  silentPublicKey: Buffer,
+  sendAmount: number,
+  sharedSecret: Buffer,
+) {
+  const psbt = new bitcoin.Psbt({ network: regtest });
+  psbt.addInput({
+    hash: prevOutTxId,
+    index: 0,
+    witnessUtxo,
+    tapInternalKey: silentPublicKey,
+    tapMerkleRoot: sharedSecret,
+  });
+
+  // random address value, not important
+  const address =
+    'bcrt1pqknex3jwpsaatu5e5dcjw70nac3fr5k5y3hcxr4hgg6rljzp59nqs6a0vh';
+  psbt.addOutput({
+    value: sendAmount,
+    address,
+  });
+
+  return { psbt, address };
+}
 const toBuffer = (a: Uint8Array) => Buffer.from(a);

--- a/test/integration/taproot.utils.ts
+++ b/test/integration/taproot.utils.ts
@@ -1,0 +1,40 @@
+import * as ecc from 'tiny-secp256k1';
+import ECPairFactory from 'ecpair';
+import { toXOnly } from '../../src/psbt/bip371';
+import * as bitcoin from '../..';
+
+const ECPair = ECPairFactory(ecc);
+
+// This logic will be extracted to ecpair
+export function tweakSigner(
+  signer: bitcoin.Signer,
+  opts: any = {},
+): bitcoin.Signer {
+  // @ts-ignore
+  let privateKey: Uint8Array | undefined = signer.privateKey!;
+  if (!privateKey) {
+    throw new Error('Private key is required for tweaking signer!');
+  }
+  if (signer.publicKey[0] === 3) {
+    privateKey = ecc.privateNegate(privateKey);
+  }
+
+  const tweakedPrivateKey = ecc.privateAdd(
+    privateKey,
+    tapTweakHash(toXOnly(signer.publicKey), opts.tweakHash),
+  );
+  if (!tweakedPrivateKey) {
+    throw new Error('Invalid tweaked private key!');
+  }
+
+  return ECPair.fromPrivateKey(Buffer.from(tweakedPrivateKey), {
+    network: opts.network,
+  });
+}
+
+function tapTweakHash(pubKey: Buffer, h: Buffer | undefined): Buffer {
+  return bitcoin.crypto.taggedHash(
+    'TapTweak',
+    Buffer.concat(h ? [pubKey, h] : [pubKey]),
+  );
+}


### PR DESCRIPTION
### Silent Payments
> Receive private payments from anyone on a single static address without requiring any interaction or extra on-chain overhead.

More on `Silent Payments`:
 - https://gist.github.com/RubenSomsen/c43b79517e7cb701ebf77eec6dbb46b8
 - https://rumble.com/v12kuz7-bitcoin-silent-payments.html

`silent-payments.spec` contains a simple test for Silent Payments.

The purpose of this PR is: 
 - to see if this library can support such a construct and how it would look like (after `p2tr-v1` branch gets merged)
 - serve as a starting point for developers that want to add silent payments to their wallet
 - start a discussion on how `Silent Payments` should be constructed and check that this implementation is correct

This PR is not concerned on the scanning/detecting silent payments.