### PR TITLE
Only warn once for forward segwit warnings

### DIFF
--- a/src/cjs/address.cjs
+++ b/src/cjs/address.cjs
@@ -73,6 +73,7 @@ const FUTURE_SEGWIT_VERSION_WARNING =
   'End users MUST be warned carefully in the GUI and asked if they wish to proceed ' +
   'with caution. Wallets should verify the segwit version from the output of fromBech32, ' +
   'then decide when it is safe to use which version of segwit.';
+const WARNING_STATES = [false, false];
 /**
  * Converts an output buffer to a future segwit address.
  * @param output - The output buffer.
@@ -95,7 +96,10 @@ function _toFutureSegwitAddress(output, network) {
     throw new TypeError('Invalid version for segwit address');
   if (output[1] !== data.length)
     throw new TypeError('Invalid script for segwit address');
-  console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+  if (WARNING_STATES[0] === false) {
+    console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+    WARNING_STATES[0] = true;
+  }
   return toBech32(data, version, network.bech32);
 }
 /**
@@ -241,7 +245,10 @@ function toOutputScript(address, network) {
         decodeBech32.data.length >= FUTURE_SEGWIT_MIN_SIZE &&
         decodeBech32.data.length <= FUTURE_SEGWIT_MAX_SIZE
       ) {
-        console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+        if (WARNING_STATES[1] === false) {
+          console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+          WARNING_STATES[1] = true;
+        }
         return bscript.compile([
           decodeBech32.version + FUTURE_SEGWIT_VERSION_DIFF,
           decodeBech32.data,

--- a/src/esm/address.js
+++ b/src/esm/address.js
@@ -16,6 +16,7 @@ const FUTURE_SEGWIT_VERSION_WARNING =
   'End users MUST be warned carefully in the GUI and asked if they wish to proceed ' +
   'with caution. Wallets should verify the segwit version from the output of fromBech32, ' +
   'then decide when it is safe to use which version of segwit.';
+const WARNING_STATES = [false, false];
 /**
  * Converts an output buffer to a future segwit address.
  * @param output - The output buffer.
@@ -38,7 +39,10 @@ function _toFutureSegwitAddress(output, network) {
     throw new TypeError('Invalid version for segwit address');
   if (output[1] !== data.length)
     throw new TypeError('Invalid script for segwit address');
-  console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+  if (WARNING_STATES[0] === false) {
+    console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+    WARNING_STATES[0] = true;
+  }
   return toBech32(data, version, network.bech32);
 }
 /**
@@ -181,7 +185,10 @@ export function toOutputScript(address, network) {
         decodeBech32.data.length >= FUTURE_SEGWIT_MIN_SIZE &&
         decodeBech32.data.length <= FUTURE_SEGWIT_MAX_SIZE
       ) {
-        console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+        if (WARNING_STATES[1] === false) {
+          console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+          WARNING_STATES[1] = true;
+        }
         return bscript.compile([
           decodeBech32.version + FUTURE_SEGWIT_VERSION_DIFF,
           decodeBech32.data,

--- a/ts_src/address.ts
+++ b/ts_src/address.ts
@@ -45,6 +45,7 @@ const FUTURE_SEGWIT_VERSION_WARNING: string =
   'End users MUST be warned carefully in the GUI and asked if they wish to proceed ' +
   'with caution. Wallets should verify the segwit version from the output of fromBech32, ' +
   'then decide when it is safe to use which version of segwit.';
+const WARNING_STATES: boolean[] = [false, false];
 
 /**
  * Converts an output buffer to a future segwit address.
@@ -73,7 +74,10 @@ function _toFutureSegwitAddress(output: Uint8Array, network: Network): string {
   if (output[1] !== data.length)
     throw new TypeError('Invalid script for segwit address');
 
-  console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+  if (WARNING_STATES[0] === false) {
+    console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+    WARNING_STATES[0] = true;
+  }
 
   return toBech32(data, version, network.bech32);
 }
@@ -247,7 +251,10 @@ export function toOutputScript(address: string, network?: Network): Uint8Array {
         decodeBech32.data.length >= FUTURE_SEGWIT_MIN_SIZE &&
         decodeBech32.data.length <= FUTURE_SEGWIT_MAX_SIZE
       ) {
-        console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+        if (WARNING_STATES[1] === false) {
+          console.warn(FUTURE_SEGWIT_VERSION_WARNING);
+          WARNING_STATES[1] = true;
+        }
 
         return bscript.compile([
           decodeBech32.version + FUTURE_SEGWIT_VERSION_DIFF,


### PR DESCRIPTION
Fixes #1800 

This will lower the noise especially for long running parsing processes.