### PR TITLE
sign tapLeaf with sighashType

### DIFF
--- a/src/psbt.js
+++ b/src/psbt.js
@@ -1358,7 +1358,7 @@ function getTaprootHashesForSig(
         inputIndex,
         signingScripts,
         values,
-        transaction_1.Transaction.SIGHASH_DEFAULT,
+        sighashType,
         tapLeaf.hash,
       );
       return {

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -1789,7 +1789,7 @@ function getTaprootHashesForSig(
         inputIndex,
         signingScripts,
         values,
-        Transaction.SIGHASH_DEFAULT,
+        sighashType,
         tapLeaf.hash,
       );
 


### PR DESCRIPTION
Fixes #2046 

The pathch is for https://github.com/bitcoinjs/bitcoinjs-lib/issues/2046
it supports sighashType replace sighash_default. 