### PR TITLE
Fix: add new type to allow toBase58Check to get string in browser

### DIFF
--- a/src/address.d.ts
+++ b/src/address.d.ts
@@ -36,7 +36,7 @@ export declare function fromBech32(address: string): Bech32Result;
 /**
  * encode address hash to base58 address with version
  */
-export declare function toBase58Check(hash: Buffer, version: number): string;
+export declare function toBase58Check(hash: Buffer | string, version: number): string;
 /**
  * encode address hash to bech32 address with version and prefix
  */

--- a/src/address.js
+++ b/src/address.js
@@ -83,9 +83,10 @@ exports.fromBech32 = fromBech32;
  * encode address hash to base58 address with version
  */
 function toBase58Check(hash, version) {
+  hash = Buffer.isBuffer(hash) ? hash : Buffer.from(hash, 'hex');
   (0, types_1.typeforce)(
     (0, types_1.tuple)(types_1.Hash160bit, types_1.UInt8),
-    arguments,
+    [hash, version],
   );
   const payload = Buffer.allocUnsafe(21);
   payload.writeUInt8(version, 0);

--- a/test/address.spec.ts
+++ b/test/address.spec.ts
@@ -101,6 +101,12 @@ describe('address', () => {
 
         assert.strictEqual(address, f.base58check);
       });
+
+      it('encodes ' + f.hash + ' (' + f.network + ')', () => {
+        const address = baddress.toBase58Check(f.hash, f.version);
+
+        assert.strictEqual(address, f.base58check);
+      });
     });
   });
 

--- a/ts_src/address.ts
+++ b/ts_src/address.ts
@@ -116,8 +116,9 @@ export function fromBech32(address: string): Bech32Result {
 /**
  * encode address hash to base58 address with version
  */
-export function toBase58Check(hash: Buffer, version: number): string {
-  typeforce(tuple(Hash160bit, UInt8), arguments);
+export function toBase58Check(hash: Buffer | string, version: number): string {
+  hash = Buffer.isBuffer(hash) ? hash : Buffer.from(hash, 'hex');
+  typeforce(tuple(Hash160bit, UInt8), [hash, version]);
 
   const payload = Buffer.allocUnsafe(21);
   payload.writeUInt8(version, 0);


### PR DESCRIPTION
Issue:
fixes #2070 

Aim:
- Allow toBase58Check to get string param.

Reason:
1. I can't use toBase58Check in the browser. It mentioned this error: **Error: Expected property "0" of type Buffer, got Uint8Array**
![image](https://github.com/bitcoinjs/bitcoinjs-lib/assets/25654385/23689909-ab9d-4827-8a41-fbf7d7157188)

Link: https://jasonandjay.github.io/bitcoinjs-lib/functions/address.fromBase58Check.html
Code:

```js
// You can test it here and find more case in test/address.spec.ts
const encoder = new TextEncoder();
const hash = encoder.encode('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH')
const decode = address.toBase58Check(hash)

console.log(decode.version) // 0

console.log(decode.hash.toString('hex')) // 751e76e8199196d454941c45d1b3a323f1433bd6
```
