### PR TITLE
Fix transaction version field not properly serialized

### DIFF
--- a/src/cjs/transaction.cjs
+++ b/src/cjs/transaction.cjs
@@ -99,7 +99,7 @@ class Transaction {
   static fromBuffer(buffer, _NO_STRICT) {
     const bufferReader = new bufferutils_js_1.BufferReader(buffer);
     const tx = new Transaction();
-    tx.version = bufferReader.readInt32();
+    tx.version = bufferReader.readUInt32();
     const marker = bufferReader.readUInt8();
     const flag = bufferReader.readUInt8();
     let hasWitnesses = false;
@@ -414,7 +414,7 @@ class Transaction {
     const sigMsgWriter = bufferutils_js_1.BufferWriter.withCapacity(sigMsgSize);
     sigMsgWriter.writeUInt8(hashType);
     // Transaction
-    sigMsgWriter.writeInt32(this.version);
+    sigMsgWriter.writeUInt32(this.version);
     sigMsgWriter.writeUInt32(this.locktime);
     sigMsgWriter.writeSlice(hashPrevouts);
     sigMsgWriter.writeSlice(hashAmounts);
@@ -523,7 +523,7 @@ class Transaction {
     tbuffer = new Uint8Array(156 + varSliceSize(prevOutScript));
     bufferWriter = new bufferutils_js_1.BufferWriter(tbuffer, 0);
     const input = this.ins[inIndex];
-    bufferWriter.writeInt32(this.version);
+    bufferWriter.writeUInt32(this.version);
     bufferWriter.writeSlice(hashPrevouts);
     bufferWriter.writeSlice(hashSequence);
     bufferWriter.writeSlice(input.hash);
@@ -570,7 +570,7 @@ class Transaction {
       buffer,
       initialOffset || 0,
     );
-    bufferWriter.writeInt32(this.version);
+    bufferWriter.writeUInt32(this.version);
     const hasWitnesses = _ALLOW_WITNESS && this.hasWitnesses();
     if (hasWitnesses) {
       bufferWriter.writeUInt8(Transaction.ADVANCED_TRANSACTION_MARKER);

--- a/src/esm/transaction.js
+++ b/src/esm/transaction.js
@@ -57,7 +57,7 @@ export class Transaction {
   static fromBuffer(buffer, _NO_STRICT) {
     const bufferReader = new BufferReader(buffer);
     const tx = new Transaction();
-    tx.version = bufferReader.readInt32();
+    tx.version = bufferReader.readUInt32();
     const marker = bufferReader.readUInt8();
     const flag = bufferReader.readUInt8();
     let hasWitnesses = false;
@@ -365,7 +365,7 @@ export class Transaction {
     const sigMsgWriter = BufferWriter.withCapacity(sigMsgSize);
     sigMsgWriter.writeUInt8(hashType);
     // Transaction
-    sigMsgWriter.writeInt32(this.version);
+    sigMsgWriter.writeUInt32(this.version);
     sigMsgWriter.writeUInt32(this.locktime);
     sigMsgWriter.writeSlice(hashPrevouts);
     sigMsgWriter.writeSlice(hashAmounts);
@@ -472,7 +472,7 @@ export class Transaction {
     tbuffer = new Uint8Array(156 + varSliceSize(prevOutScript));
     bufferWriter = new BufferWriter(tbuffer, 0);
     const input = this.ins[inIndex];
-    bufferWriter.writeInt32(this.version);
+    bufferWriter.writeUInt32(this.version);
     bufferWriter.writeSlice(hashPrevouts);
     bufferWriter.writeSlice(hashSequence);
     bufferWriter.writeSlice(input.hash);
@@ -514,7 +514,7 @@ export class Transaction {
   __toBuffer(buffer, initialOffset, _ALLOW_WITNESS = false) {
     if (!buffer) buffer = new Uint8Array(this.byteLength(_ALLOW_WITNESS));
     const bufferWriter = new BufferWriter(buffer, initialOffset || 0);
-    bufferWriter.writeInt32(this.version);
+    bufferWriter.writeUInt32(this.version);
     const hasWitnesses = _ALLOW_WITNESS && this.hasWitnesses();
     if (hasWitnesses) {
       bufferWriter.writeUInt8(Transaction.ADVANCED_TRANSACTION_MARKER);

--- a/test/transaction.spec.ts
+++ b/test/transaction.spec.ts
@@ -78,10 +78,10 @@ describe('Transaction', () => {
       });
     });
 
-    it('.version should be interpreted as an int32le', () => {
+    it('.version should be interpreted as an uint32le', () => {
       const txHex = 'ffffffff0000ffffffff';
       const tx = Transaction.fromHex(txHex);
-      assert.strictEqual(-1, tx.version);
+      assert.strictEqual(0xffffffff, tx.version);
       assert.strictEqual(0xffffffff, tx.locktime);
     });
   });

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -79,7 +79,7 @@ export class Transaction {
     const bufferReader = new BufferReader(buffer);
 
     const tx = new Transaction();
-    tx.version = bufferReader.readInt32();
+    tx.version = bufferReader.readUInt32();
 
     const marker = bufferReader.readUInt8();
     const flag = bufferReader.readUInt8();
@@ -464,7 +464,7 @@ export class Transaction {
 
     sigMsgWriter.writeUInt8(hashType);
     // Transaction
-    sigMsgWriter.writeInt32(this.version);
+    sigMsgWriter.writeUInt32(this.version);
     sigMsgWriter.writeUInt32(this.locktime);
     sigMsgWriter.writeSlice(hashPrevouts);
     sigMsgWriter.writeSlice(hashAmounts);
@@ -594,7 +594,7 @@ export class Transaction {
     bufferWriter = new BufferWriter(tbuffer, 0);
 
     const input = this.ins[inIndex];
-    bufferWriter.writeInt32(this.version);
+    bufferWriter.writeUInt32(this.version);
     bufferWriter.writeSlice(hashPrevouts);
     bufferWriter.writeSlice(hashSequence);
     bufferWriter.writeSlice(input.hash);

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -652,7 +652,7 @@ export class Transaction {
 
     const bufferWriter = new BufferWriter(buffer, initialOffset || 0);
 
-    bufferWriter.writeInt32(this.version);
+    bufferWriter.writeUInt32(this.version);
 
     const hasWitnesses = _ALLOW_WITNESS && this.hasWitnesses();
 


### PR DESCRIPTION
The transaction's version is serialized as an int, instead of uint, disallowing serializing transactions with versions >0x80000000 and allowing serializing transactions with negative version field.