### PR TITLE
fix: android `TypedArray.of requires its this argument to subclass a TypedArray constructor`

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -389,7 +389,7 @@ class Transaction {
     // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-19
     return bcrypto.taggedHash(
       'TapSighash',
-      Buffer.concat([Buffer.alloc(1), sigMsgWriter.end()]),
+      Buffer.concat([Buffer.from([0x00]), sigMsgWriter.end()]),
     );
   }
   hashForWitnessV0(inIndex, prevOutScript, value, hashType) {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -389,7 +389,7 @@ class Transaction {
     // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-19
     return bcrypto.taggedHash(
       'TapSighash',
-      Buffer.concat([Buffer.of(0x00), sigMsgWriter.end()]),
+      Buffer.concat([Buffer.alloc(1), sigMsgWriter.end()]),
     );
   }
   hashForWitnessV0(inIndex, prevOutScript, value, hashType) {

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -490,7 +490,7 @@ export class Transaction {
     // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-19
     return bcrypto.taggedHash(
       'TapSighash',
-      Buffer.concat([Buffer.alloc(1), sigMsgWriter.end()]),
+      Buffer.concat([Buffer.from([0x00]), sigMsgWriter.end()]),
     );
   }
 

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -490,7 +490,7 @@ export class Transaction {
     // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-19
     return bcrypto.taggedHash(
       'TapSighash',
-      Buffer.concat([Buffer.of(0x00), sigMsgWriter.end()]),
+      Buffer.concat([Buffer.alloc(1), sigMsgWriter.end()]),
     );
   }
 


### PR DESCRIPTION
Hi team, thank you for providing and maintaining this library.

Physical android devices don't like the `Buffer.of(num)`. We are noticing `TypedArray.of requires its this argument to subclass a TypedArray constructor` signing taproot utxos. 

This could be an env problem poly filling `Buffer.of`, just that this pretty safe `Buffer.alloc` change saves this. In case other also have this problem
