### PR TITLE
Upgrade bip174 to 2.1.1.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "bitcoinjs-lib",
-      "version": "6.1.3",
+      "version": "6.1.4",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
-        "bip174": "^2.1.0",
+        "bip174": "^2.1.1",
         "bs58check": "^3.0.1",
         "typeforce": "^1.11.3",
         "varuint-bitcoin": "^1.1.2"
@@ -1171,9 +1171,9 @@
       }
     },
     "node_modules/bip174": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.0.tgz",
-      "integrity": "sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
+      "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5267,9 +5267,9 @@
       "dev": true
     },
     "bip174": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.0.tgz",
-      "integrity": "sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
+      "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ=="
     },
     "bip32": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@noble/hashes": "^1.2.0",
     "bech32": "^2.0.0",
-    "bip174": "^2.1.0",
+    "bip174": "^2.1.1",
     "bs58check": "^3.0.1",
     "typeforce": "^1.11.3",
     "varuint-bitcoin": "^1.1.2"


### PR DESCRIPTION
This fixes adding unknownKeyVals to outputs, which otherwise are being added to inputs.