### PR TITLE
Handle custom signature hash type - sig length

### DIFF
--- a/src/payments/p2tr.js
+++ b/src/payments/p2tr.js
@@ -31,7 +31,11 @@ function p2tr(a, opts) {
       internalPubkey: types_1.typeforce.maybe(types_1.typeforce.BufferN(32)),
       hash: types_1.typeforce.maybe(types_1.typeforce.BufferN(32)),
       pubkey: types_1.typeforce.maybe(types_1.typeforce.BufferN(32)),
-      signature: types_1.typeforce.maybe(types_1.typeforce.anyOf[types_1.typeforce.BufferN(64), types_1.typeforce.BufferN(65)]),
+      signature: types_1.typeforce.maybe(
+        types_1.typeforce.anyOf[
+          (types_1.typeforce.BufferN(64), types_1.typeforce.BufferN(65))
+        ],
+      ),
       witness: types_1.typeforce.maybe(
         types_1.typeforce.arrayOf(types_1.typeforce.Buffer),
       ),

--- a/src/payments/p2tr.js
+++ b/src/payments/p2tr.js
@@ -31,7 +31,7 @@ function p2tr(a, opts) {
       internalPubkey: types_1.typeforce.maybe(types_1.typeforce.BufferN(32)),
       hash: types_1.typeforce.maybe(types_1.typeforce.BufferN(32)),
       pubkey: types_1.typeforce.maybe(types_1.typeforce.BufferN(32)),
-      signature: types_1.typeforce.maybe(types_1.typeforce.BufferN(64)),
+      signature: types_1.typeforce.maybe(types_1.typeforce.anyOf[types_1.typeforce.BufferN(64), types_1.typeforce.BufferN(65)]),
       witness: types_1.typeforce.maybe(
         types_1.typeforce.arrayOf(types_1.typeforce.Buffer),
       ),

--- a/src/payments/p2tr.js
+++ b/src/payments/p2tr.js
@@ -32,9 +32,10 @@ function p2tr(a, opts) {
       hash: types_1.typeforce.maybe(types_1.typeforce.BufferN(32)),
       pubkey: types_1.typeforce.maybe(types_1.typeforce.BufferN(32)),
       signature: types_1.typeforce.maybe(
-        types_1.typeforce.anyOf[
-          (types_1.typeforce.BufferN(64), types_1.typeforce.BufferN(65))
-        ],
+        types_1.typeforce.anyOf(
+          types_1.typeforce.BufferN(64),
+          types_1.typeforce.BufferN(65),
+        ),
       ),
       witness: types_1.typeforce.maybe(
         types_1.typeforce.arrayOf(types_1.typeforce.Buffer),

--- a/test/fixtures/psbt.json
+++ b/test/fixtures/psbt.json
@@ -769,10 +769,11 @@
       },
       {
         "description": "checks taproot signing works when using custom signature type of 65 bytes",
+        "isTaproot": true,
         "shouldSign": {
           "psbt": "cHNidP8BAF4CAAAAAf17fGksrz9eKGx1nSU3RX4vcwr7bfNdQzPZ9dSEkWBcAAAAAAD/////AZBBBgAAAAAAIlEgPLBe/d3922lmXjTIt52b9NG1HFDC9jzPCTn111AG8TQAAAAAAAEBK6BoBgAAAAAAIlEgPLBe/d3922lmXjTIt52b9NG1HFDC9jzPCTn111AG8TQBAwSDAAAAARcgWzC4qnD37J3WaDEbZPRihBXdI0gN68BGutJykDcHR6wBGCDlDrX1cnzwZvmcyLBH8M6NiS9lk7JVwM58wZZVOzmuMwAA",
           "sighashTypes": [
-            3, 128
+            131
           ],
           "inputToCheck": 0,
           "WIF": "KypUz2y1jdgzM8HGDUx9DYLmyzd8EWhruvLX2J5iSL7MiAcc7dBG",

--- a/test/fixtures/psbt.json
+++ b/test/fixtures/psbt.json
@@ -768,6 +768,15 @@
         }
       },
       {
+        "description": "checks taproot signing works when using custom signature type of 65 bytes",
+        "shouldSign": {
+          "psbt": "cHNidP8BAF4CAAAAAf17fGksrz9eKGx1nSU3RX4vcwr7bfNdQzPZ9dSEkWBcAAAAAAD/////AZBBBgAAAAAAIlEgPLBe/d3922lmXjTIt52b9NG1HFDC9jzPCTn111AG8TQAAAAAAAEBK6BoBgAAAAAAIlEgPLBe/d3922lmXjTIt52b9NG1HFDC9jzPCTn111AG8TQBAwSDAAAAARcgWzC4qnD37J3WaDEbZPRihBXdI0gN68BGutJykDcHR6wBGCDlDrX1cnzwZvmcyLBH8M6NiS9lk7JVwM58wZZVOzmuMwAA",
+          "inputToCheck": 0,
+          "WIF": "KypUz2y1jdgzM8HGDUx9DYLmyzd8EWhruvLX2J5iSL7MiAcc7dBG",
+          "result": "cHNidP8BAF4CAAAAAf17fGksrz9eKGx1nSU3RX4vcwr7bfNdQzPZ9dSEkWBcAAAAAAD/////AZBBBgAAAAAAIlEgPLBe/d3922lmXjTIt52b9NG1HFDC9jzPCTn111AG8TQAAAAAAAEBK6BoBgAAAAAAIlEgPLBe/d3922lmXjTIt52b9NG1HFDC9jzPCTn111AG8TQBAwSDAAAAARNBqgjqjSQVTf41zgZ1H9Lq3CKQt0nq1APST8FpwGifNjyUHMS0MbFnIxA70SXTEOoSJePyOXTW+u59fzLpxekL2oMBFyBbMLiqcPfsndZoMRtk9GKEFd0jSA3rwEa60nKQNwdHrAEYIOUOtfVyfPBm+ZzIsEfwzo2JL2WTslXAznzBllU7Oa4zAAA="
+        }
+      },
+      {
         "description": "checks taproot key-path signer (tweaked key) matches internal tap key",
         "isTaproot": true,
         "shouldSign": {

--- a/test/fixtures/psbt.json
+++ b/test/fixtures/psbt.json
@@ -771,6 +771,9 @@
         "description": "checks taproot signing works when using custom signature type of 65 bytes",
         "shouldSign": {
           "psbt": "cHNidP8BAF4CAAAAAf17fGksrz9eKGx1nSU3RX4vcwr7bfNdQzPZ9dSEkWBcAAAAAAD/////AZBBBgAAAAAAIlEgPLBe/d3922lmXjTIt52b9NG1HFDC9jzPCTn111AG8TQAAAAAAAEBK6BoBgAAAAAAIlEgPLBe/d3922lmXjTIt52b9NG1HFDC9jzPCTn111AG8TQBAwSDAAAAARcgWzC4qnD37J3WaDEbZPRihBXdI0gN68BGutJykDcHR6wBGCDlDrX1cnzwZvmcyLBH8M6NiS9lk7JVwM58wZZVOzmuMwAA",
+          "sighashTypes": [
+            3, 128
+          ],
           "inputToCheck": 0,
           "WIF": "KypUz2y1jdgzM8HGDUx9DYLmyzd8EWhruvLX2J5iSL7MiAcc7dBG",
           "result": "cHNidP8BAF4CAAAAAf17fGksrz9eKGx1nSU3RX4vcwr7bfNdQzPZ9dSEkWBcAAAAAAD/////AZBBBgAAAAAAIlEgPLBe/d3922lmXjTIt52b9NG1HFDC9jzPCTn111AG8TQAAAAAAAEBK6BoBgAAAAAAIlEgPLBe/d3922lmXjTIt52b9NG1HFDC9jzPCTn111AG8TQBAwSDAAAAARNBqgjqjSQVTf41zgZ1H9Lq3CKQt0nq1APST8FpwGifNjyUHMS0MbFnIxA70SXTEOoSJePyOXTW+u59fzLpxekL2oMBFyBbMLiqcPfsndZoMRtk9GKEFd0jSA3rwEa60nKQNwdHrAEYIOUOtfVyfPBm+ZzIsEfwzo2JL2WTslXAznzBllU7Oa4zAAA="

--- a/ts_src/payments/p2tr.ts
+++ b/ts_src/payments/p2tr.ts
@@ -40,9 +40,7 @@ export function p2tr(a: Payment, opts?: PaymentOpts): Payment {
       internalPubkey: typef.maybe(typef.BufferN(32)),
       hash: typef.maybe(typef.BufferN(32)), // merkle root hash, the tweak
       pubkey: typef.maybe(typef.BufferN(32)), // tweaked with `hash` from `internalPubkey`
-      signature: typef.maybe(
-        typef.anyOf[(typef.BufferN(64), typef.BufferN(65))],
-      ),
+      signature: typef.maybe(typef.anyOf(typef.BufferN(64), typef.BufferN(65))),
       witness: typef.maybe(typef.arrayOf(typef.Buffer)),
       scriptTree: typef.maybe(isTaptree),
       redeem: typef.maybe({

--- a/ts_src/payments/p2tr.ts
+++ b/ts_src/payments/p2tr.ts
@@ -40,7 +40,9 @@ export function p2tr(a: Payment, opts?: PaymentOpts): Payment {
       internalPubkey: typef.maybe(typef.BufferN(32)),
       hash: typef.maybe(typef.BufferN(32)), // merkle root hash, the tweak
       pubkey: typef.maybe(typef.BufferN(32)), // tweaked with `hash` from `internalPubkey`
-      signature: typef.maybe(typef.BufferN(64)),
+      signature: typef.maybe(
+        typef.anyOf[(typef.BufferN(64), typef.BufferN(65))],
+      ),
       witness: typef.maybe(typef.arrayOf(typef.Buffer)),
       scriptTree: typef.maybe(isTaptree),
       redeem: typef.maybe({


### PR DESCRIPTION
Taproot signatures can be 65 bytes if using a custom signature type