### PR TITLE
chore: update to node v18 and remove audit job

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14, 'lts/*']
+        node-version: [18, 'lts/*']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14, 'lts/*']
+        node-version: [18, 'lts/*']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     services:
       regtest:
@@ -61,17 +61,6 @@ jobs:
   #####################
   # Jobs without matrix
   #####################
-  audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
-      - uses: actions/setup-node@eeb10cff27034e7acf239c5d29f62154018672fd # v3
-        with:
-          node-version: 'lts/*'
-          registry-url: https://registry.npmjs.org/
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run audit
   coverage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Updated the CI version to to nodev18 and removed the audit job