### PR TITLE
fix: added error with clear message when signing a tx without outputs

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -318,6 +318,8 @@ class Transaction {
       hashSequences = bcrypto.sha256(bufferWriter.end());
     }
     if (!(isNone || isSingle)) {
+      if (!this.outs.length)
+        throw new Error('Add outputs to the transaction before signing.');
       const txOutsSize = this.outs
         .map(output => 8 + varSliceSize(output.script))
         .reduce((a, b) => a + b);

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -414,6 +414,8 @@ export class Transaction {
     }
 
     if (!(isNone || isSingle)) {
+      if (!this.outs.length)
+        throw new Error('Add outputs to the transaction before signing.');
       const txOutsSize = this.outs
         .map(output => 8 + varSliceSize(output.script))
         .reduce((a, b) => a + b);


### PR DESCRIPTION
There's this line of code ```this.outs.map(output => 8 + varSliceSize(output.script)).reduce((a, b) => a + b)``` that, when the unsigned transaction has no outputs set, ```this.outs``` is an empty array and the only error it throws says "Reduce of empty array with no initial value", which makes one dig into the bitcoinjs code and understand what it was trying to do. Now the error message helps to understand what is happening.