### PR TITLE
feat: initEccLib skip verification (v7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.1.7
+__added__
+- skip ecc library verification via DANGER_DO_NOT_VERIFY_ECCLIB flag
+
 # 6.1.6
 __fixed__
 - Fix sighash treatment when signing taproot script sign scripts using Psbt (#2104)

--- a/src/cjs/ecc_lib.cjs
+++ b/src/cjs/ecc_lib.cjs
@@ -54,14 +54,14 @@ const _ECCLIB_CACHE = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
- * @param skipVerification If the ecc verification should not be executed.
+ * @param opts Extra initialization options. Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
  */
-function initEccLib(eccLib, skipVerification) {
+function initEccLib(eccLib, opts) {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    if (!skipVerification)
+    if (!opts?.DANGER_DO_NOT_VERIFY_ECCLIB)
       // new instance, verify it
       verifyEcc(eccLib);
     _ECCLIB_CACHE.eccLib = eccLib;

--- a/src/cjs/ecc_lib.cjs
+++ b/src/cjs/ecc_lib.cjs
@@ -54,14 +54,16 @@ const _ECCLIB_CACHE = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
+ * @param skipVerification If the ecc verification should not be executed.
  */
-function initEccLib(eccLib) {
+function initEccLib(eccLib, skipVerification) {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    // new instance, verify it
-    verifyEcc(eccLib);
+    if (!skipVerification)
+      // new instance, verify it
+      verifyEcc(eccLib);
     _ECCLIB_CACHE.eccLib = eccLib;
   }
 }

--- a/src/cjs/ecc_lib.d.ts
+++ b/src/cjs/ecc_lib.d.ts
@@ -5,8 +5,9 @@ import { TinySecp256k1Interface } from './types.js';
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
+ * @param skipVerification If the ecc verification should not be executed.
  */
-export declare function initEccLib(eccLib: TinySecp256k1Interface | undefined): void;
+export declare function initEccLib(eccLib: TinySecp256k1Interface | undefined, skipVerification?: boolean): void;
 /**
  * Retrieves the ECC Library instance.
  * Throws an error if the ECC Library is not provided.

--- a/src/cjs/ecc_lib.d.ts
+++ b/src/cjs/ecc_lib.d.ts
@@ -5,9 +5,11 @@ import { TinySecp256k1Interface } from './types.js';
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
- * @param skipVerification If the ecc verification should not be executed.
+ * @param opts Extra initialization options. Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
  */
-export declare function initEccLib(eccLib: TinySecp256k1Interface | undefined, skipVerification?: boolean): void;
+export declare function initEccLib(eccLib: TinySecp256k1Interface | undefined, opts?: {
+    DANGER_DO_NOT_VERIFY_ECCLIB: boolean;
+}): void;
 /**
  * Retrieves the ECC Library instance.
  * Throws an error if the ECC Library is not provided.

--- a/src/esm/ecc_lib.js
+++ b/src/esm/ecc_lib.js
@@ -6,14 +6,14 @@ const _ECCLIB_CACHE = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
- * @param skipVerification If the ecc verification should not be executed.
+ * @param opts Extra initialization options. Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
  */
-export function initEccLib(eccLib, skipVerification) {
+export function initEccLib(eccLib, opts) {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    if (!skipVerification)
+    if (!opts?.DANGER_DO_NOT_VERIFY_ECCLIB)
       // new instance, verify it
       verifyEcc(eccLib);
     _ECCLIB_CACHE.eccLib = eccLib;

--- a/src/esm/ecc_lib.js
+++ b/src/esm/ecc_lib.js
@@ -6,14 +6,16 @@ const _ECCLIB_CACHE = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
+ * @param skipVerification If the ecc verification should not be executed.
  */
-export function initEccLib(eccLib) {
+export function initEccLib(eccLib, skipVerification) {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    // new instance, verify it
-    verifyEcc(eccLib);
+    if (!skipVerification)
+      // new instance, verify it
+      verifyEcc(eccLib);
     _ECCLIB_CACHE.eccLib = eccLib;
   }
 }

--- a/test/ecc_lib.spec.ts
+++ b/test/ecc_lib.spec.ts
@@ -1,0 +1,22 @@
+import { initEccLib } from 'bitcoinjs-lib';
+import { describe, test } from 'mocha';
+import * as assert from 'assert';
+
+describe(`initEccLib`, () => {
+  beforeEach(() => {
+    initEccLib(undefined);
+  });
+
+  test('initEccLib should fail when invalid', () => {
+    assert.throws(() => {
+      initEccLib({ isXOnlyPoint: () => false } as any);
+    }, 'Error: ecc library invalid');
+  });
+
+  test('initEccLib should not fail when DANGER_DO_NOT_VERIFY_ECCLIB = true', () => {
+    initEccLib({ isXOnlyPoint: () => false } as any, {
+      DANGER_DO_NOT_VERIFY_ECCLIB: true,
+    });
+    assert.ok('it does not fail, verification is excluded');
+  });
+});

--- a/ts_src/ecc_lib.ts
+++ b/ts_src/ecc_lib.ts
@@ -9,14 +9,19 @@ const _ECCLIB_CACHE: { eccLib?: TinySecp256k1Interface } = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
+ * @param skipVerification If the ecc verification should not be executed.
  */
-export function initEccLib(eccLib: TinySecp256k1Interface | undefined): void {
+export function initEccLib(
+  eccLib: TinySecp256k1Interface | undefined,
+  skipVerification?: boolean,
+): void {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    // new instance, verify it
-    verifyEcc(eccLib!);
+    if (!skipVerification)
+      // new instance, verify it
+      verifyEcc(eccLib!);
     _ECCLIB_CACHE.eccLib = eccLib;
   }
 }

--- a/ts_src/ecc_lib.ts
+++ b/ts_src/ecc_lib.ts
@@ -9,17 +9,17 @@ const _ECCLIB_CACHE: { eccLib?: TinySecp256k1Interface } = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
- * @param skipVerification If the ecc verification should not be executed.
+ * @param opts Extra initialization options. Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
  */
 export function initEccLib(
   eccLib: TinySecp256k1Interface | undefined,
-  skipVerification?: boolean,
+  opts?: { DANGER_DO_NOT_VERIFY_ECCLIB: boolean },
 ): void {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    if (!skipVerification)
+    if (!opts?.DANGER_DO_NOT_VERIFY_ECCLIB)
       // new instance, verify it
       verifyEcc(eccLib!);
     _ECCLIB_CACHE.eccLib = eccLib;


### PR DESCRIPTION
verifyEcc could be expensive, taking up to 500 ms to finish on some devices. This PR allows the client code to avoid running the verification on run with a flag. Devs can run the verification on unit tests to verify if the provided ECC is correct. 