### PR TITLE
feat: support taproot for signAllInputsHD

### DIFF
--- a/src/payments/bip341.d.ts
+++ b/src/payments/bip341.d.ts
@@ -35,6 +35,13 @@ export declare function rootHashFromPath(controlBlock: Buffer, leafHash: Buffer)
  */
 export declare function toHashTree(scriptTree: Taptree): HashTree;
 /**
+ * Calculates the Merkle root from an array of Taproot leaf hashes.
+ *
+ * @param {Buffer[]} leafHashes - Array of Taproot leaf hashes.
+ * @returns {Buffer} - The Merkle root.
+ */
+export declare function calculateScriptTreeMerkleRoot(leafHashes: Buffer[]): Buffer | undefined;
+/**
  * Given a HashTree, finds the path from a particular hash to the root.
  * @param node - the root of the tree
  * @param hash - the hash to search for

--- a/src/payments/bip341.js
+++ b/src/payments/bip341.js
@@ -68,12 +68,12 @@ exports.toHashTree = toHashTree;
  */
 function calculateScriptTreeMerkleRoot(leafHashes) {
   if (!leafHashes || leafHashes.length === 0) {
-    return undefined;
+    return Buffer.from([]);
   }
   leafHashes.sort((a, b) => a.compare(b));
   const hashes = leafHashes.map(hash => {
     return {
-      hash: bcrypto.taggedHash('TapLeaf', buffer_1.Buffer.from(hash)),
+      hash,
     };
   });
   while (hashes.length > 1) {
@@ -81,11 +81,17 @@ function calculateScriptTreeMerkleRoot(leafHashes) {
     for (let i = 0; i < hashes.length; i += 2) {
       const left = hashes[i];
       const right = i + 1 === hashes.length ? left : hashes[i + 1];
-      nextLevel.push({
-        hash: tapBranchHash(left.hash, right.hash),
-        left,
-        right,
-      });
+      if (i + 1 === hashes.length) {
+        nextLevel.push({
+          hash: left.hash,
+          left,
+          right,
+        });
+      } else {
+        nextLevel.push({
+          hash: tapBranchHash(left.hash, right.hash),
+        });
+      }
     }
     hashes.length = 0;
     hashes.push(...nextLevel);

--- a/src/psbt.d.ts
+++ b/src/psbt.d.ts
@@ -160,6 +160,14 @@ export interface HDSigner extends HDSignerBase {
      * Return a 64 byte signature (32 byte r and 32 byte s in that order)
      */
     sign(hash: Buffer): Buffer;
+    /**
+     * Adjusts a keypair for Taproot payments by applying a tweak to derive the internal key.
+     *
+     * In Taproot, a keypair may need to be tweaked to produce an internal key that conforms to the Taproot script.
+     * This tweak process involves modifying the original keypair based on a specific tweak value to ensure compatibility
+     * with the Taproot address format and functionality.
+     */
+    tweak(t: Buffer): Signer;
 }
 /**
  * Same as above but with async sign method
@@ -167,6 +175,7 @@ export interface HDSigner extends HDSignerBase {
 export interface HDSignerAsync extends HDSignerBase {
     derivePath(path: string): HDSignerAsync;
     sign(hash: Buffer): Promise<Buffer>;
+    tweak(t: Buffer): Signer;
 }
 export interface Signer {
     publicKey: Buffer;

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -500,10 +500,7 @@ class Psbt {
     }
     return validationResultCount > 0;
   }
-  signAllInputsHD(
-    hdKeyPair,
-    sighashTypes = [transaction_1.Transaction.SIGHASH_ALL],
-  ) {
+  signAllInputsHD(hdKeyPair, sighashTypes) {
     if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
       throw new Error('Need HDSigner to sign input');
     }
@@ -521,10 +518,7 @@ class Psbt {
     }
     return this;
   }
-  signAllInputsHDAsync(
-    hdKeyPair,
-    sighashTypes = [transaction_1.Transaction.SIGHASH_ALL],
-  ) {
+  signAllInputsHDAsync(hdKeyPair, sighashTypes) {
     return new Promise((resolve, reject) => {
       if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
         return reject(new Error('Need HDSigner to sign input'));
@@ -551,11 +545,7 @@ class Psbt {
       });
     });
   }
-  signInputHD(
-    inputIndex,
-    hdKeyPair,
-    sighashTypes = [transaction_1.Transaction.SIGHASH_ALL],
-  ) {
+  signInputHD(inputIndex, hdKeyPair, sighashTypes) {
     if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
       throw new Error('Need HDSigner to sign input');
     }
@@ -563,11 +553,7 @@ class Psbt {
     signers.forEach(signer => this.signInput(inputIndex, signer, sighashTypes));
     return this;
   }
-  signInputHDAsync(
-    inputIndex,
-    hdKeyPair,
-    sighashTypes = [transaction_1.Transaction.SIGHASH_ALL],
-  ) {
+  signInputHDAsync(inputIndex, hdKeyPair, sighashTypes) {
     return new Promise((resolve, reject) => {
       if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
         return reject(new Error('Need HDSigner to sign input'));

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -1481,11 +1481,14 @@ function getTweakSignersFromHD(inputIndex, inputs, hdKeyPair) {
   }
   const signers = myDerivations.map(bipDv => {
     const node = hdKeyPair.derivePath(bipDv.path);
-    if (!bipDv.pubkey.equals(node.publicKey)) {
+    if (!bipDv.pubkey.equals((0, bip371_1.toXOnly)(node.publicKey))) {
       throw new Error('pubkey did not match tapBip32Derivation');
     }
     const h = (0, bip341_1.calculateScriptTreeMerkleRoot)(bipDv.leafHashes);
-    const tweakValue = (0, bip341_1.tapTweakHash)(node.publicKey, h);
+    const tweakValue = (0, bip341_1.tapTweakHash)(
+      (0, bip371_1.toXOnly)(node.publicKey),
+      h,
+    );
     return node.tweak(tweakValue);
   });
   return signers;

--- a/ts_src/payments/bip341.ts
+++ b/ts_src/payments/bip341.ts
@@ -92,13 +92,13 @@ export function calculateScriptTreeMerkleRoot(
   leafHashes: Buffer[],
 ): Buffer | undefined {
   if (!leafHashes || leafHashes.length === 0) {
-    return undefined;
+    return Buffer.from([]);
   }
   leafHashes.sort((a, b) => a.compare(b));
 
   const hashes = leafHashes.map(hash => {
     return {
-      hash: bcrypto.taggedHash('TapLeaf', NBuffer.from(hash)),
+      hash,
     };
   });
   while (hashes.length > 1) {
@@ -106,15 +106,22 @@ export function calculateScriptTreeMerkleRoot(
     for (let i = 0; i < hashes.length; i += 2) {
       const left = hashes[i];
       const right = i + 1 === hashes.length ? left : hashes[i + 1];
-      nextLevel.push({
-        hash: tapBranchHash(left.hash, right.hash),
-        left,
-        right,
-      });
+      if (i + 1 === hashes.length) {
+        nextLevel.push({
+          hash: left.hash,
+          left,
+          right,
+        });
+      } else {
+        nextLevel.push({
+          hash: tapBranchHash(left.hash, right.hash),
+        });
+      }
     }
     hashes.length = 0;
     hashes.push(...nextLevel);
   }
+
   return hashes[0].hash;
 }
 

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -19,7 +19,11 @@ import { fromOutputScript, toOutputScript } from './address';
 import { cloneBuffer, reverseBuffer } from './bufferutils';
 import { bitcoin as btcNetwork, Network } from './networks';
 import * as payments from './payments';
-import { tapleafHash } from './payments/bip341';
+import {
+  calculateScriptTreeMerkleRoot,
+  tapleafHash,
+  tapTweakHash,
+} from './payments/bip341';
 import * as bscript from './script';
 import { Output, Transaction } from './transaction';
 import {
@@ -1189,6 +1193,14 @@ export interface HDSigner extends HDSignerBase {
    * Return a 64 byte signature (32 byte r and 32 byte s in that order)
    */
   sign(hash: Buffer): Buffer;
+  /**
+   * Adjusts a keypair for Taproot payments by applying a tweak to derive the internal key.
+   *
+   * In Taproot, a keypair may need to be tweaked to produce an internal key that conforms to the Taproot script.
+   * This tweak process involves modifying the original keypair based on a specific tweak value to ensure compatibility
+   * with the Taproot address format and functionality.
+   */
+  tweak(t: Buffer): Signer;
 }
 
 /**
@@ -1197,6 +1209,7 @@ export interface HDSigner extends HDSignerBase {
 export interface HDSignerAsync extends HDSignerBase {
   derivePath(path: string): HDSignerAsync;
   sign(hash: Buffer): Promise<Buffer>;
+  tweak(t: Buffer): Signer;
 }
 
 export interface Signer {
@@ -1903,6 +1916,10 @@ function getSignersFromHD(
   hdKeyPair: HDSigner | HDSignerAsync,
 ): Array<Signer | SignerAsync> {
   const input = checkForInput(inputs, inputIndex);
+  if (isTaprootInput(input)) {
+    return getTweakSignersFromHD(inputIndex, inputs, hdKeyPair);
+  }
+
   if (!input.bip32Derivation || input.bip32Derivation.length === 0) {
     throw new Error('Need bip32Derivation to sign with HD');
   }
@@ -1926,6 +1943,43 @@ function getSignersFromHD(
       throw new Error('pubkey did not match bip32Derivation');
     }
     return node;
+  });
+  return signers;
+}
+
+function getTweakSignersFromHD(
+  inputIndex: number,
+  inputs: PsbtInput[],
+  hdKeyPair: HDSigner | HDSignerAsync,
+): Array<Signer | SignerAsync> {
+  const input = checkForInput(inputs, inputIndex);
+  if (!input.tapBip32Derivation || input.tapBip32Derivation.length === 0) {
+    throw new Error('Need tapBip32Derivation to sign with HD');
+  }
+  const myDerivations = input.tapBip32Derivation
+    .map(bipDv => {
+      if (bipDv.masterFingerprint.equals(hdKeyPair.fingerprint)) {
+        return bipDv;
+      } else {
+        return;
+      }
+    })
+    .filter(v => !!v);
+  if (myDerivations.length === 0) {
+    throw new Error(
+      'Need one tapBip32Derivation masterFingerprint to match the HDSigner fingerprint',
+    );
+  }
+
+  const signers: Array<Signer | SignerAsync> = myDerivations.map(bipDv => {
+    const node = hdKeyPair.derivePath(bipDv!.path);
+    if (!bipDv!.pubkey.equals(node.publicKey)) {
+      throw new Error('pubkey did not match tapBip32Derivation');
+    }
+    const h = calculateScriptTreeMerkleRoot(bipDv!.leafHashes);
+    const tweakValue = tapTweakHash(node.publicKey, h);
+
+    return node.tweak(tweakValue);
   });
   return signers;
 }

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -645,10 +645,7 @@ export class Psbt {
     return validationResultCount > 0;
   }
 
-  signAllInputsHD(
-    hdKeyPair: HDSigner,
-    sighashTypes: number[] = [Transaction.SIGHASH_ALL],
-  ): this {
+  signAllInputsHD(hdKeyPair: HDSigner, sighashTypes?: number[]): this {
     if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
       throw new Error('Need HDSigner to sign input');
     }
@@ -670,7 +667,7 @@ export class Psbt {
 
   signAllInputsHDAsync(
     hdKeyPair: HDSigner | HDSignerAsync,
-    sighashTypes: number[] = [Transaction.SIGHASH_ALL],
+    sighashTypes?: number[],
   ): Promise<void> {
     return new Promise((resolve, reject): any => {
       if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
@@ -703,7 +700,7 @@ export class Psbt {
   signInputHD(
     inputIndex: number,
     hdKeyPair: HDSigner,
-    sighashTypes: number[] = [Transaction.SIGHASH_ALL],
+    sighashTypes?: number[],
   ): this {
     if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {
       throw new Error('Need HDSigner to sign input');
@@ -720,7 +717,7 @@ export class Psbt {
   signInputHDAsync(
     inputIndex: number,
     hdKeyPair: HDSigner | HDSignerAsync,
-    sighashTypes: number[] = [Transaction.SIGHASH_ALL],
+    sighashTypes?: number[],
   ): Promise<void> {
     return new Promise((resolve, reject): any => {
       if (!hdKeyPair || !hdKeyPair.publicKey || !hdKeyPair.fingerprint) {

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -1970,11 +1970,11 @@ function getTweakSignersFromHD(
 
   const signers: Array<Signer | SignerAsync> = myDerivations.map(bipDv => {
     const node = hdKeyPair.derivePath(bipDv!.path);
-    if (!bipDv!.pubkey.equals(node.publicKey)) {
+    if (!bipDv!.pubkey.equals(toXOnly(node.publicKey))) {
       throw new Error('pubkey did not match tapBip32Derivation');
     }
     const h = calculateScriptTreeMerkleRoot(bipDv!.leafHashes);
-    const tweakValue = tapTweakHash(node.publicKey, h);
+    const tweakValue = tapTweakHash(toXOnly(node.publicKey), h);
 
     return node.tweak(tweakValue);
   });


### PR DESCRIPTION
- issue discussion: https://github.com/bitcoinjs/bitcoinjs-lib/issues/2132
- feat
   - affected Signature Methods 
      - signAllInputsHD
      - signAllInputsAsyncHD
      - signInputHD
      - signInputAsyncHD
   - remove conflict default sighashTypes of signInputHD
      - Transaction.SIGHASH_DEFAULT for _signTaprootInput
      - Transaction.SIGHASH_ALL for _signInput
      - so we should remove the outermost default signType
   - add integration test for HDWallet with tapBip32Derivation
      - we will need more integration tests later.