### PR TITLE
Redefine tiny-secp256k1-interface

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -30,8 +30,6 @@ export declare function isTaptree(scriptTree: any): scriptTree is Taptree;
 export interface TinySecp256k1Interface {
     isXOnlyPoint(p: Uint8Array): boolean;
     xOnlyPointAddTweak(p: Uint8Array, tweak: Uint8Array): XOnlyPointAddTweakResult | null;
-    privateAdd(d: Uint8Array, tweak: Uint8Array): Uint8Array | null;
-    privateNegate(d: Uint8Array): Uint8Array;
 }
 export declare const Buffer256bit: any;
 export declare const Hash160bit: any;

--- a/ts_src/types.ts
+++ b/ts_src/types.ts
@@ -105,8 +105,6 @@ export interface TinySecp256k1Interface {
     p: Uint8Array,
     tweak: Uint8Array,
   ): XOnlyPointAddTweakResult | null;
-  privateAdd(d: Uint8Array, tweak: Uint8Array): Uint8Array | null;
-  privateNegate(d: Uint8Array): Uint8Array;
 }
 
 export const Buffer256bit = typeforce.BufferN(32);


### PR DESCRIPTION
Remove privateAdd & privateNegate methods as not used in this lib(also not verified in ecc_lib).