### PR TITLE
chore(ci): bump actions/deploy-pages to v4

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -143,4 +143,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
* Switch from `actions/deploy-pages@v2` to `@v4` to comply with GitHub’s upcoming Pages artifact policy (v2 deprecated on 2025-01-30).
* v4 introduces artifact-ID deployment, clearer API-error messages, and requires `actions/upload-pages-artifact@v3` or `actions/upload-artifact@v4`.
[Reference]( https://github.com/actions/deploy-pages/releases/tag/v4.0.5) 