### PR TITLE
fix: Handle zero-input PSBTs correctly during transaction parsing

### DIFF
--- a/src/cjs/transaction.cjs
+++ b/src/cjs/transaction.cjs
@@ -100,19 +100,48 @@ class Transaction {
     const bufferReader = new bufferutils_js_1.BufferReader(buffer);
     const tx = new Transaction();
     tx.version = bufferReader.readUInt32();
+    // keep track of where we are before we try to read the marker
+    const markerPosition = bufferReader.offset;
+    // pull one byte that might be the segwit marker
     const marker = bufferReader.readUInt8();
+    // pull the next byte that might be the segwit flag
     const flag = bufferReader.readUInt8();
+    // we start by assuming there are no witnesses
     let hasWitnesses = false;
+    // we will fill this in only when we are sure about the number of inputs
+    let vinLen;
     if (
       marker === Transaction.ADVANCED_TRANSACTION_MARKER &&
       flag === Transaction.ADVANCED_TRANSACTION_FLAG
     ) {
-      hasWitnesses = true;
+      // read what the stream claims is the count of inputs
+      const potentialVinLen = bufferReader.readVarInt();
+      // find how many bytes are still left in the stream after that read
+      const remainingBytes = BigInt(buffer.length - bufferReader.offset);
+      // each legacy input needs at least 41 bytes in the unsigned tx form
+      const minInputSize = BigInt(41);
+      if (
+        potentialVinLen === BigInt(0) ||
+        remainingBytes < potentialVinLen * minInputSize
+      ) {
+        // if the count is zero or there are not enough bytes, then this was a false alarm
+        bufferReader.offset = markerPosition;
+      } else {
+        // the marker was real, so we remember that witnesses are present
+        hasWitnesses = true;
+        // we also reuse the count we already read
+        vinLen = potentialVinLen;
+      }
     } else {
-      bufferReader.offset -= 2;
+      // marker and flag were not present, so jump back before the read
+      bufferReader.offset = markerPosition;
     }
-    const vinLen = bufferReader.readVarInt();
-    for (let i = 0; i < vinLen; ++i) {
+    if (vinLen === undefined) {
+      // if we have not already read the input count, do it now in the normal way
+      vinLen = bufferReader.readVarInt();
+    }
+    const vinCount = Number(vinLen);
+    for (let i = 0; i < vinCount; ++i) {
       tx.ins.push({
         hash: bufferReader.readSlice(32),
         index: bufferReader.readUInt32(),
@@ -122,14 +151,15 @@ class Transaction {
       });
     }
     const voutLen = bufferReader.readVarInt();
-    for (let i = 0; i < voutLen; ++i) {
+    const voutCount = Number(voutLen);
+    for (let i = 0; i < voutCount; ++i) {
       tx.outs.push({
         value: bufferReader.readInt64(),
         script: bufferReader.readVarSlice(),
       });
     }
     if (hasWitnesses) {
-      for (let i = 0; i < vinLen; ++i) {
+      for (let i = 0; i < vinCount; ++i) {
         tx.ins[i].witness = bufferReader.readVector();
       }
       // was this pointless?
@@ -359,24 +389,26 @@ class Transaction {
         bufferWriter.writeSlice(txIn.hash);
         bufferWriter.writeUInt32(txIn.index);
       });
-      hashPrevouts = (0, sha256_1.sha256)(bufferWriter.end());
+      hashPrevouts = Uint8Array.from((0, sha256_1.sha256)(bufferWriter.end()));
       bufferWriter = bufferutils_js_1.BufferWriter.withCapacity(
         8 * this.ins.length,
       );
       values.forEach(value => bufferWriter.writeInt64(value));
-      hashAmounts = (0, sha256_1.sha256)(bufferWriter.end());
+      hashAmounts = Uint8Array.from((0, sha256_1.sha256)(bufferWriter.end()));
       bufferWriter = bufferutils_js_1.BufferWriter.withCapacity(
         prevOutScripts.map(varSliceSize).reduce((a, b) => a + b),
       );
       prevOutScripts.forEach(prevOutScript =>
         bufferWriter.writeVarSlice(prevOutScript),
       );
-      hashScriptPubKeys = (0, sha256_1.sha256)(bufferWriter.end());
+      hashScriptPubKeys = Uint8Array.from(
+        (0, sha256_1.sha256)(bufferWriter.end()),
+      );
       bufferWriter = bufferutils_js_1.BufferWriter.withCapacity(
         4 * this.ins.length,
       );
       this.ins.forEach(txIn => bufferWriter.writeUInt32(txIn.sequence));
-      hashSequences = (0, sha256_1.sha256)(bufferWriter.end());
+      hashSequences = Uint8Array.from((0, sha256_1.sha256)(bufferWriter.end()));
     }
     if (!(isNone || isSingle)) {
       if (!this.outs.length)
@@ -390,7 +422,7 @@ class Transaction {
         bufferWriter.writeInt64(out.value);
         bufferWriter.writeVarSlice(out.script);
       });
-      hashOutputs = (0, sha256_1.sha256)(bufferWriter.end());
+      hashOutputs = Uint8Array.from((0, sha256_1.sha256)(bufferWriter.end()));
     } else if (isSingle && inIndex < this.outs.length) {
       const output = this.outs[inIndex];
       const bufferWriter = bufferutils_js_1.BufferWriter.withCapacity(
@@ -398,7 +430,7 @@ class Transaction {
       );
       bufferWriter.writeInt64(output.value);
       bufferWriter.writeVarSlice(output.script);
-      hashOutputs = (0, sha256_1.sha256)(bufferWriter.end());
+      hashOutputs = Uint8Array.from((0, sha256_1.sha256)(bufferWriter.end()));
     }
     const spendType = (leafHash ? 2 : 0) + (annex ? 1 : 0);
     // Length calculation from:

--- a/src/esm/transaction.js
+++ b/src/esm/transaction.js
@@ -58,19 +58,48 @@ export class Transaction {
     const bufferReader = new BufferReader(buffer);
     const tx = new Transaction();
     tx.version = bufferReader.readUInt32();
+    // keep track of where we are before we try to read the marker
+    const markerPosition = bufferReader.offset;
+    // pull one byte that might be the segwit marker
     const marker = bufferReader.readUInt8();
+    // pull the next byte that might be the segwit flag
     const flag = bufferReader.readUInt8();
+    // we start by assuming there are no witnesses
     let hasWitnesses = false;
+    // we will fill this in only when we are sure about the number of inputs
+    let vinLen;
     if (
       marker === Transaction.ADVANCED_TRANSACTION_MARKER &&
       flag === Transaction.ADVANCED_TRANSACTION_FLAG
     ) {
-      hasWitnesses = true;
+      // read what the stream claims is the count of inputs
+      const potentialVinLen = bufferReader.readVarInt();
+      // find how many bytes are still left in the stream after that read
+      const remainingBytes = BigInt(buffer.length - bufferReader.offset);
+      // each legacy input needs at least 41 bytes in the unsigned tx form
+      const minInputSize = BigInt(41);
+      if (
+        potentialVinLen === BigInt(0) ||
+        remainingBytes < potentialVinLen * minInputSize
+      ) {
+        // if the count is zero or there are not enough bytes, then this was a false alarm
+        bufferReader.offset = markerPosition;
+      } else {
+        // the marker was real, so we remember that witnesses are present
+        hasWitnesses = true;
+        // we also reuse the count we already read
+        vinLen = potentialVinLen;
+      }
     } else {
-      bufferReader.offset -= 2;
+      // marker and flag were not present, so jump back before the read
+      bufferReader.offset = markerPosition;
     }
-    const vinLen = bufferReader.readVarInt();
-    for (let i = 0; i < vinLen; ++i) {
+    if (vinLen === undefined) {
+      // if we have not already read the input count, do it now in the normal way
+      vinLen = bufferReader.readVarInt();
+    }
+    const vinCount = Number(vinLen);
+    for (let i = 0; i < vinCount; ++i) {
       tx.ins.push({
         hash: bufferReader.readSlice(32),
         index: bufferReader.readUInt32(),
@@ -80,14 +109,15 @@ export class Transaction {
       });
     }
     const voutLen = bufferReader.readVarInt();
-    for (let i = 0; i < voutLen; ++i) {
+    const voutCount = Number(voutLen);
+    for (let i = 0; i < voutCount; ++i) {
       tx.outs.push({
         value: bufferReader.readInt64(),
         script: bufferReader.readVarSlice(),
       });
     }
     if (hasWitnesses) {
-      for (let i = 0; i < vinLen; ++i) {
+      for (let i = 0; i < vinCount; ++i) {
         tx.ins[i].witness = bufferReader.readVector();
       }
       // was this pointless?
@@ -315,20 +345,20 @@ export class Transaction {
         bufferWriter.writeSlice(txIn.hash);
         bufferWriter.writeUInt32(txIn.index);
       });
-      hashPrevouts = sha256(bufferWriter.end());
+      hashPrevouts = Uint8Array.from(sha256(bufferWriter.end()));
       bufferWriter = BufferWriter.withCapacity(8 * this.ins.length);
       values.forEach(value => bufferWriter.writeInt64(value));
-      hashAmounts = sha256(bufferWriter.end());
+      hashAmounts = Uint8Array.from(sha256(bufferWriter.end()));
       bufferWriter = BufferWriter.withCapacity(
         prevOutScripts.map(varSliceSize).reduce((a, b) => a + b),
       );
       prevOutScripts.forEach(prevOutScript =>
         bufferWriter.writeVarSlice(prevOutScript),
       );
-      hashScriptPubKeys = sha256(bufferWriter.end());
+      hashScriptPubKeys = Uint8Array.from(sha256(bufferWriter.end()));
       bufferWriter = BufferWriter.withCapacity(4 * this.ins.length);
       this.ins.forEach(txIn => bufferWriter.writeUInt32(txIn.sequence));
-      hashSequences = sha256(bufferWriter.end());
+      hashSequences = Uint8Array.from(sha256(bufferWriter.end()));
     }
     if (!(isNone || isSingle)) {
       if (!this.outs.length)
@@ -341,7 +371,7 @@ export class Transaction {
         bufferWriter.writeInt64(out.value);
         bufferWriter.writeVarSlice(out.script);
       });
-      hashOutputs = sha256(bufferWriter.end());
+      hashOutputs = Uint8Array.from(sha256(bufferWriter.end()));
     } else if (isSingle && inIndex < this.outs.length) {
       const output = this.outs[inIndex];
       const bufferWriter = BufferWriter.withCapacity(
@@ -349,7 +379,7 @@ export class Transaction {
       );
       bufferWriter.writeInt64(output.value);
       bufferWriter.writeVarSlice(output.script);
-      hashOutputs = sha256(bufferWriter.end());
+      hashOutputs = Uint8Array.from(sha256(bufferWriter.end()));
     }
     const spendType = (leafHash ? 2 : 0) + (annex ? 1 : 0);
     // Length calculation from:

--- a/test/fixtures/psbt.json
+++ b/test/fixtures/psbt.json
@@ -94,6 +94,18 @@
     ],
     "valid": [
       {
+        "description": "PSBT with global unsigned tx and zero inputs/outputs",
+        "psbt": "cHNidP8BAAoAAAAAAAAAAAAAAA=="
+      },
+      {
+        "description": "PSBT with zero inputs and one output",
+        "psbt": "cHNidP8BACwCAAAAAAHoAwAAAAAAABl2qRR1nWZ3CR6XO56dmfGcaPv0Pj8F+YisAAAAAAAAAA=="
+      },
+      {
+        "description": "PSBT with zero inputs",
+        "psbt": "cHNidP8BAEwCAAAAAALT3/UFAAAAABl2qRTQxZkDxbrChodg6Q/VIaRmWqdlIIisAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4ezLhMAAAAA"
+      },
+      {
         "description": "PSBT with one P2PKH input. Outputs are empty",
         "psbt": "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAAAA"
       },

--- a/test/psbt.spec.ts
+++ b/test/psbt.spec.ts
@@ -1212,6 +1212,42 @@ describe(`Psbt`, () => {
     });
   });
 
+  describe('Zero input PSBTs', () => {
+    it('creates an empty PSBT with no inputs or outputs', () => {
+      const psbt = new Psbt();
+      const expectedBase64 = 'cHNidP8BAAoCAAAAAAAAAAAAAAAA';
+      assert.strictEqual(psbt.toBase64(), expectedBase64);
+
+      const specBase64 = 'cHNidP8BAAoAAAAAAAAAAAAAAA==';
+      const parsed = Psbt.fromBase64(specBase64);
+      assert.strictEqual(parsed.data.inputs.length, 0);
+      assert.strictEqual(parsed.data.outputs.length, 0);
+      assert.strictEqual(parsed.toBase64(), expectedBase64);
+    });
+
+    it('round trips PSBTs with zero inputs and one output', () => {
+      const { output } = payments.p2pkh({
+        address: '1BitcoinEaterAddressDontSendf59kuE',
+      });
+      if (!output) throw new Error('Failed to derive output script');
+
+      const psbt = new Psbt();
+      psbt.addOutput({ script: output, value: 1000n });
+
+      const expectedBase64 =
+        'cHNidP8BACwCAAAAAAHoAwAAAAAAABl2qRR1nWZ3CR6XO56dmfGcaPv0Pj8F+YisAAAAAAAAAA==';
+      assert.strictEqual(psbt.toBase64(), expectedBase64);
+
+      const parsed = Psbt.fromBase64(expectedBase64);
+      assert.strictEqual(parsed.data.inputs.length, 0);
+      assert.strictEqual(parsed.data.outputs.length, 1);
+      const unsignedOutput = parsed.data.globalMap.unsignedTx.tx.outs[0];
+      assert.strictEqual(unsignedOutput.value, 1000n);
+      assert.deepStrictEqual(unsignedOutput.script, output);
+      assert.strictEqual(parsed.toBase64(), expectedBase64);
+    });
+  });
+
   describe('create 1-to-1 transaction', () => {
     const alice = ECPair.fromWIF(
       'L2uPYXe17xSTqbCjZvL2DsyXPCbXspvcu5mHLDYUgzdUbZGSKrSr',

--- a/ts_src/transaction.ts
+++ b/ts_src/transaction.ts
@@ -81,21 +81,50 @@ export class Transaction {
     const tx = new Transaction();
     tx.version = bufferReader.readUInt32();
 
+    // keep track of where we are before we try to read the marker
+    const markerPosition = bufferReader.offset;
+    // pull one byte that might be the segwit marker
     const marker = bufferReader.readUInt8();
+    // pull the next byte that might be the segwit flag
     const flag = bufferReader.readUInt8();
 
+    // we start by assuming there are no witnesses
     let hasWitnesses = false;
+    // we will fill this in only when we are sure about the number of inputs
+    let vinLen: bigint | undefined;
     if (
       marker === Transaction.ADVANCED_TRANSACTION_MARKER &&
       flag === Transaction.ADVANCED_TRANSACTION_FLAG
     ) {
-      hasWitnesses = true;
+      // read what the stream claims is the count of inputs
+      const potentialVinLen = bufferReader.readVarInt();
+      // find how many bytes are still left in the stream after that read
+      const remainingBytes = BigInt(buffer.length - bufferReader.offset);
+      // each legacy input needs at least 41 bytes in the unsigned tx form
+      const minInputSize = BigInt(41);
+      if (
+        potentialVinLen === BigInt(0) ||
+        remainingBytes < potentialVinLen * minInputSize
+      ) {
+        // if the count is zero or there are not enough bytes, then this was a false alarm
+        bufferReader.offset = markerPosition;
+      } else {
+        // the marker was real, so we remember that witnesses are present
+        hasWitnesses = true;
+        // we also reuse the count we already read
+        vinLen = potentialVinLen;
+      }
     } else {
-      bufferReader.offset -= 2;
+      // marker and flag were not present, so jump back before the read
+      bufferReader.offset = markerPosition;
     }
 
-    const vinLen = bufferReader.readVarInt();
-    for (let i = 0; i < vinLen; ++i) {
+    if (vinLen === undefined) {
+      // if we have not already read the input count, do it now in the normal way
+      vinLen = bufferReader.readVarInt();
+    }
+    const vinCount = Number(vinLen);
+    for (let i = 0; i < vinCount; ++i) {
       tx.ins.push({
         hash: bufferReader.readSlice(32),
         index: bufferReader.readUInt32(),
@@ -106,7 +135,8 @@ export class Transaction {
     }
 
     const voutLen = bufferReader.readVarInt();
-    for (let i = 0; i < voutLen; ++i) {
+    const voutCount = Number(voutLen);
+    for (let i = 0; i < voutCount; ++i) {
       tx.outs.push({
         value: bufferReader.readInt64(),
         script: bufferReader.readVarSlice(),
@@ -114,7 +144,7 @@ export class Transaction {
     }
 
     if (hasWitnesses) {
-      for (let i = 0; i < vinLen; ++i) {
+      for (let i = 0; i < vinCount; ++i) {
         tx.ins[i].witness = bufferReader.readVector();
       }
 
@@ -404,11 +434,11 @@ export class Transaction {
         bufferWriter.writeSlice(txIn.hash);
         bufferWriter.writeUInt32(txIn.index);
       });
-      hashPrevouts = sha256(bufferWriter.end());
+      hashPrevouts = Uint8Array.from(sha256(bufferWriter.end()));
 
       bufferWriter = BufferWriter.withCapacity(8 * this.ins.length);
       values.forEach(value => bufferWriter.writeInt64(value));
-      hashAmounts = sha256(bufferWriter.end());
+      hashAmounts = Uint8Array.from(sha256(bufferWriter.end()));
 
       bufferWriter = BufferWriter.withCapacity(
         prevOutScripts.map(varSliceSize).reduce((a, b) => a + b),
@@ -416,11 +446,11 @@ export class Transaction {
       prevOutScripts.forEach(prevOutScript =>
         bufferWriter.writeVarSlice(prevOutScript),
       );
-      hashScriptPubKeys = sha256(bufferWriter.end());
+      hashScriptPubKeys = Uint8Array.from(sha256(bufferWriter.end()));
 
       bufferWriter = BufferWriter.withCapacity(4 * this.ins.length);
       this.ins.forEach(txIn => bufferWriter.writeUInt32(txIn.sequence));
-      hashSequences = sha256(bufferWriter.end());
+      hashSequences = Uint8Array.from(sha256(bufferWriter.end()));
     }
 
     if (!(isNone || isSingle)) {
@@ -436,7 +466,7 @@ export class Transaction {
         bufferWriter.writeVarSlice(out.script);
       });
 
-      hashOutputs = sha256(bufferWriter.end());
+      hashOutputs = Uint8Array.from(sha256(bufferWriter.end()));
     } else if (isSingle && inIndex < this.outs.length) {
       const output = this.outs[inIndex];
 
@@ -445,7 +475,7 @@ export class Transaction {
       );
       bufferWriter.writeInt64(output.value);
       bufferWriter.writeVarSlice(output.script);
-      hashOutputs = sha256(bufferWriter.end());
+      hashOutputs = Uint8Array.from(sha256(bufferWriter.end()));
     }
 
     const spendType = (leafHash ? 2 : 0) + (annex ? 1 : 0);


### PR DESCRIPTION
- Guard SegWit marker detection so unsigned transactions with zero inputs don’t misidentify varint bytes as the witness marker
- Reuse the peeked vin count when the marker is legitimate and ensure the buffer has room for the claimed inputs
- Normalize hash caching to explicit Uint8Array instances to satisfy updated noble/hashes typings
- Add BIP174 fixtures covering 0-in/0-out and 0-in/1-out PSBTs and extend Mocha tests to assert creation and round-trip behaviour