### PR TITLE
Add example using BIP86 vector to verify the sending to and from a BIP86 generated taproot address

### DIFF
--- a/test/integration/taproot.spec.ts
+++ b/test/integration/taproot.spec.ts
@@ -1,4 +1,6 @@
+import * as assert from 'assert';
 import BIP32Factory from 'bip32';
+import * as bip39 from 'bip39';
 import ECPairFactory from 'ecpair';
 import * as ecc from 'tiny-secp256k1';
 import { describe, it } from 'mocha';
@@ -17,6 +19,78 @@ const bip32 = BIP32Factory(ecc);
 const ECPair = ECPairFactory(ecc);
 
 describe('bitcoinjs-lib (transaction with taproot)', () => {
+  it('can verify the BIP86 HD wallet vectors for taproot single sig (& sending example)', async () => {
+    // Values taken from BIP86 document
+    const mnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const xprv =
+      'xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu';
+    const path = `m/86'/0'/0'/0/0`; // Path to first child of receiving wallet on first account
+    const internalPubkey = Buffer.from(
+      'cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115',
+      'hex',
+    );
+    const expectedAddress =
+      'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr';
+
+    // Verify the above (Below is no different than other HD wallets)
+    const seed = await bip39.mnemonicToSeed(mnemonic);
+    const rootKey = bip32.fromSeed(seed);
+    assert.strictEqual(rootKey.toBase58(), xprv);
+    const childNode = rootKey.derivePath(path);
+    // Since internalKey is an xOnly pubkey, we drop the DER header byte
+    const childNodeXOnlyPubkey = childNode.publicKey.slice(1, 33);
+    assert.deepEqual(childNodeXOnlyPubkey, internalPubkey);
+
+    // This is new for taproot
+    // Note: we are using mainnet here to get the correct address
+    // The output is the same no matter what the network is.
+    const { address, output } = bitcoin.payments.p2tr({
+      internalPubkey,
+    });
+    assert(output);
+    assert.strictEqual(address, expectedAddress);
+    // Used for signing, since the output and address are using a tweaked key
+    // We must tweak the signer in the same way.
+    const tweakedChildNode = childNode.tweak(
+      bitcoin.crypto.taggedHash('TapTweak', childNodeXOnlyPubkey),
+    );
+
+    // amount from faucet
+    const amount = 42e4;
+    // amount to send
+    const sendAmount = amount - 1e4;
+    // Send some sats to the address via faucet. Get the hash and index. (txid/vout)
+    const { txId: hash, vout: index } = await regtestUtils.faucetComplex(
+      output,
+      amount,
+    );
+    // Sent 420000 sats to taproot address
+
+    const psbt = new bitcoin.Psbt({ network: regtest })
+      .addInput({
+        hash,
+        index,
+        witnessUtxo: { value: amount, script: output },
+        tapInternalKey: childNodeXOnlyPubkey,
+      })
+      .addOutput({
+        value: sendAmount,
+        address: regtestUtils.RANDOM_ADDRESS,
+      })
+      .signInput(0, tweakedChildNode)
+      .finalizeAllInputs();
+
+    const tx = psbt.extractTransaction();
+    await regtestUtils.broadcast(tx.toHex());
+    await regtestUtils.verify({
+      txId: tx.getId(),
+      address: regtestUtils.RANDOM_ADDRESS,
+      vout: 0,
+      value: sendAmount,
+    });
+  });
+
   it('can create (and broadcast via 3PBP) a taproot key-path spend Transaction', async () => {
     const internalKey = bip32.fromSeed(rng(64), regtest);
     const p2pkhKey = bip32.fromSeed(rng(64), regtest);


### PR DESCRIPTION
Closes #1873

This example will help people figure out how to use BIP86 derivation to use taproot.