### PR TITLE
Add stripWitness to Transaction Issue 2169

### DIFF
--- a/src/cjs/transaction.cjs
+++ b/src/cjs/transaction.cjs
@@ -203,6 +203,11 @@ class Transaction {
       return x.witness.length !== 0;
     });
   }
+  stripWitnesses() {
+    this.ins.forEach(input => {
+      input.witness = EMPTY_WITNESS; // Set witness data to an empty array
+    });
+  }
   weight() {
     const base = this.byteLength(false);
     const total = this.byteLength(true);

--- a/src/cjs/transaction.d.ts
+++ b/src/cjs/transaction.d.ts
@@ -34,6 +34,7 @@ export declare class Transaction {
     addInput(hash: Uint8Array, index: number, sequence?: number, scriptSig?: Uint8Array): number;
     addOutput(scriptPubKey: Uint8Array, value: bigint): number;
     hasWitnesses(): boolean;
+    stripWitnesses(): void;
     weight(): number;
     virtualSize(): number;
     byteLength(_ALLOW_WITNESS?: boolean): number;

--- a/src/esm/transaction.js
+++ b/src/esm/transaction.js
@@ -161,6 +161,11 @@ export class Transaction {
       return x.witness.length !== 0;
     });
   }
+  stripWitnesses() {
+    this.ins.forEach(input => {
+      input.witness = EMPTY_WITNESS; // Set witness data to an empty array
+    });
+  }
   weight() {
     const base = this.byteLength(false);
     const total = this.byteLength(true);

--- a/test/transaction.spec.ts
+++ b/test/transaction.spec.ts
@@ -140,7 +140,7 @@ describe('Transaction', () => {
       it('removes witness from the transaction if it exists', () => {
         const T = Transaction.fromHex(f.whex ? f.whex : f.hex);
         T.stripWitnesses();
-        assert.equal(T.hasWitnesses(), false);
+        assert.strictEqual(T.hasWitnesses(), false);
       });
     });
   });

--- a/test/transaction.spec.ts
+++ b/test/transaction.spec.ts
@@ -135,6 +135,16 @@ describe('Transaction', () => {
     });
   });
 
+  describe('stripWitnesses', () => {
+    fixtures.valid.forEach(f => {
+      it('removes witness from the transaction if it exists', () => {
+        const T = Transaction.fromHex(f.whex ? f.whex : f.hex);
+        T.stripWitnesses();
+        assert.equal(T.hasWitnesses(), false);
+      });
+    });
+  });
+
   describe('weight/virtualSize', () => {
     it('computes virtual size', () => {
       fixtures.valid.forEach(f => {

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -208,6 +208,12 @@ export class Transaction {
     });
   }
 
+  stripWitnesses(): void {
+    this.ins.forEach(input => {
+      input.witness = EMPTY_WITNESS; // Set witness data to an empty array
+    });
+  }
+
   weight(): number {
     const base = this.byteLength(false);
     const total = this.byteLength(true);


### PR DESCRIPTION
This PR is intended to solve [issue 2169](https://github.com/bitcoinjs/bitcoinjs-lib/issues/2169)

- Adds a method to the transaction object to remove witness data. 
  - This is needed to construct a coinbase transaction with properly formatted inputs.
- Adds a test to cover the new method.

      
Credit to @benjamin-wilson for pointing it out in [issue 1951](https://github.com/bitcoinjs/bitcoinjs-lib/issues/1951.)
