### PR TITLE
docs: align Buffer wording with Uint8Array-first APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Mistakes and bugs happen, but with your help in resolving and reporting [issues]
 - Easy to audit and verify,
 - Tested, with test coverage >95%,
 - Advanced and feature rich,
-- Standardized, using [prettier](https://github.com/prettier/prettier) and Node `Buffer`'s throughout, and
+- Standardized, using [prettier](https://github.com/prettier/prettier) and `Uint8Array` throughout (Node `Buffer` remains compatible), and
 - Friendly, with a strong and helpful community, ready to answer questions.
 
 ## Documentation

--- a/src/cjs/address.cjs
+++ b/src/cjs/address.cjs
@@ -177,7 +177,7 @@ function toBech32(data, version, prefix) {
 }
 /**
  * Converts an output script to a Bitcoin address.
- * @param output - The output script as a Buffer.
+ * @param output - The output script as a Uint8Array.
  * @param network - The Bitcoin network (optional).
  * @returns The Bitcoin address corresponding to the output script.
  * @throws If the output script has no matching address.
@@ -209,7 +209,7 @@ function fromOutputScript(output, network) {
  * Converts a Bitcoin address to its corresponding output script.
  * @param address - The Bitcoin address to convert.
  * @param network - The Bitcoin network to use. Defaults to the Bitcoin network.
- * @returns The corresponding output script as a Buffer.
+ * @returns The corresponding output script as a Uint8Array.
  * @throws If the address has an invalid prefix or no matching script.
  */
 function toOutputScript(address, network) {

--- a/src/cjs/address.d.ts
+++ b/src/cjs/address.d.ts
@@ -56,7 +56,7 @@ export declare function toBase58Check(hash: Uint8Array, version: number): string
 export declare function toBech32(data: Uint8Array, version: number, prefix: string): string;
 /**
  * Converts an output script to a Bitcoin address.
- * @param output - The output script as a Buffer.
+ * @param output - The output script as a Uint8Array.
  * @param network - The Bitcoin network (optional).
  * @returns The Bitcoin address corresponding to the output script.
  * @throws If the output script has no matching address.
@@ -66,7 +66,7 @@ export declare function fromOutputScript(output: Uint8Array, network?: Network):
  * Converts a Bitcoin address to its corresponding output script.
  * @param address - The Bitcoin address to convert.
  * @param network - The Bitcoin network to use. Defaults to the Bitcoin network.
- * @returns The corresponding output script as a Buffer.
+ * @returns The corresponding output script as a Uint8Array.
  * @throws If the address has an invalid prefix or no matching script.
  */
 export declare function toOutputScript(address: string, network?: Network): Uint8Array;

--- a/src/cjs/payments/bip341.cjs
+++ b/src/cjs/payments/bip341.cjs
@@ -122,7 +122,7 @@ function findScriptPath(node, hash) {
 /**
  * Calculates the tapleaf hash for a given Tapleaf object.
  * @param leaf - The Tapleaf object to calculate the hash for.
- * @returns The tapleaf hash as a Buffer.
+ * @returns The tapleaf hash as a Uint8Array.
  */
 function tapleafHash(leaf) {
   const version = leaf.version || exports.LEAF_VERSION_TAPSCRIPT;
@@ -181,7 +181,7 @@ function tapBranchHash(a, b) {
  * Serializes a script by encoding its length as a varint and concatenating it with the script.
  *
  * @param s - The script to be serialized.
- * @returns The serialized script as a Buffer.
+ * @returns The serialized script as a Uint8Array.
  */
 function serializeScript(s) {
   /* global BigInt */

--- a/src/cjs/payments/bip341.d.ts
+++ b/src/cjs/payments/bip341.d.ts
@@ -45,7 +45,7 @@ export declare function findScriptPath(node: HashTree, hash: Uint8Array): Uint8A
 /**
  * Calculates the tapleaf hash for a given Tapleaf object.
  * @param leaf - The Tapleaf object to calculate the hash for.
- * @returns The tapleaf hash as a Buffer.
+ * @returns The tapleaf hash as a Uint8Array.
  */
 export declare function tapleafHash(leaf: Tapleaf): Uint8Array;
 /**

--- a/src/cjs/psbt.cjs
+++ b/src/cjs/psbt.cjs
@@ -90,9 +90,9 @@ const DEFAULT_OPTS = {
  *   `psbt.addOutput(output)`, `psbt.addOutputs(outputs)` when you are looking to
  *   add new inputs and outputs to the PSBT, and `psbt.updateGlobal(itemObject)`,
  *   `psbt.updateInput(itemObject)`, `psbt.updateOutput(itemObject)`
- *   addInput requires hash: Buffer | string; and index: number; as attributes
+ *   addInput requires hash: Uint8Array | string; and index: number; as attributes
  *   and can also include any attributes that are used in updateInput method.
- *   addOutput requires script: Buffer; and value: number; and likewise can include
+ *   addOutput requires script: Uint8Array; and value: number; and likewise can include
  *   data for updateOutput.
  *   For a list of what attributes should be what types. Check the bip174 library.
  *   Also, check the integration tests for some examples of usage.

--- a/src/cjs/psbt.d.ts
+++ b/src/cjs/psbt.d.ts
@@ -30,9 +30,9 @@ export type ValidateSigFunction = (pubkey: Uint8Array, msghash: Uint8Array, sign
  *   `psbt.addOutput(output)`, `psbt.addOutputs(outputs)` when you are looking to
  *   add new inputs and outputs to the PSBT, and `psbt.updateGlobal(itemObject)`,
  *   `psbt.updateInput(itemObject)`, `psbt.updateOutput(itemObject)`
- *   addInput requires hash: Buffer | string; and index: number; as attributes
+ *   addInput requires hash: Uint8Array | string; and index: number; as attributes
  *   and can also include any attributes that are used in updateInput method.
- *   addOutput requires script: Buffer; and value: number; and likewise can include
+ *   addOutput requires script: Uint8Array; and value: number; and likewise can include
  *   data for updateOutput.
  *   For a list of what attributes should be what types. Check the bip174 library.
  *   Also, check the integration tests for some examples of usage.

--- a/src/cjs/psbt/psbtutils.cjs
+++ b/src/cjs/psbt/psbtutils.cjs
@@ -88,7 +88,7 @@ exports.isP2TR = isPaymentFactory(payments.p2tr);
 /**
  * Converts a witness stack to a script witness.
  * @param witness The witness stack to convert.
- * @returns The script witness as a Buffer.
+ * @returns The script witness as a Uint8Array.
  */
 function witnessStackToScriptWitness(witness) {
   let buffer = new Uint8Array(0);

--- a/src/cjs/psbt/psbtutils.d.ts
+++ b/src/cjs/psbt/psbtutils.d.ts
@@ -9,7 +9,7 @@ export declare const isP2TR: (script: Uint8Array) => boolean;
 /**
  * Converts a witness stack to a script witness.
  * @param witness The witness stack to convert.
- * @returns The script witness as a Buffer.
+ * @returns The script witness as a Uint8Array.
  */
 export declare function witnessStackToScriptWitness(witness: Uint8Array[]): Uint8Array;
 /**

--- a/src/cjs/script.cjs
+++ b/src/cjs/script.cjs
@@ -241,7 +241,7 @@ function decompile(buffer) {
 }
 /**
  * Converts the given chunks into an ASM (Assembly) string representation.
- * If the chunks parameter is a Buffer, it will be decompiled into a Stack before conversion.
+ * If the chunks parameter is a Uint8Array (Buffer-compatible), it will be decompiled into a Stack before conversion.
  * @param chunks - The chunks to convert into ASM.
  * @returns The ASM string representation of the chunks.
  */
@@ -265,9 +265,9 @@ function toASM(chunks) {
     .join(' ');
 }
 /**
- * Converts an ASM string to a Buffer.
+ * Converts an ASM string to a Uint8Array.
  * @param asm The ASM string to convert.
- * @returns The converted Buffer.
+ * @returns The converted Uint8Array.
  */
 function fromASM(asm) {
   v.parse(v.string(), asm);

--- a/src/cjs/script.d.ts
+++ b/src/cjs/script.d.ts
@@ -41,15 +41,15 @@ export declare function compile(chunks: Uint8Array | Stack): Uint8Array;
 export declare function decompile(buffer: Uint8Array | Array<number | Uint8Array>): Array<number | Uint8Array> | null;
 /**
  * Converts the given chunks into an ASM (Assembly) string representation.
- * If the chunks parameter is a Buffer, it will be decompiled into a Stack before conversion.
+ * If the chunks parameter is a Uint8Array (Buffer-compatible), it will be decompiled into a Stack before conversion.
  * @param chunks - The chunks to convert into ASM.
  * @returns The ASM string representation of the chunks.
  */
 export declare function toASM(chunks: Uint8Array | Array<number | Uint8Array>): string;
 /**
- * Converts an ASM string to a Buffer.
+ * Converts an ASM string to a Uint8Array.
  * @param asm The ASM string to convert.
- * @returns The converted Buffer.
+ * @returns The converted Uint8Array.
  */
 export declare function fromASM(asm: string): Uint8Array;
 /**

--- a/src/esm/address.js
+++ b/src/esm/address.js
@@ -117,7 +117,7 @@ export function toBech32(data, version, prefix) {
 }
 /**
  * Converts an output script to a Bitcoin address.
- * @param output - The output script as a Buffer.
+ * @param output - The output script as a Uint8Array.
  * @param network - The Bitcoin network (optional).
  * @returns The Bitcoin address corresponding to the output script.
  * @throws If the output script has no matching address.
@@ -149,7 +149,7 @@ export function fromOutputScript(output, network) {
  * Converts a Bitcoin address to its corresponding output script.
  * @param address - The Bitcoin address to convert.
  * @param network - The Bitcoin network to use. Defaults to the Bitcoin network.
- * @returns The corresponding output script as a Buffer.
+ * @returns The corresponding output script as a Uint8Array.
  * @throws If the address has an invalid prefix or no matching script.
  */
 export function toOutputScript(address, network) {

--- a/src/esm/payments/bip341.js
+++ b/src/esm/payments/bip341.js
@@ -68,7 +68,7 @@ export function findScriptPath(node, hash) {
 /**
  * Calculates the tapleaf hash for a given Tapleaf object.
  * @param leaf - The Tapleaf object to calculate the hash for.
- * @returns The tapleaf hash as a Buffer.
+ * @returns The tapleaf hash as a Uint8Array.
  */
 export function tapleafHash(leaf) {
   const version = leaf.version || LEAF_VERSION_TAPSCRIPT;
@@ -124,7 +124,7 @@ function tapBranchHash(a, b) {
  * Serializes a script by encoding its length as a varint and concatenating it with the script.
  *
  * @param s - The script to be serialized.
- * @returns The serialized script as a Buffer.
+ * @returns The serialized script as a Uint8Array.
  */
 function serializeScript(s) {
   /* global BigInt */

--- a/src/esm/psbt.js
+++ b/src/esm/psbt.js
@@ -57,9 +57,9 @@ const DEFAULT_OPTS = {
  *   `psbt.addOutput(output)`, `psbt.addOutputs(outputs)` when you are looking to
  *   add new inputs and outputs to the PSBT, and `psbt.updateGlobal(itemObject)`,
  *   `psbt.updateInput(itemObject)`, `psbt.updateOutput(itemObject)`
- *   addInput requires hash: Buffer | string; and index: number; as attributes
+ *   addInput requires hash: Uint8Array | string; and index: number; as attributes
  *   and can also include any attributes that are used in updateInput method.
- *   addOutput requires script: Buffer; and value: number; and likewise can include
+ *   addOutput requires script: Uint8Array; and value: number; and likewise can include
  *   data for updateOutput.
  *   For a list of what attributes should be what types. Check the bip174 library.
  *   Also, check the integration tests for some examples of usage.

--- a/src/esm/psbt/psbtutils.js
+++ b/src/esm/psbt/psbtutils.js
@@ -29,7 +29,7 @@ export const isP2TR = isPaymentFactory(payments.p2tr);
 /**
  * Converts a witness stack to a script witness.
  * @param witness The witness stack to convert.
- * @returns The script witness as a Buffer.
+ * @returns The script witness as a Uint8Array.
  */
 export function witnessStackToScriptWitness(witness) {
   let buffer = new Uint8Array(0);

--- a/src/esm/script.js
+++ b/src/esm/script.js
@@ -179,7 +179,7 @@ export function decompile(buffer) {
 }
 /**
  * Converts the given chunks into an ASM (Assembly) string representation.
- * If the chunks parameter is a Buffer, it will be decompiled into a Stack before conversion.
+ * If the chunks parameter is a Uint8Array (Buffer-compatible), it will be decompiled into a Stack before conversion.
  * @param chunks - The chunks to convert into ASM.
  * @returns The ASM string representation of the chunks.
  */
@@ -203,9 +203,9 @@ export function toASM(chunks) {
     .join(' ');
 }
 /**
- * Converts an ASM string to a Buffer.
+ * Converts an ASM string to a Uint8Array.
  * @param asm The ASM string to convert.
- * @returns The converted Buffer.
+ * @returns The converted Uint8Array.
  */
 export function fromASM(asm) {
   v.parse(v.string(), asm);

--- a/ts_src/address.ts
+++ b/ts_src/address.ts
@@ -171,7 +171,7 @@ export function toBech32(
 
 /**
  * Converts an output script to a Bitcoin address.
- * @param output - The output script as a Buffer.
+ * @param output - The output script as a Uint8Array.
  * @param network - The Bitcoin network (optional).
  * @returns The Bitcoin address corresponding to the output script.
  * @throws If the output script has no matching address.
@@ -209,7 +209,7 @@ export function fromOutputScript(
  * Converts a Bitcoin address to its corresponding output script.
  * @param address - The Bitcoin address to convert.
  * @param network - The Bitcoin network to use. Defaults to the Bitcoin network.
- * @returns The corresponding output script as a Buffer.
+ * @returns The corresponding output script as a Uint8Array.
  * @throws If the address has an invalid prefix or no matching script.
  */
 export function toOutputScript(address: string, network?: Network): Uint8Array {

--- a/ts_src/payments/bip341.ts
+++ b/ts_src/payments/bip341.ts
@@ -110,7 +110,7 @@ export function findScriptPath(
 /**
  * Calculates the tapleaf hash for a given Tapleaf object.
  * @param leaf - The Tapleaf object to calculate the hash for.
- * @returns The tapleaf hash as a Buffer.
+ * @returns The tapleaf hash as a Uint8Array.
  */
 export function tapleafHash(leaf: Tapleaf): Uint8Array {
   const version = leaf.version || LEAF_VERSION_TAPSCRIPT;
@@ -178,7 +178,7 @@ function tapBranchHash(a: Uint8Array, b: Uint8Array): Uint8Array {
  * Serializes a script by encoding its length as a varint and concatenating it with the script.
  *
  * @param s - The script to be serialized.
- * @returns The serialized script as a Buffer.
+ * @returns The serialized script as a Uint8Array.
  */
 function serializeScript(s: Uint8Array): Uint8Array {
   /* global BigInt */

--- a/ts_src/psbt.ts
+++ b/ts_src/psbt.ts
@@ -101,9 +101,9 @@ const DEFAULT_OPTS: PsbtOpts = {
  *   `psbt.addOutput(output)`, `psbt.addOutputs(outputs)` when you are looking to
  *   add new inputs and outputs to the PSBT, and `psbt.updateGlobal(itemObject)`,
  *   `psbt.updateInput(itemObject)`, `psbt.updateOutput(itemObject)`
- *   addInput requires hash: Buffer | string; and index: number; as attributes
+ *   addInput requires hash: Uint8Array | string; and index: number; as attributes
  *   and can also include any attributes that are used in updateInput method.
- *   addOutput requires script: Buffer; and value: number; and likewise can include
+ *   addOutput requires script: Uint8Array; and value: number; and likewise can include
  *   data for updateOutput.
  *   For a list of what attributes should be what types. Check the bip174 library.
  *   Also, check the integration tests for some examples of usage.

--- a/ts_src/psbt/psbtutils.ts
+++ b/ts_src/psbt/psbtutils.ts
@@ -33,7 +33,7 @@ export const isP2TR = isPaymentFactory(payments.p2tr);
 /**
  * Converts a witness stack to a script witness.
  * @param witness The witness stack to convert.
- * @returns The script witness as a Buffer.
+ * @returns The script witness as a Uint8Array.
  */
 export function witnessStackToScriptWitness(witness: Uint8Array[]): Uint8Array {
   let buffer = new Uint8Array(0);

--- a/ts_src/script.ts
+++ b/ts_src/script.ts
@@ -218,7 +218,7 @@ export function decompile(
 
 /**
  * Converts the given chunks into an ASM (Assembly) string representation.
- * If the chunks parameter is a Buffer, it will be decompiled into a Stack before conversion.
+ * If the chunks parameter is a Uint8Array (Buffer-compatible), it will be decompiled into a Stack before conversion.
  * @param chunks - The chunks to convert into ASM.
  * @returns The ASM string representation of the chunks.
  */
@@ -244,9 +244,9 @@ export function toASM(chunks: Uint8Array | Array<number | Uint8Array>): string {
 }
 
 /**
- * Converts an ASM string to a Buffer.
+ * Converts an ASM string to a Uint8Array.
  * @param asm The ASM string to convert.
- * @returns The converted Buffer.
+ * @returns The converted Uint8Array.
  */
 export function fromASM(asm: string): Uint8Array {
   v.parse(v.string(), asm);


### PR DESCRIPTION
Closes #2321

This is a docs-only cleanup to align wording with the v7 Uint8Array-first API direction.

### What changed
- Updated README wording to reflect Uint8Array-first usage (Buffer-compatible).
- Updated JSDoc comments in ts sources where return/param types still said "Buffer" while signatures are Uint8Array.

### Non-goals
- No runtime behavior changes
- No API signature changes