### PR TITLE
feat: initEccLib skip verification (v6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.1.7
+__added__
+- skip ecc library verification via DANGER_DO_NOT_VERIFY_ECCLIB flag
+
 # 6.1.6
 __fixed__
 - Fix sighash treatment when signing taproot script sign scripts using Psbt (#2104)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitcoinjs-lib",
-      "version": "6.1.6",
+      "version": "6.1.7",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoinjs-lib",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "description": "Client-side Bitcoin JavaScript library",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/src/ecc_lib.d.ts
+++ b/src/ecc_lib.d.ts
@@ -5,9 +5,11 @@ import { TinySecp256k1Interface } from './types';
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
- * @param skipVerification If the ecc verification should not be executed.
+ * @param skipVerification Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
  */
-export declare function initEccLib(eccLib: TinySecp256k1Interface | undefined, skipVerification?: boolean): void;
+export declare function initEccLib(eccLib: TinySecp256k1Interface | undefined, skipVerification?: {
+    DANGER_DO_NOT_VERIFY_ECCLIB: boolean;
+}): void;
 /**
  * Retrieves the ECC Library instance.
  * Throws an error if the ECC Library is not provided.

--- a/src/ecc_lib.d.ts
+++ b/src/ecc_lib.d.ts
@@ -5,8 +5,9 @@ import { TinySecp256k1Interface } from './types';
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
+ * @param skipVerification If the ecc verification should not be executed.
  */
-export declare function initEccLib(eccLib: TinySecp256k1Interface | undefined): void;
+export declare function initEccLib(eccLib: TinySecp256k1Interface | undefined, skipVerification?: boolean): void;
 /**
  * Retrieves the ECC Library instance.
  * Throws an error if the ECC Library is not provided.

--- a/src/ecc_lib.d.ts
+++ b/src/ecc_lib.d.ts
@@ -5,9 +5,9 @@ import { TinySecp256k1Interface } from './types';
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
- * @param skipVerification Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
+ * @param opts Extra initialization options. Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
  */
-export declare function initEccLib(eccLib: TinySecp256k1Interface | undefined, skipVerification?: {
+export declare function initEccLib(eccLib: TinySecp256k1Interface | undefined, opts?: {
     DANGER_DO_NOT_VERIFY_ECCLIB: boolean;
 }): void;
 /**

--- a/src/ecc_lib.js
+++ b/src/ecc_lib.js
@@ -8,14 +8,14 @@ const _ECCLIB_CACHE = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
- * @param skipVerification Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
+ * @param opts Extra initialization options. Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
  */
-function initEccLib(eccLib, skipVerification) {
+function initEccLib(eccLib, opts) {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    if (!skipVerification?.DANGER_DO_NOT_VERIFY_ECCLIB)
+    if (!opts?.DANGER_DO_NOT_VERIFY_ECCLIB)
       // new instance, verify it
       verifyEcc(eccLib);
     _ECCLIB_CACHE.eccLib = eccLib;

--- a/src/ecc_lib.js
+++ b/src/ecc_lib.js
@@ -8,14 +8,16 @@ const _ECCLIB_CACHE = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
+ * @param skipVerification If the ecc verification should not be executed.
  */
-function initEccLib(eccLib) {
+function initEccLib(eccLib, skipVerification) {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    // new instance, verify it
-    verifyEcc(eccLib);
+    if (!skipVerification)
+      // new instance, verify it
+      verifyEcc(eccLib);
     _ECCLIB_CACHE.eccLib = eccLib;
   }
 }

--- a/src/ecc_lib.js
+++ b/src/ecc_lib.js
@@ -8,14 +8,14 @@ const _ECCLIB_CACHE = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
- * @param skipVerification If the ecc verification should not be executed.
+ * @param skipVerification Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
  */
 function initEccLib(eccLib, skipVerification) {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    if (!skipVerification)
+    if (!skipVerification?.DANGER_DO_NOT_VERIFY_ECCLIB)
       // new instance, verify it
       verifyEcc(eccLib);
     _ECCLIB_CACHE.eccLib = eccLib;

--- a/test/ecc_lib.spec.ts
+++ b/test/ecc_lib.spec.ts
@@ -1,0 +1,22 @@
+import { initEccLib } from '../src';
+import { describe, test } from 'mocha';
+import * as assert from 'assert';
+
+describe(`initEccLib`, () => {
+  beforeEach(() => {
+    initEccLib(undefined);
+  });
+
+  test('initEccLib should fail when invalid', () => {
+    assert.throws(() => {
+      initEccLib({ isXOnlyPoint: () => false } as any);
+    }, 'Error: ecc library invalid');
+  });
+
+  test('initEccLib should not fail when DANGER_DO_NOT_VERIFY_ECCLIB = true', () => {
+    initEccLib({ isXOnlyPoint: () => false } as any, {
+      DANGER_DO_NOT_VERIFY_ECCLIB: true,
+    });
+    assert.ok('it does not fail, verification is excluded');
+  });
+});

--- a/ts_src/ecc_lib.ts
+++ b/ts_src/ecc_lib.ts
@@ -8,14 +8,19 @@ const _ECCLIB_CACHE: { eccLib?: TinySecp256k1Interface } = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
+ * @param skipVerification If the ecc verification should not be executed.
  */
-export function initEccLib(eccLib: TinySecp256k1Interface | undefined): void {
+export function initEccLib(
+  eccLib: TinySecp256k1Interface | undefined,
+  skipVerification?: boolean,
+): void {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    // new instance, verify it
-    verifyEcc(eccLib!);
+    if (!skipVerification)
+      // new instance, verify it
+      verifyEcc(eccLib!);
     _ECCLIB_CACHE.eccLib = eccLib;
   }
 }

--- a/ts_src/ecc_lib.ts
+++ b/ts_src/ecc_lib.ts
@@ -8,17 +8,17 @@ const _ECCLIB_CACHE: { eccLib?: TinySecp256k1Interface } = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
- * @param skipVerification If the ecc verification should not be executed.
+ * @param skipVerification Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
  */
 export function initEccLib(
   eccLib: TinySecp256k1Interface | undefined,
-  skipVerification?: boolean,
+  skipVerification?: { DANGER_DO_NOT_VERIFY_ECCLIB: boolean },
 ): void {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    if (!skipVerification)
+    if (!skipVerification?.DANGER_DO_NOT_VERIFY_ECCLIB)
       // new instance, verify it
       verifyEcc(eccLib!);
     _ECCLIB_CACHE.eccLib = eccLib;

--- a/ts_src/ecc_lib.ts
+++ b/ts_src/ecc_lib.ts
@@ -8,17 +8,17 @@ const _ECCLIB_CACHE: { eccLib?: TinySecp256k1Interface } = {};
  * If `eccLib` is a new instance, it will be verified before setting it as the active library.
  *
  * @param eccLib The instance of the ECC library to initialize.
- * @param skipVerification Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
+ * @param opts Extra initialization options. Use {DANGER_DO_NOT_VERIFY_ECCLIB:true} if ecc verification should not be executed. Not recommended!
  */
 export function initEccLib(
   eccLib: TinySecp256k1Interface | undefined,
-  skipVerification?: { DANGER_DO_NOT_VERIFY_ECCLIB: boolean },
+  opts?: { DANGER_DO_NOT_VERIFY_ECCLIB: boolean },
 ): void {
   if (!eccLib) {
     // allow clearing the library
     _ECCLIB_CACHE.eccLib = eccLib;
   } else if (eccLib !== _ECCLIB_CACHE.eccLib) {
-    if (!skipVerification?.DANGER_DO_NOT_VERIFY_ECCLIB)
+    if (!opts?.DANGER_DO_NOT_VERIFY_ECCLIB)
       // new instance, verify it
       verifyEcc(eccLib!);
     _ECCLIB_CACHE.eccLib = eccLib;


### PR DESCRIPTION
verifyEcc could be expensive, taking up to 500 ms to finish on some devices. This PR allows the client code to avoid running the verification on boot with a flag. Devs can run the verification on unit tests to verify if the provided ECC is correct. 

This is for V6, we are currently running this version