### PR TITLE
fix: typos in documentation files

### DIFF
--- a/test/integration/taproot.spec.ts
+++ b/test/integration/taproot.spec.ts
@@ -451,7 +451,7 @@ describe('bitcoinjs-lib (transaction with taproot)', () => {
     } catch (err) {
       if ((err as any).message !== 'non-BIP68-final')
         throw new Error(
-          'Expected OP_CHECKSEQUENCEVERIFY validation to fail. But it faild with: ' +
+          'Expected OP_CHECKSEQUENCEVERIFY validation to fail. But it failed with: ' +
             err,
         );
     }

--- a/test/psbt.spec.ts
+++ b/test/psbt.spec.ts
@@ -208,7 +208,7 @@ describe(`Psbt`, () => {
 
         psbts[0].combine(psbts[1]);
 
-        // Produces a different Base64 string due to implemetation specific key-value ordering.
+        // Produces a different Base64 string due to implementation specific key-value ordering.
         // That means this test will fail:
         // assert.strictEqual(psbts[0].toBase64(), f.result)
         // However, if we compare the actual PSBT properties we can see they are logically identical:


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `faild` to `failed`
Corrected `implemetation` to `implementation`

Please review the changes and let me know if any additional changes are needed.