### PR TITLE
Allow PSBT to use `bip174`'s getTransaction method

### DIFF
--- a/src/psbt.d.ts
+++ b/src/psbt.d.ts
@@ -119,6 +119,7 @@ export declare class Psbt {
     updateGlobal(updateData: PsbtGlobalUpdate): this;
     updateInput(inputIndex: number, updateData: PsbtInputUpdate): this;
     updateOutput(outputIndex: number, updateData: PsbtOutputUpdate): this;
+    getTransaction(): Buffer;
     addUnknownKeyValToGlobal(keyVal: KeyValue): this;
     addUnknownKeyValToInput(inputIndex: number, keyVal: KeyValue): this;
     addUnknownKeyValToOutput(outputIndex: number, keyVal: KeyValue): this;

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -901,6 +901,9 @@ class Psbt {
     this.data.updateOutput(outputIndex, updateData);
     return this;
   }
+  getTransaction() {
+    return this.data.getTransaction();
+  }
   addUnknownKeyValToGlobal(keyVal) {
     this.data.addUnknownKeyValToGlobal(keyVal);
     return this;

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -1111,6 +1111,10 @@ export class Psbt {
     return this;
   }
 
+  getTransaction(): Buffer {
+    return this.data.getTransaction();
+  }
+
   addUnknownKeyValToGlobal(keyVal: KeyValue): this {
     this.data.addUnknownKeyValToGlobal(keyVal);
     return this;


### PR DESCRIPTION
Small change that allows this repository's `Psbt` class to access a method present in the `PsbtBase`, which comes from the `bip174` package. Currently, this method is not accessible:

https://github.com/bitcoinjs/bip174/blob/25fd6842b76984b169d8f0be2adcb3db322fe98c/ts_src/lib/psbt.ts#L188-L190

---

## Context

I am working with a multi-party computation system where I'd like to build a PSBT with intermediate steps. Among those steps is asking the MPC to sign each input UTXO.

In order to get the sighash for each input, it seems the `Transaction` object is needed, since it contains methods like `hashForSignature`.

My original approach was to build a PSBT incrementally, but I could not determine how to extract the Transaction object from the PSBT. My attempts seemed to always necessitate "finalizing inputs" which I cannot do until I've gathered the signatures from the MPCs for each input.

If I'm tracking this problem correctly, I believe I'd currently have to create independent Transaction objects in this library for each input UTXO, get the signatures, and then be able to create the PSBT, extract the finalized transaction, and broadcast. With the small change in this PR, the PSBT can exist from the start.