### PR TITLE
export toXOnly

### DIFF
--- a/src/cjs/index.cjs
+++ b/src/cjs/index.cjs
@@ -47,6 +47,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 exports.initEccLib =
   exports.Transaction =
   exports.opcodes =
+  exports.toXOnly =
   exports.Psbt =
   exports.Block =
   exports.script =
@@ -77,6 +78,12 @@ Object.defineProperty(exports, 'Psbt', {
   enumerable: true,
   get: function () {
     return psbt_js_1.Psbt;
+  },
+});
+Object.defineProperty(exports, 'toXOnly', {
+  enumerable: true,
+  get: function () {
+    return psbt_js_1.toXOnly;
   },
 });
 /** @hidden */

--- a/src/cjs/index.d.ts
+++ b/src/cjs/index.d.ts
@@ -7,7 +7,7 @@ export { address, crypto, networks, payments, script };
 export { Block } from './block.js';
 /** @hidden */
 export { TaggedHashPrefix } from './crypto.js';
-export { Psbt, PsbtTxInput, PsbtTxOutput, Signer, SignerAsync, HDSigner, HDSignerAsync, } from './psbt.js';
+export { Psbt, PsbtTxInput, PsbtTxOutput, Signer, SignerAsync, HDSigner, HDSignerAsync, toXOnly, } from './psbt.js';
 /** @hidden */
 export { OPS as opcodes } from './ops.js';
 export { Transaction } from './transaction.js';

--- a/src/cjs/psbt.cjs
+++ b/src/cjs/psbt.cjs
@@ -44,7 +44,7 @@ var __importStar =
     return result;
   };
 Object.defineProperty(exports, '__esModule', { value: true });
-exports.Psbt = void 0;
+exports.Psbt = exports.toXOnly = void 0;
 const bip174_1 = require('bip174');
 const varuint = __importStar(require('varuint-bitcoin'));
 const bip174_2 = require('bip174');
@@ -56,6 +56,12 @@ const bip341_js_1 = require('./payments/bip341.cjs');
 const bscript = __importStar(require('./script.cjs'));
 const transaction_js_1 = require('./transaction.cjs');
 const bip371_js_1 = require('./psbt/bip371.cjs');
+Object.defineProperty(exports, 'toXOnly', {
+  enumerable: true,
+  get: function () {
+    return bip371_js_1.toXOnly;
+  },
+});
 const psbtutils_js_1 = require('./psbt/psbtutils.cjs');
 const tools = __importStar(require('uint8array-tools'));
 /**

--- a/src/cjs/psbt.d.ts
+++ b/src/cjs/psbt.d.ts
@@ -2,6 +2,8 @@ import { Psbt as PsbtBase } from 'bip174';
 import { KeyValue, PsbtGlobalUpdate, PsbtInput, PsbtInputUpdate, PsbtOutput, PsbtOutputUpdate } from 'bip174';
 import { Network } from './networks.js';
 import { Transaction } from './transaction.js';
+import { toXOnly } from './psbt/bip371.js';
+export { toXOnly };
 export interface TransactionInput {
     hash: string | Uint8Array;
     index: number;
@@ -202,4 +204,3 @@ tapLeafHashToFinalize?: Uint8Array) => {
     finalScriptWitness: Uint8Array | undefined;
 };
 type AllScriptType = 'witnesspubkeyhash' | 'pubkeyhash' | 'multisig' | 'pubkey' | 'nonstandard' | 'p2sh-witnesspubkeyhash' | 'p2sh-pubkeyhash' | 'p2sh-multisig' | 'p2sh-pubkey' | 'p2sh-nonstandard' | 'p2wsh-pubkeyhash' | 'p2wsh-multisig' | 'p2wsh-pubkey' | 'p2wsh-nonstandard' | 'p2sh-p2wsh-pubkeyhash' | 'p2sh-p2wsh-multisig' | 'p2sh-p2wsh-pubkey' | 'p2sh-p2wsh-nonstandard';
-export {};

--- a/src/esm/index.js
+++ b/src/esm/index.js
@@ -5,7 +5,7 @@ import * as payments from './payments/index.js';
 import * as script from './script.js';
 export { address, crypto, networks, payments, script };
 export { Block } from './block.js';
-export { Psbt } from './psbt.js';
+export { Psbt, toXOnly } from './psbt.js';
 /** @hidden */
 export { OPS as opcodes } from './ops.js';
 export { Transaction } from './transaction.js';

--- a/src/esm/psbt.js
+++ b/src/esm/psbt.js
@@ -30,6 +30,7 @@ import {
   isP2TR,
 } from './psbt/psbtutils.js';
 import * as tools from 'uint8array-tools';
+export { toXOnly };
 /**
  * These are the default arguments for a Psbt instance.
  */

--- a/test/bip371.spec.ts
+++ b/test/bip371.spec.ts
@@ -1,0 +1,23 @@
+import { toXOnly } from 'bitcoinjs-lib';
+import * as assert from 'assert';
+
+describe('toXOnly', () => {
+  it('should return the input if the pubKey length is 32', () => {
+    const pubKey = new Uint8Array(32).fill(1); // Example 32-byte public key
+    const result = toXOnly(pubKey);
+    assert.strictEqual(result, pubKey); // Expect the same array (reference equality)
+  });
+
+  it('should return the sliced key if the pubKey length is greater than 32', () => {
+    const pubKey = new Uint8Array(33).fill(1);
+    pubKey[0] = 0; // Add a leading byte
+    const result = toXOnly(pubKey);
+    assert.deepStrictEqual(result, pubKey.slice(1, 33)); // Expect the sliced array
+  });
+
+  it('should throw an error if the pubKey length is less than 32', () => {
+    const pubKey = new Uint8Array(31).fill(1); // Example invalid public key
+    const result = toXOnly(pubKey);
+    assert.deepStrictEqual(result, pubKey.slice(1, 33)); // Expect the sliced array
+  });
+});

--- a/test/bip371.spec.ts
+++ b/test/bip371.spec.ts
@@ -15,7 +15,7 @@ describe('toXOnly', () => {
     assert.deepStrictEqual(result, pubKey.slice(1, 33)); // Expect the sliced array
   });
 
-  it('should throw an error if the pubKey length is less than 32', () => {
+  it('should return the key if the pubKey length is less than 32', () => {
     const pubKey = new Uint8Array(31).fill(1); // Example invalid public key
     const result = toXOnly(pubKey);
     assert.deepStrictEqual(result, pubKey.slice(1, 33)); // Expect the sliced array

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -17,6 +17,7 @@ export {
   SignerAsync,
   HDSigner,
   HDSignerAsync,
+  toXOnly,
 } from './psbt.js';
 /** @hidden */
 export { OPS as opcodes } from './ops.js';

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -46,6 +46,8 @@ import {
 } from './psbt/psbtutils.js';
 import * as tools from 'uint8array-tools';
 
+export { toXOnly };
+
 export interface TransactionInput {
   hash: string | Uint8Array;
   index: number;


### PR DESCRIPTION
handle issue: https://github.com/bitcoinjs/bitcoinjs-lib/issues/1862

Although this function is small, it is often used when building Taproot type transactions, and exporting it is also a good choice