### PR TITLE
— `Add version info utility for CI and developer use`**

### DIFF
--- a/ts_src/utils/getLibraryVersion.ts
+++ b/ts_src/utils/getLibraryVersion.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns the current bitcoinjs-lib version as defined in package.json
+ * For CI checks or quick debugging in dev environments.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+export function getLibraryVersion(): string {
+  try {
+    const pkgPath = resolve(__dirname, '../../package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    return pkg.version || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+if (require.main === module) {
+  console.log(`bitcoinjs-lib version: ${getLibraryVersion()}`);
+}


### PR DESCRIPTION
This PR introduces a small helper function that returns the current `bitcoinjs-lib` version from `package.json`.  
It can be used by developers and CI scripts to verify the exact library version being used in local builds or test pipelines.

### Changes
- Added new file: `ts_src/utils/getLibraryVersion.ts`
- Reads version string safely and logs it when run directly

### Motivation
Sometimes, developers need to confirm that the source and npm package versions match.  
This utility provides a simple and lightweight way to check that, without importing the full library.