### PR TITLE
Remove methods that neither used nor export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/*.js
 test/integration/*.js
 !test/ts-node-register.js
 docs
+plugin

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,15 +13,7 @@ export declare function stacksEqual(a: Buffer[], b: Buffer[]): boolean;
  * @returns True if the value is a valid elliptic curve point, false otherwise.
  */
 export declare function isPoint(p: Buffer | number | undefined | null): boolean;
-export declare function UInt31(value: number): boolean;
-export declare function BIP32Path(value: string): boolean;
-export declare namespace BIP32Path {
-    var toJSON: () => string;
-}
-export declare function Signer(obj: any): boolean;
 export declare function Satoshi(value: number): boolean;
-export declare const ECPoint: any;
-export declare const Network: any;
 export interface XOnlyPointAddTweakResult {
     parity: 1 | 0;
     xOnlyPubkey: Uint8Array;

--- a/src/types.js
+++ b/src/types.js
@@ -20,12 +20,7 @@ exports.oneOf =
   exports.isTaptree =
   exports.isTapleaf =
   exports.TAPLEAF_VERSION_MASK =
-  exports.Network =
-  exports.ECPoint =
   exports.Satoshi =
-  exports.Signer =
-  exports.BIP32Path =
-  exports.UInt31 =
   exports.isPoint =
   exports.stacksEqual =
   exports.typeforce =
@@ -72,49 +67,11 @@ function isPoint(p) {
   return false;
 }
 exports.isPoint = isPoint;
-const UINT31_MAX = Math.pow(2, 31) - 1;
-function UInt31(value) {
-  return exports.typeforce.UInt32(value) && value <= UINT31_MAX;
-}
-exports.UInt31 = UInt31;
-function BIP32Path(value) {
-  return (
-    exports.typeforce.String(value) && !!value.match(/^(m\/)?(\d+'?\/)*\d+'?$/)
-  );
-}
-exports.BIP32Path = BIP32Path;
-BIP32Path.toJSON = () => {
-  return 'BIP32 derivation path';
-};
-function Signer(obj) {
-  return (
-    (exports.typeforce.Buffer(obj.publicKey) ||
-      typeof obj.getPublicKey === 'function') &&
-    typeof obj.sign === 'function'
-  );
-}
-exports.Signer = Signer;
 const SATOSHI_MAX = 21 * 1e14;
 function Satoshi(value) {
   return exports.typeforce.UInt53(value) && value <= SATOSHI_MAX;
 }
 exports.Satoshi = Satoshi;
-// external dependent types
-exports.ECPoint = exports.typeforce.quacksLike('Point');
-// exposed, external API
-exports.Network = exports.typeforce.compile({
-  messagePrefix: exports.typeforce.oneOf(
-    exports.typeforce.Buffer,
-    exports.typeforce.String,
-  ),
-  bip32: {
-    public: exports.typeforce.UInt32,
-    private: exports.typeforce.UInt32,
-  },
-  pubKeyHash: exports.typeforce.UInt8,
-  scriptHash: exports.typeforce.UInt8,
-  wif: exports.typeforce.UInt8,
-});
 exports.TAPLEAF_VERSION_MASK = 0xfe;
 function isTapleaf(o) {
   if (!o || !('output' in o)) return false;

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -54,41 +54,4 @@ describe('types', () => {
       });
     });
   });
-
-  describe('UInt31', () => {
-    const UINT31_MAX = Math.pow(2, 31) - 1;
-    it('return true for valid values', () => {
-      assert.strictEqual(types.UInt31(0), true);
-      assert.strictEqual(types.UInt31(1000), true);
-      assert.strictEqual(types.UInt31(UINT31_MAX), true);
-    });
-
-    it('return false for negative values', () => {
-      assert.strictEqual(types.UInt31(-1), false);
-      assert.strictEqual(types.UInt31(-UINT31_MAX), false);
-    });
-
-    it(`return false for value > ${UINT31_MAX}`, () => {
-      assert.strictEqual(types.UInt31(UINT31_MAX + 1), false);
-    });
-  });
-
-  describe('BIP32Path', () => {
-    it('return true for valid paths', () => {
-      assert.strictEqual(types.BIP32Path("m/0'/0'"), true);
-      assert.strictEqual(types.BIP32Path("m/0'/0"), true);
-      assert.strictEqual(types.BIP32Path("m/0'/1'/2'/3/4'"), true);
-    });
-
-    it('return false for invalid paths', () => {
-      assert.strictEqual(types.BIP32Path('m'), false);
-      assert.strictEqual(types.BIP32Path("n/0'/0'"), false);
-      assert.strictEqual(types.BIP32Path("m/0'/x"), false);
-    });
-
-    it('return "BIP32 derivation path" for JSON.strigify()', () => {
-      const toJsonValue = JSON.stringify(types.BIP32Path);
-      assert.equal(toJsonValue, '"BIP32 derivation path"');
-    });
-  });
 });

--- a/ts_src/types.ts
+++ b/ts_src/types.ts
@@ -46,45 +46,10 @@ export function isPoint(p: Buffer | number | undefined | null): boolean {
   return false;
 }
 
-const UINT31_MAX: number = Math.pow(2, 31) - 1;
-export function UInt31(value: number): boolean {
-  return typeforce.UInt32(value) && value <= UINT31_MAX;
-}
-
-export function BIP32Path(value: string): boolean {
-  return typeforce.String(value) && !!value.match(/^(m\/)?(\d+'?\/)*\d+'?$/);
-}
-BIP32Path.toJSON = (): string => {
-  return 'BIP32 derivation path';
-};
-
-export function Signer(obj: any): boolean {
-  return (
-    (typeforce.Buffer(obj.publicKey) ||
-      typeof obj.getPublicKey === 'function') &&
-    typeof obj.sign === 'function'
-  );
-}
-
 const SATOSHI_MAX: number = 21 * 1e14;
 export function Satoshi(value: number): boolean {
   return typeforce.UInt53(value) && value <= SATOSHI_MAX;
 }
-
-// external dependent types
-export const ECPoint = typeforce.quacksLike('Point');
-
-// exposed, external API
-export const Network = typeforce.compile({
-  messagePrefix: typeforce.oneOf(typeforce.Buffer, typeforce.String),
-  bip32: {
-    public: typeforce.UInt32,
-    private: typeforce.UInt32,
-  },
-  pubKeyHash: typeforce.UInt8,
-  scriptHash: typeforce.UInt8,
-  wif: typeforce.UInt8,
-});
 
 export interface XOnlyPointAddTweakResult {
   parity: 1 | 0;


### PR DESCRIPTION
1.  For Signer & Network, we have defined and exported it from psbt module.
2.  For UInt31, BIP32Path and ECPoint, we have neither used nor exported them. The check of BIP32Path should be related to BIP32, and ECPoint should be related to ECPair. This project is not suitable for checking.

So I think it's time to remove this methods.

In addition, I suggest that we stop using typeforce to verify input parameters and use ts types instead for better maintenance.