### PR TITLE
feat(psbt): add PsbtV2 BIP-370 support built on bip370

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
         "bip174": "^3.0.0",
+        "bip370": "github:jvgelder/bip370#0ca4383bd6fa17a979501339997a5e3407ea7b38",
         "bs58check": "^4.0.0",
         "uint8array-tools": "^0.0.9",
         "valibot": "^1.2.0",
@@ -1303,6 +1304,28 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bip370": {
+      "version": "0.0.1",
+      "resolved": "git+ssh://git@github.com/jvgelder/bip370.git#0ca4383bd6fa17a979501339997a5e3407ea7b38",
+      "integrity": "sha512-A0frZI0RvxfAtgR6V3Cl10H+3nkBVwV7PkCK0dux002ePZlAQAYNkym+EY1aVGXccNTc4rCqoy/ClqrflsMGkg==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.9",
+        "valibot": "^1.2.0",
+        "varuint-bitcoin": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "bitcoinjs-lib": "^7.0.1"
+      },
+      "peerDependenciesMeta": {
+        "bitcoinjs-lib": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@noble/hashes": "^1.2.0",
     "bech32": "^2.0.0",
     "bip174": "^3.0.0",
+    "bip370": "github:jvgelder/bip370#0ca4383bd6fa17a979501339997a5e3407ea7b38",
     "bs58check": "^4.0.0",
     "uint8array-tools": "^0.0.9",
     "valibot": "^1.2.0",

--- a/src/cjs/index.cjs
+++ b/src/cjs/index.cjs
@@ -47,6 +47,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 exports.initEccLib =
   exports.Transaction =
   exports.opcodes =
+  exports.PsbtV2 =
   exports.toXOnly =
   exports.Psbt =
   exports.Block =
@@ -84,6 +85,13 @@ Object.defineProperty(exports, 'toXOnly', {
   enumerable: true,
   get: function () {
     return psbt_js_1.toXOnly;
+  },
+});
+var psbtv2_js_1 = require('./psbtv2.cjs');
+Object.defineProperty(exports, 'PsbtV2', {
+  enumerable: true,
+  get: function () {
+    return psbtv2_js_1.PsbtV2;
   },
 });
 /** @hidden */

--- a/src/cjs/index.d.ts
+++ b/src/cjs/index.d.ts
@@ -8,6 +8,7 @@ export { Block } from './block.js';
 /** @hidden */
 export { TaggedHashPrefix } from './crypto.js';
 export { Psbt, PsbtTxInput, PsbtTxOutput, Signer, SignerAsync, HDSigner, HDSignerAsync, toXOnly, } from './psbt.js';
+export { PsbtV2Opts, PsbtV2InputExtended, PsbtV2OutputExtended, PsbtV2, ValidateSigFunction, } from './psbtv2.js';
 /** @hidden */
 export { OPS as opcodes } from './ops.js';
 export { Transaction } from './transaction.js';

--- a/src/cjs/psbtv2.cjs
+++ b/src/cjs/psbtv2.cjs
@@ -1,0 +1,773 @@
+'use strict';
+/**
+ * PSBTv2 (BIP-370) implementation for bitcoinjs-lib
+ *
+ * Lives at ts_src/psbtv2.ts alongside ts_src/psbt.ts.
+ * Extends PSBTv2Builder from bip370 with Bitcoin-aware functionality,
+ * mirroring the API of the existing Psbt class where possible.
+ *
+ * Usage:
+ *   import { PsbtV2 } from './psbtv2.js';
+ *   const psbt = new PsbtV2({ network: networks.testnet });
+ *   psbt.addInputExtended({ hash: txid, index: 0, witnessUtxo: { script, value } });
+ *   psbt.addOutput({ address: 'tb1q...', value: 50000n });
+ *   psbt.signInput(0, ecPair);
+ *   psbt.finalizeAllInputs();
+ *   const tx = psbt.toTransaction();
+ */
+var __createBinding =
+  (this && this.__createBinding) ||
+  (Object.create
+    ? function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (
+          !desc ||
+          ('get' in desc ? !m.__esModule : desc.writable || desc.configurable)
+        ) {
+          desc = {
+            enumerable: true,
+            get: function () {
+              return m[k];
+            },
+          };
+        }
+        Object.defineProperty(o, k2, desc);
+      }
+    : function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+      });
+var __setModuleDefault =
+  (this && this.__setModuleDefault) ||
+  (Object.create
+    ? function (o, v) {
+        Object.defineProperty(o, 'default', { enumerable: true, value: v });
+      }
+    : function (o, v) {
+        o['default'] = v;
+      });
+var __importStar =
+  (this && this.__importStar) ||
+  function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null)
+      for (var k in mod)
+        if (k !== 'default' && Object.prototype.hasOwnProperty.call(mod, k))
+          __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+  };
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.PsbtV2 = exports.toXOnly = exports.ValidationErrorContainer = void 0;
+const bip370_1 = require('bip370');
+const errors_1 = require('bip370/errors');
+Object.defineProperty(exports, 'ValidationErrorContainer', {
+  enumerable: true,
+  get: function () {
+    return errors_1.ValidationErrorContainer;
+  },
+});
+const fields_1 = require('bip370/fields');
+const fields_2 = require('bip370/fields');
+const utils_1 = require('bip370/utils');
+const address_js_1 = require('./address.cjs');
+const networks_js_1 = require('./networks.cjs');
+const payments = __importStar(require('./payments/index.cjs'));
+const bscript = __importStar(require('./script.cjs'));
+const transaction_js_1 = require('./transaction.cjs');
+const bip371_js_1 = require('./psbt/bip371.cjs');
+Object.defineProperty(exports, 'toXOnly', {
+  enumerable: true,
+  get: function () {
+    return bip371_js_1.toXOnly;
+  },
+});
+const bip341_js_1 = require('./payments/bip341.cjs');
+const psbtutils_js_1 = require('./psbt/psbtutils.cjs');
+const uint8array_tools_1 = require('uint8array-tools');
+// ─── Adapter ─────────────────────────────────────────────────────────────────
+class PsbtV2 extends bip370_1.PSBTv2Builder {
+  network;
+  maximumFeeRate;
+  constructor(opts = {}) {
+    super();
+    this.network = opts.network ?? networks_js_1.bitcoin;
+    this.maximumFeeRate = opts.maximumFeeRate ?? 5000;
+    // BIP-370 requires these four globals to be present from construction
+    this.setGlobal(
+      fields_1.GlobalTypes.PSBT_VERSION,
+      fields_2.GlobalField[fields_1.GlobalTypes.PSBT_VERSION].encode(2).value,
+    );
+    this.setGlobal(
+      fields_1.GlobalTypes.TX_VERSION,
+      fields_2.GlobalField[fields_1.GlobalTypes.TX_VERSION].encode(2).value,
+    );
+    this.setGlobal(
+      fields_1.GlobalTypes.INPUT_COUNT,
+      fields_2.GlobalField[fields_1.GlobalTypes.INPUT_COUNT].encode(0).value,
+    );
+    this.setGlobal(
+      fields_1.GlobalTypes.OUTPUT_COUNT,
+      fields_2.GlobalField[fields_1.GlobalTypes.OUTPUT_COUNT].encode(0).value,
+    );
+  }
+  setMaximumFeeRate(satoshiPerByte) {
+    this.maximumFeeRate = satoshiPerByte;
+  }
+  // ─── Creator ───────────────────────────────────────────────────────────────
+  /**
+   * Mirrors Psbt.addInput() — hash + index plus any input update fields
+   * in a single object. Splits into addInput() + updateInput() internally.
+   */
+  addInputExtended(data) {
+    const {
+      hash,
+      index,
+      witnessUtxo,
+      nonWitnessUtxo,
+      redeemScript,
+      witnessScript,
+      sighashType,
+      bip32Derivation,
+      tapInternalKey,
+      tapMerkleRoot,
+      tapBip32Derivation,
+      tapLeafScript,
+      sequence,
+      requiredTimeLockTime,
+      requiredHeightLockTime,
+    } = data;
+    this.addInput({ hash, index });
+    const inputUpdate = {
+      witnessUtxo,
+      nonWitnessUtxo,
+      redeemScript,
+      witnessScript,
+      sighashType,
+      tapInternalKey,
+      tapMerkleRoot,
+      tapLeafScript,
+      sequence,
+      requiredTimeLockTime,
+      requiredHeightLockTime,
+      // bip174 path is string, bip370 expects number[] — structurally compatible at runtime
+      bip32Derivation: bip32Derivation,
+      tapBip32Derivation: tapBip32Derivation,
+    };
+    if (Object.values(inputUpdate).some(v => v !== undefined)) {
+      this.updateInput(this.inputCount - 1, inputUpdate);
+    }
+    return this;
+  }
+  /**
+   * Mirrors Psbt.addOutput() — accepts address or script plus value and any
+   * output update fields. Address-to-script conversion is network-aware.
+   */
+  addOutput(data) {
+    const script =
+      'address' in data
+        ? (0, address_js_1.toOutputScript)(data.address, this.network)
+        : data.script;
+    const outputIndex = super.addOutput({ script, value: data.value });
+    const {
+      redeemScript,
+      witnessScript,
+      bip32Derivation,
+      tapInternalKey,
+      tapTree,
+      tapBip32Derivation,
+    } = data;
+    const outputUpdate = {
+      redeemScript,
+      witnessScript,
+      tapInternalKey,
+      tapTree,
+      // bip174 path is string, bip370 expects number[] — compatible at runtime
+      bip32Derivation: bip32Derivation,
+      tapBip32Derivation: tapBip32Derivation,
+    };
+    if (Object.values(outputUpdate).some(v => v !== undefined)) {
+      this.updateOutput(this.outputCount - 1, outputUpdate);
+    }
+    return outputIndex;
+  }
+  // ─── Signer ────────────────────────────────────────────────────────────────
+  /**
+   * Sign an input. Computes the sighash internally from UTXO data,
+   * mirroring Psbt.signInput(). Handles legacy, segwit, and Taproot inputs.
+   * For Taproot, pass tapLeafHashToSign for script-path, omit for key-path.
+   */
+  signInput(inputIndex, keyPair, tapLeafHashToSign, sighashTypes) {
+    if (!keyPair?.publicKey) throw new Error('Need Signer to sign input');
+    return this._isTaprootInput(inputIndex)
+      ? this._signTaprootInput(
+          inputIndex,
+          keyPair,
+          tapLeafHashToSign,
+          sighashTypes,
+        )
+      : this._signNonTaprootInput(inputIndex, keyPair, sighashTypes);
+  }
+  signInputAsync(inputIndex, keyPair, tapLeafHashToSign, sighashTypes) {
+    return Promise.resolve().then(() => {
+      if (!keyPair?.publicKey) throw new Error('Need Signer to sign input');
+      return this._isTaprootInput(inputIndex)
+        ? this._signTaprootInputAsync(
+            inputIndex,
+            keyPair,
+            tapLeafHashToSign,
+            sighashTypes,
+          )
+        : this._signNonTaprootInputAsync(inputIndex, keyPair, sighashTypes);
+    });
+  }
+  _signNonTaprootInput(
+    inputIndex,
+    keyPair,
+    sighashTypes = [transaction_js_1.Transaction.SIGHASH_ALL],
+  ) {
+    const { hash, sighashType } = this._getHashForInput(
+      inputIndex,
+      sighashTypes,
+    );
+    const signature = bscript.signature.encode(keyPair.sign(hash), sighashType);
+    this.addPartialSig(inputIndex, { pubkey: keyPair.publicKey, signature });
+    return this;
+  }
+  async _signNonTaprootInputAsync(
+    inputIndex,
+    keyPair,
+    sighashTypes = [transaction_js_1.Transaction.SIGHASH_ALL],
+  ) {
+    const { hash, sighashType } = this._getHashForInput(
+      inputIndex,
+      sighashTypes,
+    );
+    const signature = bscript.signature.encode(
+      await keyPair.sign(hash),
+      sighashType,
+    );
+    this.addPartialSig(inputIndex, { pubkey: keyPair.publicKey, signature });
+  }
+  _signTaprootInput(
+    inputIndex,
+    keyPair,
+    tapLeafHashToSign,
+    sighashTypes = [transaction_js_1.Transaction.SIGHASH_DEFAULT],
+  ) {
+    if (typeof keyPair.signSchnorr !== 'function')
+      throw new Error(
+        `Need Schnorr Signer to sign taproot input #${inputIndex}`,
+      );
+    const hashes = this._getTaprootHashes(
+      inputIndex,
+      keyPair.publicKey,
+      tapLeafHashToSign,
+      sighashTypes,
+    );
+    if (!hashes.length)
+      throw new Error(
+        `Can not sign for input #${inputIndex} with key ${(0, uint8array_tools_1.toHex)(keyPair.publicKey)}`,
+      );
+    for (const { hash, leafHash } of hashes) {
+      this._addTaprootSig(
+        inputIndex,
+        keyPair.publicKey,
+        leafHash,
+        (0, bip371_js_1.serializeTaprootSignature)(
+          keyPair.signSchnorr(hash),
+          this._getSighashType(inputIndex),
+        ),
+      );
+    }
+    return this;
+  }
+  async _signTaprootInputAsync(
+    inputIndex,
+    keyPair,
+    tapLeafHashToSign,
+    sighashTypes = [transaction_js_1.Transaction.SIGHASH_DEFAULT],
+  ) {
+    if (typeof keyPair.signSchnorr !== 'function')
+      throw new Error(
+        `Need Schnorr Signer to sign taproot input #${inputIndex}`,
+      );
+    const hashes = this._getTaprootHashes(
+      inputIndex,
+      keyPair.publicKey,
+      tapLeafHashToSign,
+      sighashTypes,
+    );
+    if (!hashes.length)
+      throw new Error(
+        `Can not sign for input #${inputIndex} with key ${(0, uint8array_tools_1.toHex)(keyPair.publicKey)}`,
+      );
+    await Promise.all(
+      hashes.map(async ({ hash, leafHash }) =>
+        this._addTaprootSig(
+          inputIndex,
+          keyPair.publicKey,
+          leafHash,
+          (0, bip371_js_1.serializeTaprootSignature)(
+            await keyPair.signSchnorr(hash),
+            this._getSighashType(inputIndex),
+          ),
+        ),
+      ),
+    );
+  }
+  /** Shared: store a taproot signature as key-sig or script-sig depending on leafHash. */
+  _addTaprootSig(inputIndex, pubkey, leafHash, sig) {
+    if (leafHash) {
+      this.addTapScriptSig(inputIndex, {
+        pubkey: (0, bip371_js_1.toXOnly)(pubkey),
+        leafHash,
+        signature: sig,
+      });
+    } else {
+      this.addTapKeySig(inputIndex, sig);
+    }
+  }
+  // ─── Validation ───────────────────────────────────────────────────────────
+  /**
+   * Validate signatures for a specific input. Recomputes the sighash from
+   * UTXO data. Mirrors Psbt.validateSignaturesOfInput().
+   */
+  validateSignaturesOfInput(inputIndex, validator, pubkey) {
+    return this._isTaprootInput(inputIndex)
+      ? this._validateTaprootSignatures(inputIndex, validator, pubkey)
+      : this._validateNonTaprootSignatures(inputIndex, validator, pubkey);
+  }
+  /** Mirrors Psbt.validateSignaturesOfAllInputs(). */
+  validateSignaturesOfAllInputs(validator) {
+    if (this.inputCount === 0) throw new Error('No inputs to validate');
+    return Array.from({ length: this.inputCount }, (_, i) => i).every(i =>
+      this.validateSignaturesOfInput(i, validator),
+    );
+  }
+  _validateNonTaprootSignatures(inputIndex, validator, pubkey) {
+    const partialSigs = this.getPartialSigs(inputIndex);
+    if (!partialSigs.length) throw new Error('No signatures to validate');
+    const sigsToCheck = pubkey
+      ? partialSigs.filter(
+          ps => (0, uint8array_tools_1.compare)(ps.pubkey, pubkey) === 0,
+        )
+      : partialSigs;
+    if (!sigsToCheck.length) throw new Error('No signatures for this pubkey');
+    for (const pSig of sigsToCheck) {
+      const { signature, hashType } = bscript.signature.decode(pSig.signature);
+      const { hash } = this._getHashForInput(inputIndex, [hashType]);
+      try {
+        if (!validator(pSig.pubkey, hash, signature)) return false;
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  }
+  _validateTaprootSignatures(inputIndex, validator, pubkey) {
+    const tapKeySig = this.getInput(
+      inputIndex,
+      fields_1.InputTypes.TAP_KEY_SIG,
+    );
+    const tapScriptSigs = this.getTapScriptSigs(inputIndex);
+    if (!tapKeySig && !tapScriptSigs.length)
+      throw new Error('No signatures to validate');
+    const xOnlyPubkey = pubkey ? (0, bip371_js_1.toXOnly)(pubkey) : undefined;
+    let validated = 0;
+    if (tapKeySig) {
+      const tapInternalKeyBuf = this.getInput(
+        inputIndex,
+        fields_1.InputTypes.TAP_INTERNAL_KEY,
+      );
+      const keyForHashes =
+        pubkey ??
+        (tapInternalKeyBuf
+          ? fields_2.InputField[fields_1.InputTypes.TAP_INTERNAL_KEY].decode(
+              tapInternalKeyBuf,
+            )
+          : tapKeySig.slice(0, 32));
+      const keyHash = this._getTaprootHashes(inputIndex, keyForHashes).find(
+        h => !h.leafHash,
+      );
+      if (keyHash) {
+        const sig =
+          tapKeySig.length === 65 ? tapKeySig.slice(0, 64) : tapKeySig;
+        try {
+          if (!validator(keyHash.pubkey, keyHash.hash, sig)) return false;
+        } catch {
+          return false;
+        }
+        validated++;
+      }
+    }
+    for (const tapScriptSig of tapScriptSigs) {
+      if (
+        xOnlyPubkey &&
+        (0, uint8array_tools_1.compare)(tapScriptSig.pubkey, xOnlyPubkey) !== 0
+      )
+        continue;
+      const hashes = this._getTaprootHashes(
+        inputIndex,
+        tapScriptSig.pubkey,
+        tapScriptSig.leafHash,
+      );
+      const match = hashes.find(
+        h =>
+          h.leafHash &&
+          (0, uint8array_tools_1.compare)(h.leafHash, tapScriptSig.leafHash) ===
+            0,
+      );
+      if (match) {
+        const sig =
+          tapScriptSig.signature.length === 65
+            ? tapScriptSig.signature.slice(0, 64)
+            : tapScriptSig.signature;
+        try {
+          if (!validator(tapScriptSig.pubkey, match.hash, sig)) return false;
+        } catch {
+          return false;
+        }
+        validated++;
+      }
+    }
+    if (validated === 0) throw new Error('No signatures for this pubkey');
+    return true;
+  }
+  /**
+   * Verify that NON_WITNESS_UTXO txid matches PREVIOUS_TXID.
+   * Only possible inside bitcoinjs-lib where we have Transaction.getHash().
+   */
+  verifyNonWitnessUtxo(inputIndex) {
+    const nonWitnessUtxoBuf = this.getInput(
+      inputIndex,
+      fields_1.InputTypes.NON_WITNESS_UTXO,
+    );
+    const previousTxidBuf = this.getInput(
+      inputIndex,
+      fields_1.InputTypes.PREVIOUS_TXID,
+    );
+    if (!nonWitnessUtxoBuf || !previousTxidBuf) return false;
+    return (
+      (0, uint8array_tools_1.compare)(
+        transaction_js_1.Transaction.fromBuffer(nonWitnessUtxoBuf).getHash(),
+        previousTxidBuf,
+      ) === 0
+    );
+  }
+  // ─── Extractor ─────────────────────────────────────────────────────────────
+  /**
+   * Build a bitcoinjs-lib Transaction from the PSBT maps.
+   * Mirrors Psbt.extractTransaction() including the maximumFeeRate guard.
+   */
+  toTransaction(disableFeeCheck = false) {
+    const tx = new transaction_js_1.Transaction();
+    const versionBuf = this.getGlobal(fields_1.GlobalTypes.TX_VERSION);
+    tx.version = versionBuf
+      ? fields_2.GlobalField[fields_1.GlobalTypes.TX_VERSION].decode(versionBuf)
+      : 2;
+    tx.locktime = this.computeLockTime();
+    for (let i = 0; i < this.inputCount; i++) {
+      const hashBuf = this.getInput(i, fields_1.InputTypes.PREVIOUS_TXID);
+      const indexBuf = this.getInput(i, fields_1.InputTypes.OUTPUT_INDEX);
+      if (!hashBuf || !indexBuf)
+        throw new Error(`Input ${i}: missing PREVIOUS_TXID or OUTPUT_INDEX`);
+      const seqBuf = this.getInput(i, fields_1.InputTypes.SEQUENCE);
+      const finalScriptSig = this.getInput(
+        i,
+        fields_1.InputTypes.FINAL_SCRIPTSIG,
+      );
+      const finalScriptWitness = this.getInput(
+        i,
+        fields_1.InputTypes.FINAL_SCRIPTWITNESS,
+      );
+      if (!finalScriptSig && !finalScriptWitness)
+        throw new Error(
+          `Input ${i} is not finalized. Call finalizeInput() first.`,
+        );
+      tx.addInput(
+        fields_2.InputField[fields_1.InputTypes.PREVIOUS_TXID].decode(hashBuf),
+        fields_2.InputField[fields_1.InputTypes.OUTPUT_INDEX].decode(indexBuf),
+        seqBuf
+          ? fields_2.InputField[fields_1.InputTypes.SEQUENCE].decode(seqBuf)
+          : 0xffffffff,
+        finalScriptSig,
+      );
+      if (finalScriptWitness)
+        tx.setWitness(
+          i,
+          (0, utils_1.deserializeWitnessStack)(finalScriptWitness),
+        );
+    }
+    for (let i = 0; i < this.outputCount; i++) {
+      const scriptBuf = this.getOutput(i, fields_1.OutputTypes.SCRIPT);
+      const amountBuf = this.getOutput(i, fields_1.OutputTypes.AMOUNT);
+      if (!scriptBuf || !amountBuf)
+        throw new Error(`Output ${i}: missing SCRIPT or AMOUNT`);
+      tx.addOutput(
+        fields_2.OutputField[fields_1.OutputTypes.SCRIPT].decode(scriptBuf),
+        fields_2.OutputField[fields_1.OutputTypes.AMOUNT].decode(amountBuf),
+      );
+    }
+    if (!disableFeeCheck) {
+      const inputTotal = this.getTotalInputValue();
+      if (inputTotal > 0n) {
+        const feeRate =
+          Number(inputTotal - this.getTotalOutputValue()) / tx.virtualSize();
+        if (feeRate >= this.maximumFeeRate)
+          throw new Error(
+            `Warning: fee rate ${feeRate} sat/vB exceeds maximumFeeRate ${this.maximumFeeRate}. ` +
+              `Use setMaximumFeeRate() to raise your threshold, or pass true to toTransaction().`,
+          );
+      }
+    }
+    return tx;
+  }
+  /**
+   * Get the sighash for a non-taproot input (legacy, P2WPKH, P2WSH).
+   * Sign externally, inject with addPartialSig(), then serialize with toHex().
+   *
+   * @example
+   * const { hash, sighashType } = psbt.getInputHashForSig(0);
+   * psbt.addPartialSig(0, { pubkey, signature: bscript.signature.encode(signer.sign(hash), sighashType) });
+   * const signedHex = psbt.toHex();
+   */
+  getInputHashForSig(
+    inputIndex,
+    sighashTypes = [transaction_js_1.Transaction.SIGHASH_ALL],
+  ) {
+    return this._getHashForInput(inputIndex, sighashTypes);
+  }
+  /**
+   * Get the sighash(es) for a taproot input (key-path or script-path).
+   * Sign externally, inject with addTapKeySig()/addTapScriptSig(), then serialize with toHex().
+   *
+   * @example
+   * const [{ hash }] = psbt.getTaprootHashesForSig(0, pubkey);
+   * psbt.addTapKeySig(0, serializeTaprootSignature(signer.signSchnorr(hash)));
+   * const signedHex = psbt.toHex();
+   */
+  getTaprootHashesForSig(
+    inputIndex,
+    pubkey,
+    tapLeafHashToSign,
+    sighashTypes = [transaction_js_1.Transaction.SIGHASH_DEFAULT],
+  ) {
+    return this._getTaprootHashes(
+      inputIndex,
+      pubkey,
+      tapLeafHashToSign,
+      sighashTypes,
+    );
+  }
+  // ─── Private helpers ───────────────────────────────────────────────────────
+  /**
+   * Check if an input is taproot by inspecting its input map fields.
+   * Uses field presence rather than UTXO script type — more reliable and
+   * avoids WITNESS_UTXO decode issues with untweaked keys in tests.
+   * TAP_LEAF_SCRIPT and TAP_SCRIPT_SIG use key data so need a prefix scan.
+   */
+  _isTaprootInput(inputIndex) {
+    if (
+      this.getInput(inputIndex, fields_1.InputTypes.TAP_INTERNAL_KEY) !=
+      undefined
+    )
+      return true;
+    if (this.getInput(inputIndex, fields_1.InputTypes.TAP_KEY_SIG) != undefined)
+      return true;
+    const map = this._inputMaps[inputIndex];
+    if (!map) return false;
+    const tapLeafPrefix = (0, utils_1.keyFromType)(
+      fields_1.InputTypes.TAP_LEAF_SCRIPT,
+    );
+    const tapScriptPrefix = (0, utils_1.keyFromType)(
+      fields_1.InputTypes.TAP_SCRIPT_SIG,
+    );
+    for (const key of map.keys()) {
+      if (key.startsWith(tapLeafPrefix) || key.startsWith(tapScriptPrefix))
+        return true;
+    }
+    return false;
+  }
+  _buildUnsignedTx() {
+    const tx = new transaction_js_1.Transaction();
+    const versionBuf = this.getGlobal(fields_1.GlobalTypes.TX_VERSION);
+    tx.version = versionBuf
+      ? fields_2.GlobalField[fields_1.GlobalTypes.TX_VERSION].decode(versionBuf)
+      : 2;
+    tx.locktime = this.computeLockTime();
+    for (let i = 0; i < this.inputCount; i++) {
+      const hashBuf = this.getInput(i, fields_1.InputTypes.PREVIOUS_TXID);
+      const indexBuf = this.getInput(i, fields_1.InputTypes.OUTPUT_INDEX);
+      const seqBuf = this.getInput(i, fields_1.InputTypes.SEQUENCE);
+      tx.addInput(
+        fields_2.InputField[fields_1.InputTypes.PREVIOUS_TXID].decode(hashBuf),
+        fields_2.InputField[fields_1.InputTypes.OUTPUT_INDEX].decode(indexBuf),
+        seqBuf
+          ? fields_2.InputField[fields_1.InputTypes.SEQUENCE].decode(seqBuf)
+          : 0xffffffff,
+      );
+    }
+    for (let i = 0; i < this.outputCount; i++) {
+      const scriptBuf = this.getOutput(i, fields_1.OutputTypes.SCRIPT);
+      const amountBuf = this.getOutput(i, fields_1.OutputTypes.AMOUNT);
+      tx.addOutput(
+        fields_2.OutputField[fields_1.OutputTypes.SCRIPT].decode(scriptBuf),
+        fields_2.OutputField[fields_1.OutputTypes.AMOUNT].decode(amountBuf),
+      );
+    }
+    return tx;
+  }
+  _getUtxoForInput(inputIndex) {
+    const witnessUtxoBuf = this.getInput(
+      inputIndex,
+      fields_1.InputTypes.WITNESS_UTXO,
+    );
+    if (witnessUtxoBuf)
+      return fields_2.InputField[fields_1.InputTypes.WITNESS_UTXO].decode(
+        witnessUtxoBuf,
+      );
+    const nonWitnessUtxoBuf = this.getInput(
+      inputIndex,
+      fields_1.InputTypes.NON_WITNESS_UTXO,
+    );
+    const indexBuf = this.getInput(
+      inputIndex,
+      fields_1.InputTypes.OUTPUT_INDEX,
+    );
+    if (nonWitnessUtxoBuf && indexBuf) {
+      const prevTx = transaction_js_1.Transaction.fromBuffer(nonWitnessUtxoBuf);
+      const out =
+        prevTx.outs[
+          fields_2.InputField[fields_1.InputTypes.OUTPUT_INDEX].decode(indexBuf)
+        ];
+      return { script: out.script, value: out.value };
+    }
+    throw new Error(
+      `Input ${inputIndex}: missing WITNESS_UTXO or NON_WITNESS_UTXO`,
+    );
+  }
+  _getSighashType(inputIndex) {
+    const buf = this.getInput(inputIndex, fields_1.InputTypes.SIGHASH_TYPE);
+    return buf
+      ? fields_2.InputField[fields_1.InputTypes.SIGHASH_TYPE].decode(buf)
+      : undefined;
+  }
+  _getHashForInput(
+    inputIndex,
+    sighashTypes = [transaction_js_1.Transaction.SIGHASH_ALL],
+  ) {
+    const sighashType =
+      this._getSighashType(inputIndex) ??
+      transaction_js_1.Transaction.SIGHASH_ALL;
+    if (!sighashTypes.includes(sighashType))
+      throw new Error(
+        `Sighash type ${sighashType} not in allowed list: ${sighashTypes}`,
+      );
+    const tx = this._buildUnsignedTx();
+    const utxo = this._getUtxoForInput(inputIndex);
+    const redeemScriptBuf = this.getInput(
+      inputIndex,
+      fields_1.InputTypes.REDEEM_SCRIPT,
+    );
+    const witnessScriptBuf = this.getInput(
+      inputIndex,
+      fields_1.InputTypes.WITNESS_SCRIPT,
+    );
+    const redeemScript = redeemScriptBuf
+      ? fields_2.InputField[fields_1.InputTypes.REDEEM_SCRIPT].decode(
+          redeemScriptBuf,
+        )
+      : undefined;
+    const witnessScript = witnessScriptBuf
+      ? fields_2.InputField[fields_1.InputTypes.WITNESS_SCRIPT].decode(
+          witnessScriptBuf,
+        )
+      : undefined;
+    // Determine meaningful script (mirrors getMeaningfulScript in psbt.ts)
+    const meaningfulScript = witnessScript ?? redeemScript ?? utxo.script;
+    let hash;
+    if (witnessScript || (0, psbtutils_js_1.isP2WPKH)(meaningfulScript)) {
+      const signingScript = (0, psbtutils_js_1.isP2WPKH)(meaningfulScript)
+        ? payments.p2pkh({ hash: meaningfulScript.slice(2) }).output
+        : meaningfulScript;
+      hash = tx.hashForWitnessV0(
+        inputIndex,
+        signingScript,
+        utxo.value,
+        sighashType,
+      );
+    } else {
+      hash = tx.hashForSignature(inputIndex, meaningfulScript, sighashType);
+    }
+    return { hash, sighashType };
+  }
+  _getTaprootHashes(
+    inputIndex,
+    pubkey,
+    tapLeafHashToSign,
+    sighashTypes = [transaction_js_1.Transaction.SIGHASH_DEFAULT],
+  ) {
+    const sighashType =
+      this._getSighashType(inputIndex) ??
+      transaction_js_1.Transaction.SIGHASH_DEFAULT;
+    if (!sighashTypes.includes(sighashType))
+      throw new Error(`Sighash type ${sighashType} not in allowed list`);
+    const tx = this._buildUnsignedTx();
+    const witnessUtxos = Array.from({ length: this.inputCount }, (_, i) => {
+      const buf = this.getInput(i, fields_1.InputTypes.WITNESS_UTXO);
+      if (!buf)
+        throw new Error(
+          `Input ${i}: missing WITNESS_UTXO (required for taproot)`,
+        );
+      return fields_2.InputField[fields_1.InputTypes.WITNESS_UTXO].decode(buf);
+    });
+    const scripts = witnessUtxos.map(u => u.script);
+    const values = witnessUtxos.map(u => u.value);
+    const xOnly =
+      pubkey.length === 32 ? pubkey : (0, bip371_js_1.toXOnly)(pubkey);
+    const hashes = [];
+    // Key-path spend
+    // Key-path spend (synthetic/internal-key match only; does not derive tweaked output key)
+    if (
+      !tapLeafHashToSign &&
+      this.getInput(inputIndex, fields_1.InputTypes.TAP_INTERNAL_KEY)
+    ) {
+      const outputKey = witnessUtxos[inputIndex].script.slice(2, 34);
+      if ((0, uint8array_tools_1.compare)(xOnly, outputKey) === 0) {
+        hashes.push({
+          pubkey: xOnly,
+          hash: tx.hashForWitnessV1(inputIndex, scripts, values, sighashType),
+        });
+      }
+    }
+    // Script-path spend
+    for (const leaf of this.getTapLeafScripts(inputIndex)) {
+      const leafHash = (0, bip341_js_1.tapleafHash)({
+        output: leaf.script,
+        version: leaf.leafVersion,
+      });
+      if (
+        tapLeafHashToSign &&
+        (0, uint8array_tools_1.compare)(leafHash, tapLeafHashToSign) !== 0
+      )
+        continue;
+      if (!(0, psbtutils_js_1.pubkeyInScript)(pubkey, leaf.script)) continue;
+      hashes.push({
+        pubkey: xOnly,
+        hash: tx.hashForWitnessV1(
+          inputIndex,
+          scripts,
+          values,
+          sighashType,
+          leafHash,
+        ),
+        leafHash,
+      });
+    }
+    return hashes;
+  }
+}
+exports.PsbtV2 = PsbtV2;

--- a/src/cjs/psbtv2.d.ts
+++ b/src/cjs/psbtv2.d.ts
@@ -1,0 +1,141 @@
+/**
+ * PSBTv2 (BIP-370) implementation for bitcoinjs-lib
+ *
+ * Lives at ts_src/psbtv2.ts alongside ts_src/psbt.ts.
+ * Extends PSBTv2Builder from bip370 with Bitcoin-aware functionality,
+ * mirroring the API of the existing Psbt class where possible.
+ *
+ * Usage:
+ *   import { PsbtV2 } from './psbtv2.js';
+ *   const psbt = new PsbtV2({ network: networks.testnet });
+ *   psbt.addInputExtended({ hash: txid, index: 0, witnessUtxo: { script, value } });
+ *   psbt.addOutput({ address: 'tb1q...', value: 50000n });
+ *   psbt.signInput(0, ecPair);
+ *   psbt.finalizeAllInputs();
+ *   const tx = psbt.toTransaction();
+ */
+import { PSBTv2Builder } from 'bip370';
+import { ValidationErrorContainer } from 'bip370/errors';
+export { ValidationErrorContainer };
+import type { Signer, SignerAsync } from './psbt.js';
+import type { PsbtInput, PsbtOutput } from 'bip174';
+import type { TransactionInput } from './psbt.js';
+import { Network } from './networks.js';
+import { Transaction } from './transaction.js';
+import { toXOnly } from './psbt/bip371.js';
+export { toXOnly };
+export interface PsbtV2Opts {
+    network?: Network;
+    /** Maximum fee rate in sat/vB checked on toTransaction(). Matches Psbt's default. */
+    maximumFeeRate?: number;
+}
+/**
+ * PSBTv2 input — mirrors psbt.ts's internal PsbtInputExtended plus
+ * PSBTv2-only fields (requiredTimeLockTime, requiredHeightLockTime).
+ */
+export interface PsbtV2InputExtended extends PsbtInput, TransactionInput {
+    requiredTimeLockTime?: number;
+    requiredHeightLockTime?: number;
+}
+/**
+ * PSBTv2 output — mirrors psbt.ts's internal PsbtOutputExtended plus
+ * bip370's tapTree as Uint8Array (bip174 uses a TapTree object).
+ */
+export type PsbtV2OutputExtended = (PsbtOutput & {
+    address: string;
+    value: bigint;
+    tapTree?: Uint8Array;
+}) | (PsbtOutput & {
+    script: Uint8Array;
+    value: bigint;
+    tapTree?: Uint8Array;
+});
+/** (pubkey, msghash, signature) → boolean — same as Psbt's ValidateSigFunction */
+export type ValidateSigFunction = (pubkey: Uint8Array, msghash: Uint8Array, signature: Uint8Array) => boolean;
+export declare class PsbtV2 extends PSBTv2Builder {
+    readonly network: Network;
+    private maximumFeeRate;
+    constructor(opts?: PsbtV2Opts);
+    setMaximumFeeRate(satoshiPerByte: number): void;
+    /**
+     * Mirrors Psbt.addInput() — hash + index plus any input update fields
+     * in a single object. Splits into addInput() + updateInput() internally.
+     */
+    addInputExtended(data: PsbtV2InputExtended): this;
+    /**
+     * Mirrors Psbt.addOutput() — accepts address or script plus value and any
+     * output update fields. Address-to-script conversion is network-aware.
+     */
+    addOutput(data: PsbtV2OutputExtended): number;
+    /**
+     * Sign an input. Computes the sighash internally from UTXO data,
+     * mirroring Psbt.signInput(). Handles legacy, segwit, and Taproot inputs.
+     * For Taproot, pass tapLeafHashToSign for script-path, omit for key-path.
+     */
+    signInput(inputIndex: number, keyPair: Signer, tapLeafHashToSign?: Uint8Array, sighashTypes?: number[]): this;
+    signInputAsync(inputIndex: number, keyPair: SignerAsync, tapLeafHashToSign?: Uint8Array, sighashTypes?: number[]): Promise<void>;
+    private _signNonTaprootInput;
+    private _signNonTaprootInputAsync;
+    private _signTaprootInput;
+    private _signTaprootInputAsync;
+    /** Shared: store a taproot signature as key-sig or script-sig depending on leafHash. */
+    private _addTaprootSig;
+    /**
+     * Validate signatures for a specific input. Recomputes the sighash from
+     * UTXO data. Mirrors Psbt.validateSignaturesOfInput().
+     */
+    validateSignaturesOfInput(inputIndex: number, validator: ValidateSigFunction, pubkey?: Uint8Array): boolean;
+    /** Mirrors Psbt.validateSignaturesOfAllInputs(). */
+    validateSignaturesOfAllInputs(validator: ValidateSigFunction): boolean;
+    private _validateNonTaprootSignatures;
+    private _validateTaprootSignatures;
+    /**
+     * Verify that NON_WITNESS_UTXO txid matches PREVIOUS_TXID.
+     * Only possible inside bitcoinjs-lib where we have Transaction.getHash().
+     */
+    verifyNonWitnessUtxo(inputIndex: number): boolean;
+    /**
+     * Build a bitcoinjs-lib Transaction from the PSBT maps.
+     * Mirrors Psbt.extractTransaction() including the maximumFeeRate guard.
+     */
+    toTransaction(disableFeeCheck?: boolean): Transaction;
+    /**
+     * Get the sighash for a non-taproot input (legacy, P2WPKH, P2WSH).
+     * Sign externally, inject with addPartialSig(), then serialize with toHex().
+     *
+     * @example
+     * const { hash, sighashType } = psbt.getInputHashForSig(0);
+     * psbt.addPartialSig(0, { pubkey, signature: bscript.signature.encode(signer.sign(hash), sighashType) });
+     * const signedHex = psbt.toHex();
+     */
+    getInputHashForSig(inputIndex: number, sighashTypes?: number[]): {
+        hash: Uint8Array;
+        sighashType: number;
+    };
+    /**
+     * Get the sighash(es) for a taproot input (key-path or script-path).
+     * Sign externally, inject with addTapKeySig()/addTapScriptSig(), then serialize with toHex().
+     *
+     * @example
+     * const [{ hash }] = psbt.getTaprootHashesForSig(0, pubkey);
+     * psbt.addTapKeySig(0, serializeTaprootSignature(signer.signSchnorr(hash)));
+     * const signedHex = psbt.toHex();
+     */
+    getTaprootHashesForSig(inputIndex: number, pubkey: Uint8Array, tapLeafHashToSign?: Uint8Array, sighashTypes?: number[]): {
+        pubkey: Uint8Array;
+        hash: Uint8Array;
+        leafHash?: Uint8Array;
+    }[];
+    /**
+     * Check if an input is taproot by inspecting its input map fields.
+     * Uses field presence rather than UTXO script type — more reliable and
+     * avoids WITNESS_UTXO decode issues with untweaked keys in tests.
+     * TAP_LEAF_SCRIPT and TAP_SCRIPT_SIG use key data so need a prefix scan.
+     */
+    private _isTaprootInput;
+    private _buildUnsignedTx;
+    private _getUtxoForInput;
+    private _getSighashType;
+    private _getHashForInput;
+    private _getTaprootHashes;
+}

--- a/src/esm/index.js
+++ b/src/esm/index.js
@@ -6,6 +6,7 @@ import * as script from './script.js';
 export { address, crypto, networks, payments, script };
 export { Block } from './block.js';
 export { Psbt, toXOnly } from './psbt.js';
+export { PsbtV2 } from './psbtv2.js';
 /** @hidden */
 export { OPS as opcodes } from './ops.js';
 export { Transaction } from './transaction.js';

--- a/src/esm/psbtv2.js
+++ b/src/esm/psbtv2.js
@@ -1,0 +1,651 @@
+/**
+ * PSBTv2 (BIP-370) implementation for bitcoinjs-lib
+ *
+ * Lives at ts_src/psbtv2.ts alongside ts_src/psbt.ts.
+ * Extends PSBTv2Builder from bip370 with Bitcoin-aware functionality,
+ * mirroring the API of the existing Psbt class where possible.
+ *
+ * Usage:
+ *   import { PsbtV2 } from './psbtv2.js';
+ *   const psbt = new PsbtV2({ network: networks.testnet });
+ *   psbt.addInputExtended({ hash: txid, index: 0, witnessUtxo: { script, value } });
+ *   psbt.addOutput({ address: 'tb1q...', value: 50000n });
+ *   psbt.signInput(0, ecPair);
+ *   psbt.finalizeAllInputs();
+ *   const tx = psbt.toTransaction();
+ */
+import { PSBTv2Builder } from 'bip370';
+import { ValidationErrorContainer } from 'bip370/errors';
+export { ValidationErrorContainer };
+import { InputTypes, OutputTypes, GlobalTypes } from 'bip370/fields';
+import { GlobalField, InputField, OutputField } from 'bip370/fields';
+import { deserializeWitnessStack, keyFromType } from 'bip370/utils';
+import { toOutputScript } from './address.js';
+import { bitcoin as btcNetwork } from './networks.js';
+import * as payments from './payments/index.js';
+import * as bscript from './script.js';
+import { Transaction } from './transaction.js';
+import { toXOnly, serializeTaprootSignature } from './psbt/bip371.js';
+import { tapleafHash } from './payments/bip341.js';
+import { isP2WPKH, pubkeyInScript } from './psbt/psbtutils.js';
+import { compare, toHex } from 'uint8array-tools';
+export { toXOnly };
+// ─── Adapter ─────────────────────────────────────────────────────────────────
+export class PsbtV2 extends PSBTv2Builder {
+  network;
+  maximumFeeRate;
+  constructor(opts = {}) {
+    super();
+    this.network = opts.network ?? btcNetwork;
+    this.maximumFeeRate = opts.maximumFeeRate ?? 5000;
+    // BIP-370 requires these four globals to be present from construction
+    this.setGlobal(
+      GlobalTypes.PSBT_VERSION,
+      GlobalField[GlobalTypes.PSBT_VERSION].encode(2).value,
+    );
+    this.setGlobal(
+      GlobalTypes.TX_VERSION,
+      GlobalField[GlobalTypes.TX_VERSION].encode(2).value,
+    );
+    this.setGlobal(
+      GlobalTypes.INPUT_COUNT,
+      GlobalField[GlobalTypes.INPUT_COUNT].encode(0).value,
+    );
+    this.setGlobal(
+      GlobalTypes.OUTPUT_COUNT,
+      GlobalField[GlobalTypes.OUTPUT_COUNT].encode(0).value,
+    );
+  }
+  setMaximumFeeRate(satoshiPerByte) {
+    this.maximumFeeRate = satoshiPerByte;
+  }
+  // ─── Creator ───────────────────────────────────────────────────────────────
+  /**
+   * Mirrors Psbt.addInput() — hash + index plus any input update fields
+   * in a single object. Splits into addInput() + updateInput() internally.
+   */
+  addInputExtended(data) {
+    const {
+      hash,
+      index,
+      witnessUtxo,
+      nonWitnessUtxo,
+      redeemScript,
+      witnessScript,
+      sighashType,
+      bip32Derivation,
+      tapInternalKey,
+      tapMerkleRoot,
+      tapBip32Derivation,
+      tapLeafScript,
+      sequence,
+      requiredTimeLockTime,
+      requiredHeightLockTime,
+    } = data;
+    this.addInput({ hash, index });
+    const inputUpdate = {
+      witnessUtxo,
+      nonWitnessUtxo,
+      redeemScript,
+      witnessScript,
+      sighashType,
+      tapInternalKey,
+      tapMerkleRoot,
+      tapLeafScript,
+      sequence,
+      requiredTimeLockTime,
+      requiredHeightLockTime,
+      // bip174 path is string, bip370 expects number[] — structurally compatible at runtime
+      bip32Derivation: bip32Derivation,
+      tapBip32Derivation: tapBip32Derivation,
+    };
+    if (Object.values(inputUpdate).some(v => v !== undefined)) {
+      this.updateInput(this.inputCount - 1, inputUpdate);
+    }
+    return this;
+  }
+  /**
+   * Mirrors Psbt.addOutput() — accepts address or script plus value and any
+   * output update fields. Address-to-script conversion is network-aware.
+   */
+  addOutput(data) {
+    const script =
+      'address' in data
+        ? toOutputScript(data.address, this.network)
+        : data.script;
+    const outputIndex = super.addOutput({ script, value: data.value });
+    const {
+      redeemScript,
+      witnessScript,
+      bip32Derivation,
+      tapInternalKey,
+      tapTree,
+      tapBip32Derivation,
+    } = data;
+    const outputUpdate = {
+      redeemScript,
+      witnessScript,
+      tapInternalKey,
+      tapTree,
+      // bip174 path is string, bip370 expects number[] — compatible at runtime
+      bip32Derivation: bip32Derivation,
+      tapBip32Derivation: tapBip32Derivation,
+    };
+    if (Object.values(outputUpdate).some(v => v !== undefined)) {
+      this.updateOutput(this.outputCount - 1, outputUpdate);
+    }
+    return outputIndex;
+  }
+  // ─── Signer ────────────────────────────────────────────────────────────────
+  /**
+   * Sign an input. Computes the sighash internally from UTXO data,
+   * mirroring Psbt.signInput(). Handles legacy, segwit, and Taproot inputs.
+   * For Taproot, pass tapLeafHashToSign for script-path, omit for key-path.
+   */
+  signInput(inputIndex, keyPair, tapLeafHashToSign, sighashTypes) {
+    if (!keyPair?.publicKey) throw new Error('Need Signer to sign input');
+    return this._isTaprootInput(inputIndex)
+      ? this._signTaprootInput(
+          inputIndex,
+          keyPair,
+          tapLeafHashToSign,
+          sighashTypes,
+        )
+      : this._signNonTaprootInput(inputIndex, keyPair, sighashTypes);
+  }
+  signInputAsync(inputIndex, keyPair, tapLeafHashToSign, sighashTypes) {
+    return Promise.resolve().then(() => {
+      if (!keyPair?.publicKey) throw new Error('Need Signer to sign input');
+      return this._isTaprootInput(inputIndex)
+        ? this._signTaprootInputAsync(
+            inputIndex,
+            keyPair,
+            tapLeafHashToSign,
+            sighashTypes,
+          )
+        : this._signNonTaprootInputAsync(inputIndex, keyPair, sighashTypes);
+    });
+  }
+  _signNonTaprootInput(
+    inputIndex,
+    keyPair,
+    sighashTypes = [Transaction.SIGHASH_ALL],
+  ) {
+    const { hash, sighashType } = this._getHashForInput(
+      inputIndex,
+      sighashTypes,
+    );
+    const signature = bscript.signature.encode(keyPair.sign(hash), sighashType);
+    this.addPartialSig(inputIndex, { pubkey: keyPair.publicKey, signature });
+    return this;
+  }
+  async _signNonTaprootInputAsync(
+    inputIndex,
+    keyPair,
+    sighashTypes = [Transaction.SIGHASH_ALL],
+  ) {
+    const { hash, sighashType } = this._getHashForInput(
+      inputIndex,
+      sighashTypes,
+    );
+    const signature = bscript.signature.encode(
+      await keyPair.sign(hash),
+      sighashType,
+    );
+    this.addPartialSig(inputIndex, { pubkey: keyPair.publicKey, signature });
+  }
+  _signTaprootInput(
+    inputIndex,
+    keyPair,
+    tapLeafHashToSign,
+    sighashTypes = [Transaction.SIGHASH_DEFAULT],
+  ) {
+    if (typeof keyPair.signSchnorr !== 'function')
+      throw new Error(
+        `Need Schnorr Signer to sign taproot input #${inputIndex}`,
+      );
+    const hashes = this._getTaprootHashes(
+      inputIndex,
+      keyPair.publicKey,
+      tapLeafHashToSign,
+      sighashTypes,
+    );
+    if (!hashes.length)
+      throw new Error(
+        `Can not sign for input #${inputIndex} with key ${toHex(keyPair.publicKey)}`,
+      );
+    for (const { hash, leafHash } of hashes) {
+      this._addTaprootSig(
+        inputIndex,
+        keyPair.publicKey,
+        leafHash,
+        serializeTaprootSignature(
+          keyPair.signSchnorr(hash),
+          this._getSighashType(inputIndex),
+        ),
+      );
+    }
+    return this;
+  }
+  async _signTaprootInputAsync(
+    inputIndex,
+    keyPair,
+    tapLeafHashToSign,
+    sighashTypes = [Transaction.SIGHASH_DEFAULT],
+  ) {
+    if (typeof keyPair.signSchnorr !== 'function')
+      throw new Error(
+        `Need Schnorr Signer to sign taproot input #${inputIndex}`,
+      );
+    const hashes = this._getTaprootHashes(
+      inputIndex,
+      keyPair.publicKey,
+      tapLeafHashToSign,
+      sighashTypes,
+    );
+    if (!hashes.length)
+      throw new Error(
+        `Can not sign for input #${inputIndex} with key ${toHex(keyPair.publicKey)}`,
+      );
+    await Promise.all(
+      hashes.map(async ({ hash, leafHash }) =>
+        this._addTaprootSig(
+          inputIndex,
+          keyPair.publicKey,
+          leafHash,
+          serializeTaprootSignature(
+            await keyPair.signSchnorr(hash),
+            this._getSighashType(inputIndex),
+          ),
+        ),
+      ),
+    );
+  }
+  /** Shared: store a taproot signature as key-sig or script-sig depending on leafHash. */
+  _addTaprootSig(inputIndex, pubkey, leafHash, sig) {
+    if (leafHash) {
+      this.addTapScriptSig(inputIndex, {
+        pubkey: toXOnly(pubkey),
+        leafHash,
+        signature: sig,
+      });
+    } else {
+      this.addTapKeySig(inputIndex, sig);
+    }
+  }
+  // ─── Validation ───────────────────────────────────────────────────────────
+  /**
+   * Validate signatures for a specific input. Recomputes the sighash from
+   * UTXO data. Mirrors Psbt.validateSignaturesOfInput().
+   */
+  validateSignaturesOfInput(inputIndex, validator, pubkey) {
+    return this._isTaprootInput(inputIndex)
+      ? this._validateTaprootSignatures(inputIndex, validator, pubkey)
+      : this._validateNonTaprootSignatures(inputIndex, validator, pubkey);
+  }
+  /** Mirrors Psbt.validateSignaturesOfAllInputs(). */
+  validateSignaturesOfAllInputs(validator) {
+    if (this.inputCount === 0) throw new Error('No inputs to validate');
+    return Array.from({ length: this.inputCount }, (_, i) => i).every(i =>
+      this.validateSignaturesOfInput(i, validator),
+    );
+  }
+  _validateNonTaprootSignatures(inputIndex, validator, pubkey) {
+    const partialSigs = this.getPartialSigs(inputIndex);
+    if (!partialSigs.length) throw new Error('No signatures to validate');
+    const sigsToCheck = pubkey
+      ? partialSigs.filter(ps => compare(ps.pubkey, pubkey) === 0)
+      : partialSigs;
+    if (!sigsToCheck.length) throw new Error('No signatures for this pubkey');
+    for (const pSig of sigsToCheck) {
+      const { signature, hashType } = bscript.signature.decode(pSig.signature);
+      const { hash } = this._getHashForInput(inputIndex, [hashType]);
+      try {
+        if (!validator(pSig.pubkey, hash, signature)) return false;
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  }
+  _validateTaprootSignatures(inputIndex, validator, pubkey) {
+    const tapKeySig = this.getInput(inputIndex, InputTypes.TAP_KEY_SIG);
+    const tapScriptSigs = this.getTapScriptSigs(inputIndex);
+    if (!tapKeySig && !tapScriptSigs.length)
+      throw new Error('No signatures to validate');
+    const xOnlyPubkey = pubkey ? toXOnly(pubkey) : undefined;
+    let validated = 0;
+    if (tapKeySig) {
+      const tapInternalKeyBuf = this.getInput(
+        inputIndex,
+        InputTypes.TAP_INTERNAL_KEY,
+      );
+      const keyForHashes =
+        pubkey ??
+        (tapInternalKeyBuf
+          ? InputField[InputTypes.TAP_INTERNAL_KEY].decode(tapInternalKeyBuf)
+          : tapKeySig.slice(0, 32));
+      const keyHash = this._getTaprootHashes(inputIndex, keyForHashes).find(
+        h => !h.leafHash,
+      );
+      if (keyHash) {
+        const sig =
+          tapKeySig.length === 65 ? tapKeySig.slice(0, 64) : tapKeySig;
+        try {
+          if (!validator(keyHash.pubkey, keyHash.hash, sig)) return false;
+        } catch {
+          return false;
+        }
+        validated++;
+      }
+    }
+    for (const tapScriptSig of tapScriptSigs) {
+      if (xOnlyPubkey && compare(tapScriptSig.pubkey, xOnlyPubkey) !== 0)
+        continue;
+      const hashes = this._getTaprootHashes(
+        inputIndex,
+        tapScriptSig.pubkey,
+        tapScriptSig.leafHash,
+      );
+      const match = hashes.find(
+        h => h.leafHash && compare(h.leafHash, tapScriptSig.leafHash) === 0,
+      );
+      if (match) {
+        const sig =
+          tapScriptSig.signature.length === 65
+            ? tapScriptSig.signature.slice(0, 64)
+            : tapScriptSig.signature;
+        try {
+          if (!validator(tapScriptSig.pubkey, match.hash, sig)) return false;
+        } catch {
+          return false;
+        }
+        validated++;
+      }
+    }
+    if (validated === 0) throw new Error('No signatures for this pubkey');
+    return true;
+  }
+  /**
+   * Verify that NON_WITNESS_UTXO txid matches PREVIOUS_TXID.
+   * Only possible inside bitcoinjs-lib where we have Transaction.getHash().
+   */
+  verifyNonWitnessUtxo(inputIndex) {
+    const nonWitnessUtxoBuf = this.getInput(
+      inputIndex,
+      InputTypes.NON_WITNESS_UTXO,
+    );
+    const previousTxidBuf = this.getInput(inputIndex, InputTypes.PREVIOUS_TXID);
+    if (!nonWitnessUtxoBuf || !previousTxidBuf) return false;
+    return (
+      compare(
+        Transaction.fromBuffer(nonWitnessUtxoBuf).getHash(),
+        previousTxidBuf,
+      ) === 0
+    );
+  }
+  // ─── Extractor ─────────────────────────────────────────────────────────────
+  /**
+   * Build a bitcoinjs-lib Transaction from the PSBT maps.
+   * Mirrors Psbt.extractTransaction() including the maximumFeeRate guard.
+   */
+  toTransaction(disableFeeCheck = false) {
+    const tx = new Transaction();
+    const versionBuf = this.getGlobal(GlobalTypes.TX_VERSION);
+    tx.version = versionBuf
+      ? GlobalField[GlobalTypes.TX_VERSION].decode(versionBuf)
+      : 2;
+    tx.locktime = this.computeLockTime();
+    for (let i = 0; i < this.inputCount; i++) {
+      const hashBuf = this.getInput(i, InputTypes.PREVIOUS_TXID);
+      const indexBuf = this.getInput(i, InputTypes.OUTPUT_INDEX);
+      if (!hashBuf || !indexBuf)
+        throw new Error(`Input ${i}: missing PREVIOUS_TXID or OUTPUT_INDEX`);
+      const seqBuf = this.getInput(i, InputTypes.SEQUENCE);
+      const finalScriptSig = this.getInput(i, InputTypes.FINAL_SCRIPTSIG);
+      const finalScriptWitness = this.getInput(
+        i,
+        InputTypes.FINAL_SCRIPTWITNESS,
+      );
+      if (!finalScriptSig && !finalScriptWitness)
+        throw new Error(
+          `Input ${i} is not finalized. Call finalizeInput() first.`,
+        );
+      tx.addInput(
+        InputField[InputTypes.PREVIOUS_TXID].decode(hashBuf),
+        InputField[InputTypes.OUTPUT_INDEX].decode(indexBuf),
+        seqBuf ? InputField[InputTypes.SEQUENCE].decode(seqBuf) : 0xffffffff,
+        finalScriptSig,
+      );
+      if (finalScriptWitness)
+        tx.setWitness(i, deserializeWitnessStack(finalScriptWitness));
+    }
+    for (let i = 0; i < this.outputCount; i++) {
+      const scriptBuf = this.getOutput(i, OutputTypes.SCRIPT);
+      const amountBuf = this.getOutput(i, OutputTypes.AMOUNT);
+      if (!scriptBuf || !amountBuf)
+        throw new Error(`Output ${i}: missing SCRIPT or AMOUNT`);
+      tx.addOutput(
+        OutputField[OutputTypes.SCRIPT].decode(scriptBuf),
+        OutputField[OutputTypes.AMOUNT].decode(amountBuf),
+      );
+    }
+    if (!disableFeeCheck) {
+      const inputTotal = this.getTotalInputValue();
+      if (inputTotal > 0n) {
+        const feeRate =
+          Number(inputTotal - this.getTotalOutputValue()) / tx.virtualSize();
+        if (feeRate >= this.maximumFeeRate)
+          throw new Error(
+            `Warning: fee rate ${feeRate} sat/vB exceeds maximumFeeRate ${this.maximumFeeRate}. ` +
+              `Use setMaximumFeeRate() to raise your threshold, or pass true to toTransaction().`,
+          );
+      }
+    }
+    return tx;
+  }
+  /**
+   * Get the sighash for a non-taproot input (legacy, P2WPKH, P2WSH).
+   * Sign externally, inject with addPartialSig(), then serialize with toHex().
+   *
+   * @example
+   * const { hash, sighashType } = psbt.getInputHashForSig(0);
+   * psbt.addPartialSig(0, { pubkey, signature: bscript.signature.encode(signer.sign(hash), sighashType) });
+   * const signedHex = psbt.toHex();
+   */
+  getInputHashForSig(inputIndex, sighashTypes = [Transaction.SIGHASH_ALL]) {
+    return this._getHashForInput(inputIndex, sighashTypes);
+  }
+  /**
+   * Get the sighash(es) for a taproot input (key-path or script-path).
+   * Sign externally, inject with addTapKeySig()/addTapScriptSig(), then serialize with toHex().
+   *
+   * @example
+   * const [{ hash }] = psbt.getTaprootHashesForSig(0, pubkey);
+   * psbt.addTapKeySig(0, serializeTaprootSignature(signer.signSchnorr(hash)));
+   * const signedHex = psbt.toHex();
+   */
+  getTaprootHashesForSig(
+    inputIndex,
+    pubkey,
+    tapLeafHashToSign,
+    sighashTypes = [Transaction.SIGHASH_DEFAULT],
+  ) {
+    return this._getTaprootHashes(
+      inputIndex,
+      pubkey,
+      tapLeafHashToSign,
+      sighashTypes,
+    );
+  }
+  // ─── Private helpers ───────────────────────────────────────────────────────
+  /**
+   * Check if an input is taproot by inspecting its input map fields.
+   * Uses field presence rather than UTXO script type — more reliable and
+   * avoids WITNESS_UTXO decode issues with untweaked keys in tests.
+   * TAP_LEAF_SCRIPT and TAP_SCRIPT_SIG use key data so need a prefix scan.
+   */
+  _isTaprootInput(inputIndex) {
+    if (this.getInput(inputIndex, InputTypes.TAP_INTERNAL_KEY) != undefined)
+      return true;
+    if (this.getInput(inputIndex, InputTypes.TAP_KEY_SIG) != undefined)
+      return true;
+    const map = this._inputMaps[inputIndex];
+    if (!map) return false;
+    const tapLeafPrefix = keyFromType(InputTypes.TAP_LEAF_SCRIPT);
+    const tapScriptPrefix = keyFromType(InputTypes.TAP_SCRIPT_SIG);
+    for (const key of map.keys()) {
+      if (key.startsWith(tapLeafPrefix) || key.startsWith(tapScriptPrefix))
+        return true;
+    }
+    return false;
+  }
+  _buildUnsignedTx() {
+    const tx = new Transaction();
+    const versionBuf = this.getGlobal(GlobalTypes.TX_VERSION);
+    tx.version = versionBuf
+      ? GlobalField[GlobalTypes.TX_VERSION].decode(versionBuf)
+      : 2;
+    tx.locktime = this.computeLockTime();
+    for (let i = 0; i < this.inputCount; i++) {
+      const hashBuf = this.getInput(i, InputTypes.PREVIOUS_TXID);
+      const indexBuf = this.getInput(i, InputTypes.OUTPUT_INDEX);
+      const seqBuf = this.getInput(i, InputTypes.SEQUENCE);
+      tx.addInput(
+        InputField[InputTypes.PREVIOUS_TXID].decode(hashBuf),
+        InputField[InputTypes.OUTPUT_INDEX].decode(indexBuf),
+        seqBuf ? InputField[InputTypes.SEQUENCE].decode(seqBuf) : 0xffffffff,
+      );
+    }
+    for (let i = 0; i < this.outputCount; i++) {
+      const scriptBuf = this.getOutput(i, OutputTypes.SCRIPT);
+      const amountBuf = this.getOutput(i, OutputTypes.AMOUNT);
+      tx.addOutput(
+        OutputField[OutputTypes.SCRIPT].decode(scriptBuf),
+        OutputField[OutputTypes.AMOUNT].decode(amountBuf),
+      );
+    }
+    return tx;
+  }
+  _getUtxoForInput(inputIndex) {
+    const witnessUtxoBuf = this.getInput(inputIndex, InputTypes.WITNESS_UTXO);
+    if (witnessUtxoBuf)
+      return InputField[InputTypes.WITNESS_UTXO].decode(witnessUtxoBuf);
+    const nonWitnessUtxoBuf = this.getInput(
+      inputIndex,
+      InputTypes.NON_WITNESS_UTXO,
+    );
+    const indexBuf = this.getInput(inputIndex, InputTypes.OUTPUT_INDEX);
+    if (nonWitnessUtxoBuf && indexBuf) {
+      const prevTx = Transaction.fromBuffer(nonWitnessUtxoBuf);
+      const out =
+        prevTx.outs[InputField[InputTypes.OUTPUT_INDEX].decode(indexBuf)];
+      return { script: out.script, value: out.value };
+    }
+    throw new Error(
+      `Input ${inputIndex}: missing WITNESS_UTXO or NON_WITNESS_UTXO`,
+    );
+  }
+  _getSighashType(inputIndex) {
+    const buf = this.getInput(inputIndex, InputTypes.SIGHASH_TYPE);
+    return buf ? InputField[InputTypes.SIGHASH_TYPE].decode(buf) : undefined;
+  }
+  _getHashForInput(inputIndex, sighashTypes = [Transaction.SIGHASH_ALL]) {
+    const sighashType =
+      this._getSighashType(inputIndex) ?? Transaction.SIGHASH_ALL;
+    if (!sighashTypes.includes(sighashType))
+      throw new Error(
+        `Sighash type ${sighashType} not in allowed list: ${sighashTypes}`,
+      );
+    const tx = this._buildUnsignedTx();
+    const utxo = this._getUtxoForInput(inputIndex);
+    const redeemScriptBuf = this.getInput(inputIndex, InputTypes.REDEEM_SCRIPT);
+    const witnessScriptBuf = this.getInput(
+      inputIndex,
+      InputTypes.WITNESS_SCRIPT,
+    );
+    const redeemScript = redeemScriptBuf
+      ? InputField[InputTypes.REDEEM_SCRIPT].decode(redeemScriptBuf)
+      : undefined;
+    const witnessScript = witnessScriptBuf
+      ? InputField[InputTypes.WITNESS_SCRIPT].decode(witnessScriptBuf)
+      : undefined;
+    // Determine meaningful script (mirrors getMeaningfulScript in psbt.ts)
+    const meaningfulScript = witnessScript ?? redeemScript ?? utxo.script;
+    let hash;
+    if (witnessScript || isP2WPKH(meaningfulScript)) {
+      const signingScript = isP2WPKH(meaningfulScript)
+        ? payments.p2pkh({ hash: meaningfulScript.slice(2) }).output
+        : meaningfulScript;
+      hash = tx.hashForWitnessV0(
+        inputIndex,
+        signingScript,
+        utxo.value,
+        sighashType,
+      );
+    } else {
+      hash = tx.hashForSignature(inputIndex, meaningfulScript, sighashType);
+    }
+    return { hash, sighashType };
+  }
+  _getTaprootHashes(
+    inputIndex,
+    pubkey,
+    tapLeafHashToSign,
+    sighashTypes = [Transaction.SIGHASH_DEFAULT],
+  ) {
+    const sighashType =
+      this._getSighashType(inputIndex) ?? Transaction.SIGHASH_DEFAULT;
+    if (!sighashTypes.includes(sighashType))
+      throw new Error(`Sighash type ${sighashType} not in allowed list`);
+    const tx = this._buildUnsignedTx();
+    const witnessUtxos = Array.from({ length: this.inputCount }, (_, i) => {
+      const buf = this.getInput(i, InputTypes.WITNESS_UTXO);
+      if (!buf)
+        throw new Error(
+          `Input ${i}: missing WITNESS_UTXO (required for taproot)`,
+        );
+      return InputField[InputTypes.WITNESS_UTXO].decode(buf);
+    });
+    const scripts = witnessUtxos.map(u => u.script);
+    const values = witnessUtxos.map(u => u.value);
+    const xOnly = pubkey.length === 32 ? pubkey : toXOnly(pubkey);
+    const hashes = [];
+    // Key-path spend
+    // Key-path spend (synthetic/internal-key match only; does not derive tweaked output key)
+    if (
+      !tapLeafHashToSign &&
+      this.getInput(inputIndex, InputTypes.TAP_INTERNAL_KEY)
+    ) {
+      const outputKey = witnessUtxos[inputIndex].script.slice(2, 34);
+      if (compare(xOnly, outputKey) === 0) {
+        hashes.push({
+          pubkey: xOnly,
+          hash: tx.hashForWitnessV1(inputIndex, scripts, values, sighashType),
+        });
+      }
+    }
+    // Script-path spend
+    for (const leaf of this.getTapLeafScripts(inputIndex)) {
+      const leafHash = tapleafHash({
+        output: leaf.script,
+        version: leaf.leafVersion,
+      });
+      if (tapLeafHashToSign && compare(leafHash, tapLeafHashToSign) !== 0)
+        continue;
+      if (!pubkeyInScript(pubkey, leaf.script)) continue;
+      hashes.push({
+        pubkey: xOnly,
+        hash: tx.hashForWitnessV1(
+          inputIndex,
+          scripts,
+          values,
+          sighashType,
+          leafHash,
+        ),
+        leafHash,
+      });
+    }
+    return hashes;
+  }
+}

--- a/test/psbtv2.spec.ts
+++ b/test/psbtv2.spec.ts
@@ -1,0 +1,795 @@
+/**
+ * PsbtV2 adapter tests — test/psbtv2.spec.ts in bitcoinjs-lib
+ *
+ * Reuses the same fixtures, helpers and key patterns as psbt.spec.ts to prove
+ * API parity between Psbt (BIP-174) and PsbtV2 (BIP-370).
+ */
+
+import * as assert from 'assert';
+import * as ecc from 'tiny-secp256k1';
+import { describe, it, before } from 'mocha';
+import ECPairFactory from 'ecpair';
+import { toHex, concat } from 'uint8array-tools';
+import {
+  initEccLib,
+  payments,
+  script as bscript,
+  Transaction,
+  networks,
+  Psbt,
+} from '../src/esm/index.js';
+import { serializeTaprootSignature, toXOnly } from '../src/esm/psbt/bip371.js';
+import { OPS } from '../src/esm/ops.js';
+import {
+  findScriptPath,
+  LEAF_VERSION_TAPSCRIPT,
+  rootHashFromPath,
+  tapleafHash,
+  toHashTree,
+  tweakKey,
+} from '../src/esm/payments/bip341.js';
+import { PsbtV2 } from '../src/esm/psbtv2.js';
+
+const ECPair = ECPairFactory(ecc);
+
+// ─── Helpers (mirrors psbt.spec.ts) ──────────────────────────────────────────
+
+const validator = (
+  pubkey: Uint8Array,
+  msghash: Uint8Array,
+  signature: Uint8Array,
+): boolean => ECPair.fromPublicKey(pubkey).verify(msghash, signature);
+
+const schnorrValidator = (
+  pubkey: Uint8Array,
+  msghash: Uint8Array,
+  signature: Uint8Array,
+): boolean => {
+  return ecc.verifySchnorr(msghash, pubkey, signature);
+};
+
+const NETWORK = networks.regtest;
+
+function makeKey() {
+  return ECPair.makeRandom({ network: NETWORK });
+}
+
+function makeP2wpkh(pubkey: Uint8Array) {
+  return payments.p2wpkh({ pubkey, network: NETWORK });
+}
+
+function buildPrevTx(outputScript: Uint8Array, value: bigint): Transaction {
+  const tx = new Transaction();
+  tx.addInput(new Uint8Array(32), 0);
+  tx.addOutput(outputScript, value);
+  return tx;
+}
+
+function makeP2trScript(xOnlyOutputKey: Uint8Array): Uint8Array {
+  return concat([new Uint8Array([OPS.OP_1, 0x20]), xOnlyOutputKey]);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('PsbtV2 adapter', () => {
+  before(() => initEccLib(ecc));
+
+  // ─── Construction ────────────────────────────────────────────────────────────
+
+  describe('construction', () => {
+    it('defaults to mainnet like Psbt', () => {
+      assert.strictEqual(new PsbtV2().network.bech32, networks.bitcoin.bech32);
+    });
+
+    it('accepts network option like Psbt', () => {
+      assert.strictEqual(new PsbtV2({ network: NETWORK }).network, NETWORK);
+    });
+
+    it('starts empty', () => {
+      const psbt = new PsbtV2({ network: NETWORK });
+      assert.strictEqual(psbt.inputCount, 0);
+      assert.strictEqual(psbt.outputCount, 0);
+    });
+  });
+
+  // ─── addInputExtended ────────────────────────────────────────────────────────
+
+  describe('addInputExtended', () => {
+    it('accepts same witnessUtxo fields as Psbt.addInput', () => {
+      const alice = makeKey();
+      const p2wpkh = makeP2wpkh(alice.publicKey);
+
+      const inputData = {
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: p2wpkh.output!, value: 100_000n },
+      };
+
+      const psbt0 = new Psbt({ network: NETWORK });
+      psbt0.addInput(inputData);
+
+      const psbt2 = new PsbtV2({ network: NETWORK });
+      psbt2.addInputExtended(inputData);
+
+      assert.strictEqual(psbt2.inputCount, psbt0.inputCount);
+    });
+
+    it('accepts hash as hex string like Psbt.addInput', () => {
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: toHex(new Uint8Array(32).fill(3)),
+        index: 0,
+      });
+      assert.strictEqual(psbt.inputCount, 1);
+    });
+
+    it('PSBTv2-only: requiredTimeLockTime', () => {
+      const psbt = new PsbtV2({ network: NETWORK });
+      assert.doesNotThrow(() =>
+        psbt.addInputExtended({
+          hash: new Uint8Array(32),
+          index: 0,
+          requiredTimeLockTime: 500_000_000,
+        }),
+      );
+    });
+
+    it('PSBTv2-only: requiredHeightLockTime', () => {
+      const psbt = new PsbtV2({ network: NETWORK });
+      assert.doesNotThrow(() =>
+        psbt.addInputExtended({
+          hash: new Uint8Array(32),
+          index: 0,
+          requiredHeightLockTime: 840_000,
+        }),
+      );
+    });
+  });
+
+  // ─── addOutput ───────────────────────────────────────────────────────────────
+
+  describe('addOutput', () => {
+    it('accepts script + value like Psbt.addOutput', () => {
+      const p2wpkh = makeP2wpkh(makeKey().publicKey);
+
+      const psbt0 = new Psbt({ network: NETWORK });
+      psbt0.addOutput({ script: p2wpkh.output!, value: 50_000n });
+
+      const psbt2 = new PsbtV2({ network: NETWORK });
+      psbt2.addOutput({ script: p2wpkh.output!, value: 50_000n });
+
+      assert.strictEqual(psbt2.outputCount, psbt0.data.outputs.length);
+    });
+
+    it('accepts address + value like Psbt.addOutput', () => {
+      const p2wpkh = makeP2wpkh(makeKey().publicKey);
+
+      const psbt0 = new Psbt({ network: NETWORK });
+      psbt0.addOutput({ address: p2wpkh.address!, value: 50_000n });
+
+      const psbt2 = new PsbtV2({ network: NETWORK });
+      psbt2.addOutput({ address: p2wpkh.address!, value: 50_000n });
+
+      assert.strictEqual(psbt2.outputCount, psbt0.data.outputs.length);
+    });
+
+    it('returns incrementing output index', () => {
+      const psbt = new PsbtV2({ network: NETWORK });
+      const script = makeP2wpkh(makeKey().publicKey).output!;
+      assert.strictEqual(psbt.addOutput({ script, value: 1000n }), 0);
+      assert.strictEqual(psbt.addOutput({ script, value: 2000n }), 1);
+    });
+
+    it('throws on invalid address', () => {
+      const psbt = new PsbtV2({ network: NETWORK });
+      assert.throws(() =>
+        psbt.addOutput({ address: 'not_valid', value: 1000n }),
+      );
+    });
+  });
+
+  // ─── P2WPKH: sign → validate → finalize → extract ───────────────────────────
+
+  describe('P2WPKH full round-trip', () => {
+    it('produces valid witness data matching Psbt behaviour', () => {
+      const alice = makeKey();
+      const bob = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(bob.publicKey);
+      const prevTx = buildPrevTx(alicePay.output!, 100_000n);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: prevTx.getHash(),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ address: bobPay.address!, value: 90_000n });
+
+      psbt.signInput(0, alice);
+      assert.strictEqual(
+        psbt.validateSignaturesOfInput(0, validator),
+        true,
+        'sig should validate',
+      );
+
+      psbt.finalizeAllInputs();
+      const tx = psbt.toTransaction();
+
+      assert.strictEqual(tx.ins.length, 1);
+      assert.strictEqual(tx.outs.length, 1);
+      assert.ok(tx.ins[0].witness.length > 0, 'witness should be populated');
+    });
+
+    it('validateSignaturesOfInput returns false for tampered sig', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 90_000n });
+      psbt.signInput(0, alice);
+
+      // Tamper with signature
+      const sigs = psbt.getPartialSigs(0);
+      sigs[0].signature[10] ^= 0xff;
+
+      assert.strictEqual(psbt.validateSignaturesOfInput(0, validator), false);
+    });
+
+    it('signInputAsync produces same result as signInput', async () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+
+      const asyncAlice = {
+        publicKey: alice.publicKey,
+        sign: async (hash: Uint8Array) => alice.sign(hash),
+      };
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 90_000n });
+
+      await psbt.signInputAsync(0, asyncAlice);
+      assert.strictEqual(psbt.validateSignaturesOfInput(0, validator), true);
+    });
+  });
+
+  // ─── P2TR key-path ───────────────────────────────────────────────────────────
+  describe('P2TR script-path', () => {
+    it('signs and validates script-path spend', () => {
+      const internalKeyPair = makeKey();
+      const internalKey = toXOnly(internalKeyPair.publicKey);
+
+      const leafKey = makeKey();
+      const leafXOnly = toXOnly(leafKey.publicKey);
+
+      const leafScript = bscript.compile([leafXOnly, OPS.OP_CHECKSIG]);
+      const scriptTree = { output: leafScript };
+
+      const tree = toHashTree(scriptTree);
+      const leafHash = tapleafHash({
+        output: leafScript,
+        version: LEAF_VERSION_TAPSCRIPT,
+      });
+      const path = findScriptPath(tree, leafHash);
+      if (!path) throw new Error('Leaf not found in script tree');
+
+      const merkleRoot = path.length
+        ? rootHashFromPath(
+            concat([
+              new Uint8Array([LEAF_VERSION_TAPSCRIPT]),
+              internalKey,
+              ...path,
+            ]),
+            leafHash,
+          )
+        : leafHash;
+
+      const tweaked = tweakKey(internalKey, merkleRoot);
+      if (!tweaked) throw new Error('Failed to tweak taproot output key');
+
+      const p2trScript = makeP2trScript(tweaked.x);
+
+      const controlBlock = concat([
+        new Uint8Array([LEAF_VERSION_TAPSCRIPT | tweaked.parity]),
+        internalKey,
+        ...path,
+      ]);
+
+      const dest = makeP2wpkh(makeKey().publicKey);
+
+      const schnorrLeaf = {
+        publicKey: leafKey.publicKey,
+        sign: (hash: Uint8Array) => leafKey.sign(hash),
+        signSchnorr: (hash: Uint8Array) =>
+          ecc.signSchnorr(hash, leafKey.privateKey!),
+      };
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: p2trScript, value: 100_000n },
+        tapLeafScript: [
+          {
+            leafVersion: LEAF_VERSION_TAPSCRIPT,
+            script: leafScript,
+            controlBlock,
+          },
+        ],
+      });
+      psbt.addOutput({ script: dest.output!, value: 90_000n });
+
+      psbt.signInput(0, schnorrLeaf);
+      assert.strictEqual(
+        psbt.validateSignaturesOfInput(0, schnorrValidator),
+        true,
+      );
+    });
+  });
+
+  // ─── verifyNonWitnessUtxo ────────────────────────────────────────────────────
+
+  describe('verifyNonWitnessUtxo', () => {
+    it('returns true when txid matches', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const prevTx = buildPrevTx(alicePay.output!, 100_000n);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: prevTx.getHash(),
+        index: 0,
+        nonWitnessUtxo: prevTx.toBuffer() as Uint8Array,
+      });
+
+      assert.strictEqual(psbt.verifyNonWitnessUtxo(0), true);
+    });
+
+    it('returns false with wrong txid', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const prevTx = buildPrevTx(alicePay.output!, 100_000n);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(0xff),
+        index: 0,
+        nonWitnessUtxo: prevTx.toBuffer() as Uint8Array,
+      });
+
+      assert.strictEqual(psbt.verifyNonWitnessUtxo(0), false);
+    });
+
+    it('returns false when no nonWitnessUtxo present', () => {
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: {
+          script: makeP2wpkh(makeKey().publicKey).output!,
+          value: 100_000n,
+        },
+      });
+      assert.strictEqual(psbt.verifyNonWitnessUtxo(0), false);
+    });
+  });
+
+  // ─── toTransaction ───────────────────────────────────────────────────────────
+
+  describe('toTransaction', () => {
+    it('throws if not finalized', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 90_000n });
+      psbt.signInput(0, alice);
+      // not finalized
+
+      assert.throws(() => psbt.toTransaction(), /finalized/i);
+    });
+
+    it('throws when fee rate exceeds maximumFeeRate', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK, maximumFeeRate: 1 });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 1_000n }); // huge fee
+      psbt.signInput(0, alice);
+      psbt.finalizeAllInputs();
+
+      assert.throws(() => psbt.toTransaction(), /fee rate/i);
+    });
+
+    it('skips fee check with disableFeeCheck=true', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK, maximumFeeRate: 1 });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 1_000n });
+      psbt.signInput(0, alice);
+      psbt.finalizeAllInputs();
+
+      assert.doesNotThrow(() => psbt.toTransaction(true));
+    });
+
+    it('preserves version and locktime', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.txVersion = 1;
+      psbt.fallbackLockTime = 500_000;
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 99_000n });
+      psbt.signInput(0, alice);
+      psbt.finalizeAllInputs();
+
+      const tx = psbt.toTransaction();
+      assert.strictEqual(tx.version, 1);
+      assert.strictEqual(tx.locktime, 500_000);
+    });
+  });
+
+  // ─── validateSignaturesOfInput — negative cases ─────────────────────────────
+
+  describe('validateSignaturesOfInput — signature correctness', () => {
+    function makePsbt() {
+      const alice = makeKey();
+      const bob = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(bob.publicKey);
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 90_000n });
+      return { psbt, alice, bob };
+    }
+
+    it('returns true for valid signature with correct key', () => {
+      const { psbt, alice } = makePsbt();
+      psbt.signInput(0, alice);
+      assert.strictEqual(psbt.validateSignaturesOfInput(0, validator), true);
+    });
+
+    it('returns false for valid signature verified against wrong key', () => {
+      const { psbt, alice, bob } = makePsbt();
+      psbt.signInput(0, alice);
+      // Manually inject the same signature but attributed to bob's pubkey
+      const sigs = psbt.getPartialSigs(0);
+      const aliceSig = sigs[0].signature;
+      // Clear alice's sig and add same bytes attributed to bob
+      psbt.addPartialSig(0, { pubkey: bob.publicKey, signature: aliceSig });
+      // Validate only bob's sig — wrong key for this hash → false
+      assert.strictEqual(
+        psbt.validateSignaturesOfInput(0, validator, bob.publicKey),
+        false,
+      );
+    });
+
+    it('returns false for tampered (invalid) signature', () => {
+      const { psbt, alice } = makePsbt();
+      psbt.signInput(0, alice);
+      const sigs = psbt.getPartialSigs(0);
+      // Flip bytes deep in the signature body (after DER header)
+      sigs[0].signature[10] ^= 0xff;
+      assert.strictEqual(psbt.validateSignaturesOfInput(0, validator), false);
+    });
+
+    it('throws when validating with pubkey that has no matching sig', () => {
+      const { psbt, alice, bob } = makePsbt();
+      psbt.signInput(0, alice);
+      assert.throws(
+        () => psbt.validateSignaturesOfInput(0, validator, bob.publicKey),
+        /No signatures/,
+      );
+    });
+
+    it('returns false for tampered schnorr (tap key) sig', () => {
+      const key = makeKey();
+      const internalKey = toXOnly(key.publicKey);
+      const p2trScript = concat([
+        new Uint8Array([OPS.OP_1, 0x20]),
+        internalKey,
+      ]);
+
+      const schnorrKey = {
+        publicKey: key.publicKey,
+        sign: (h: Uint8Array) => key.sign(h),
+        signSchnorr: (h: Uint8Array) => ecc.signSchnorr(h, key.privateKey!),
+      };
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: p2trScript, value: 100_000n },
+        tapInternalKey: internalKey,
+      });
+      psbt.addOutput({ script: p2trScript, value: 90_000n });
+      psbt.signInput(0, schnorrKey);
+
+      // Overwrite with a clearly invalid 64-byte tap key sig
+      const tamperedSig = new Uint8Array(64).fill(0xff);
+      psbt.addTapKeySig(0, tamperedSig);
+
+      assert.strictEqual(
+        psbt.validateSignaturesOfInput(0, schnorrValidator),
+        false,
+      );
+    });
+  });
+
+  // ─── validateSignaturesOfAllInputs ───────────────────────────────────────────
+
+  describe('validateSignaturesOfAllInputs', () => {
+    it('validates multiple inputs signed by different keys', () => {
+      const alice = makeKey();
+      const bob = makeKey();
+      const dest = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: {
+          script: makeP2wpkh(alice.publicKey).output!,
+          value: 100_000n,
+        },
+      });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(2),
+        index: 0,
+        witnessUtxo: {
+          script: makeP2wpkh(bob.publicKey).output!,
+          value: 50_000n,
+        },
+      });
+      psbt.addOutput({ script: dest.output!, value: 140_000n });
+
+      psbt.signInput(0, alice);
+      psbt.signInput(1, bob);
+
+      assert.strictEqual(psbt.validateSignaturesOfAllInputs(validator), true);
+    });
+
+    it('throws when no inputs', () => {
+      const psbt = new PsbtV2({ network: NETWORK });
+      assert.throws(() => psbt.validateSignaturesOfAllInputs(validator));
+    });
+  });
+
+  // ─── External signer support ────────────────────────────────────────────────
+
+  describe('getInputHashForSig', () => {
+    it('returns hash and sighashType for non-taproot input', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 90_000n });
+
+      const { hash, sighashType } = psbt.getInputHashForSig(0);
+      assert.strictEqual(hash.length, 32);
+      assert.strictEqual(sighashType, Transaction.SIGHASH_ALL);
+    });
+
+    it('full external sign round-trip: getInputHashForSig → addPartialSig → toHex → fromHex → validate', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 90_000n });
+
+      // Serialize unsigned PSBT — pass to external signer
+      const unsignedHex = psbt.toHex();
+
+      // External signer: deserialize, get hash, sign, inject, re-serialize
+      const signerPsbt = PsbtV2.fromHex(unsignedHex);
+      const { hash, sighashType } = signerPsbt.getInputHashForSig(0);
+      const sig = alice.sign(hash);
+      signerPsbt.addPartialSig(0, {
+        pubkey: alice.publicKey,
+        signature: bscript.signature.encode(sig, sighashType),
+      });
+      const signedHex = signerPsbt.toHex();
+
+      // Finalizer: deserialize, validate, finalize, extract
+      const finalizerPsbt = PsbtV2.fromHex(signedHex);
+      assert.strictEqual(
+        finalizerPsbt.validateSignaturesOfInput(0, validator),
+        true,
+      );
+      finalizerPsbt.finalizeAllInputs();
+      const tx = finalizerPsbt.toTransaction();
+      assert.ok(tx.ins[0].witness.length > 0);
+    });
+
+    it('full external sign round-trip using bscript directly', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 90_000n });
+
+      const { hash, sighashType } = psbt.getInputHashForSig(0);
+      const sig = alice.sign(hash);
+      psbt.addPartialSig(0, {
+        pubkey: alice.publicKey,
+        signature: bscript.signature.encode(sig, sighashType),
+      });
+
+      assert.strictEqual(psbt.validateSignaturesOfInput(0, validator), true);
+      psbt.finalizeAllInputs();
+      const tx = psbt.toTransaction();
+      assert.ok(tx.ins[0].witness.length > 0);
+    });
+  });
+
+  describe('getTaprootHashesForSig', () => {
+    it('returns hash for taproot key-path', () => {
+      const key = makeKey();
+      const internalKey = toXOnly(key.publicKey);
+      const p2trScript = concat([
+        new Uint8Array([OPS.OP_1, 0x20]),
+        internalKey,
+      ]);
+      const dest = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: p2trScript, value: 100_000n },
+        tapInternalKey: internalKey,
+      });
+      psbt.addOutput({ script: dest.output!, value: 90_000n });
+
+      // Pass x-only pubkey — _getTaprootHashes compares toXOnly(pubkey) with script output key
+      const hashes = psbt.getTaprootHashesForSig(0, internalKey);
+      assert.strictEqual(hashes.length, 1);
+      assert.strictEqual(hashes[0].hash.length, 32);
+      assert.strictEqual(hashes[0].leafHash, undefined);
+    });
+
+    it('full external taproot key-path round-trip: getTaprootHashesForSig → addTapKeySig → toHex → fromHex → validate', () => {
+      const key = makeKey();
+      const internalKey = toXOnly(key.publicKey);
+      const p2trScript = concat([
+        new Uint8Array([OPS.OP_1, 0x20]),
+        internalKey,
+      ]);
+      const dest = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: p2trScript, value: 100_000n },
+        tapInternalKey: internalKey,
+      });
+      psbt.addOutput({ script: dest.output!, value: 90_000n });
+
+      // Serialize unsigned PSBT — pass to external signer
+      const unsignedHex = psbt.toHex();
+
+      // External Schnorr signer
+      const signerPsbt = PsbtV2.fromHex(unsignedHex);
+      const [{ hash }] = signerPsbt.getTaprootHashesForSig(0, internalKey);
+      const sig = ecc.signSchnorr(hash, key.privateKey!);
+      signerPsbt.addTapKeySig(0, serializeTaprootSignature(sig));
+      const signedHex = signerPsbt.toHex();
+
+      // Validate and finalize
+      const finalizerPsbt = PsbtV2.fromHex(signedHex);
+      assert.strictEqual(
+        finalizerPsbt.validateSignaturesOfInput(0, schnorrValidator),
+        true,
+      );
+    });
+  });
+
+  // ─── serialize / deserialize round-trip ──────────────────────────────────────
+
+  describe('serialize / deserialize round-trip', () => {
+    it('preserves signatures', () => {
+      const alice = makeKey();
+      const alicePay = makeP2wpkh(alice.publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+
+      const psbt = new PsbtV2({ network: NETWORK });
+      psbt.addInputExtended({
+        hash: new Uint8Array(32).fill(1),
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt.addOutput({ script: bobPay.output!, value: 90_000n });
+      psbt.signInput(0, alice);
+
+      const hex = psbt.toHex();
+      const psbt2 = PsbtV2.fromHex(hex);
+
+      assert.strictEqual(psbt2.validateSignaturesOfInput(0, validator), true);
+    });
+
+    it('PSBTv2 hex differs from PSBTv0 hex (different version in global map)', () => {
+      const alicePay = makeP2wpkh(makeKey().publicKey);
+      const bobPay = makeP2wpkh(makeKey().publicKey);
+      const hash = new Uint8Array(32).fill(1);
+
+      const psbt0 = new Psbt({ network: NETWORK });
+      psbt0.addInput({
+        hash,
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt0.addOutput({ script: bobPay.output!, value: 90_000n });
+
+      const psbt2 = new PsbtV2({ network: NETWORK });
+      psbt2.addInputExtended({
+        hash,
+        index: 0,
+        witnessUtxo: { script: alicePay.output!, value: 100_000n },
+      });
+      psbt2.addOutput({ script: bobPay.output!, value: 90_000n });
+
+      assert.notStrictEqual(psbt2.toHex(), psbt0.toHex());
+    });
+  });
+});

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -19,6 +19,13 @@ export {
   HDSignerAsync,
   toXOnly,
 } from './psbt.js';
+export {
+  PsbtV2Opts,
+  PsbtV2InputExtended,
+  PsbtV2OutputExtended,
+  PsbtV2,
+  ValidateSigFunction,
+} from './psbtv2.js';
 /** @hidden */
 export { OPS as opcodes } from './ops.js';
 export { Transaction } from './transaction.js';

--- a/ts_src/psbtv2.ts
+++ b/ts_src/psbtv2.ts
@@ -1,0 +1,807 @@
+/**
+ * PSBTv2 (BIP-370) implementation for bitcoinjs-lib
+ *
+ * Lives at ts_src/psbtv2.ts alongside ts_src/psbt.ts.
+ * Extends PSBTv2Builder from bip370 with Bitcoin-aware functionality,
+ * mirroring the API of the existing Psbt class where possible.
+ *
+ * Usage:
+ *   import { PsbtV2 } from './psbtv2.js';
+ *   const psbt = new PsbtV2({ network: networks.testnet });
+ *   psbt.addInputExtended({ hash: txid, index: 0, witnessUtxo: { script, value } });
+ *   psbt.addOutput({ address: 'tb1q...', value: 50000n });
+ *   psbt.signInput(0, ecPair);
+ *   psbt.finalizeAllInputs();
+ *   const tx = psbt.toTransaction();
+ */
+
+import { PSBTv2Builder } from 'bip370';
+import { ValidationErrorContainer } from 'bip370/errors';
+export { ValidationErrorContainer };
+import type { InputUpdateData, OutputUpdateData } from 'bip370/roles';
+import { InputTypes, OutputTypes, GlobalTypes } from 'bip370/fields';
+import { GlobalField, InputField, OutputField } from 'bip370/fields';
+import { deserializeWitnessStack, keyFromType } from 'bip370/utils';
+
+import { toOutputScript } from './address.js';
+import type { Signer, SignerAsync } from './psbt.js';
+import type { PsbtInput, PsbtOutput } from 'bip174';
+import type { TransactionInput } from './psbt.js';
+import { bitcoin as btcNetwork, Network } from './networks.js';
+import * as payments from './payments/index.js';
+import * as bscript from './script.js';
+import { Output, Transaction } from './transaction.js';
+import { toXOnly, serializeTaprootSignature } from './psbt/bip371.js';
+import { tapleafHash } from './payments/bip341.js';
+import { isP2WPKH, pubkeyInScript } from './psbt/psbtutils.js';
+import { compare, toHex } from 'uint8array-tools';
+
+export { toXOnly };
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface PsbtV2Opts {
+  network?: Network;
+  /** Maximum fee rate in sat/vB checked on toTransaction(). Matches Psbt's default. */
+  maximumFeeRate?: number;
+}
+
+/**
+ * PSBTv2 input — mirrors psbt.ts's internal PsbtInputExtended plus
+ * PSBTv2-only fields (requiredTimeLockTime, requiredHeightLockTime).
+ */
+export interface PsbtV2InputExtended extends PsbtInput, TransactionInput {
+  requiredTimeLockTime?: number;
+  requiredHeightLockTime?: number;
+}
+
+/**
+ * PSBTv2 output — mirrors psbt.ts's internal PsbtOutputExtended plus
+ * bip370's tapTree as Uint8Array (bip174 uses a TapTree object).
+ */
+export type PsbtV2OutputExtended =
+  | (PsbtOutput & { address: string; value: bigint; tapTree?: Uint8Array })
+  | (PsbtOutput & { script: Uint8Array; value: bigint; tapTree?: Uint8Array });
+
+/** (pubkey, msghash, signature) → boolean — same as Psbt's ValidateSigFunction */
+export type ValidateSigFunction = (
+  pubkey: Uint8Array,
+  msghash: Uint8Array,
+  signature: Uint8Array,
+) => boolean;
+
+// ─── Adapter ─────────────────────────────────────────────────────────────────
+
+export class PsbtV2 extends PSBTv2Builder {
+  readonly network: Network;
+  private maximumFeeRate: number;
+
+  constructor(opts: PsbtV2Opts = {}) {
+    super();
+    this.network = opts.network ?? btcNetwork;
+    this.maximumFeeRate = opts.maximumFeeRate ?? 5000;
+    // BIP-370 requires these four globals to be present from construction
+    this.setGlobal(
+      GlobalTypes.PSBT_VERSION,
+      GlobalField[GlobalTypes.PSBT_VERSION].encode(2).value,
+    );
+    this.setGlobal(
+      GlobalTypes.TX_VERSION,
+      GlobalField[GlobalTypes.TX_VERSION].encode(2).value,
+    );
+    this.setGlobal(
+      GlobalTypes.INPUT_COUNT,
+      GlobalField[GlobalTypes.INPUT_COUNT].encode(0).value,
+    );
+    this.setGlobal(
+      GlobalTypes.OUTPUT_COUNT,
+      GlobalField[GlobalTypes.OUTPUT_COUNT].encode(0).value,
+    );
+  }
+
+  setMaximumFeeRate(satoshiPerByte: number): void {
+    this.maximumFeeRate = satoshiPerByte;
+  }
+
+  // ─── Creator ───────────────────────────────────────────────────────────────
+
+  /**
+   * Mirrors Psbt.addInput() — hash + index plus any input update fields
+   * in a single object. Splits into addInput() + updateInput() internally.
+   */
+  addInputExtended(data: PsbtV2InputExtended): this {
+    const {
+      hash,
+      index,
+      witnessUtxo,
+      nonWitnessUtxo,
+      redeemScript,
+      witnessScript,
+      sighashType,
+      bip32Derivation,
+      tapInternalKey,
+      tapMerkleRoot,
+      tapBip32Derivation,
+      tapLeafScript,
+      sequence,
+      requiredTimeLockTime,
+      requiredHeightLockTime,
+    } = data;
+
+    this.addInput({ hash, index });
+
+    const inputUpdate: InputUpdateData = {
+      witnessUtxo,
+      nonWitnessUtxo,
+      redeemScript,
+      witnessScript,
+      sighashType,
+      tapInternalKey,
+      tapMerkleRoot,
+      tapLeafScript,
+      sequence,
+      requiredTimeLockTime,
+      requiredHeightLockTime,
+      // bip174 path is string, bip370 expects number[] — structurally compatible at runtime
+      bip32Derivation: bip32Derivation as InputUpdateData['bip32Derivation'],
+      tapBip32Derivation:
+        tapBip32Derivation as InputUpdateData['tapBip32Derivation'],
+    };
+    if (Object.values(inputUpdate).some(v => v !== undefined)) {
+      this.updateInput(this.inputCount - 1, inputUpdate);
+    }
+    return this;
+  }
+
+  /**
+   * Mirrors Psbt.addOutput() — accepts address or script plus value and any
+   * output update fields. Address-to-script conversion is network-aware.
+   */
+  addOutput(data: PsbtV2OutputExtended): number {
+    const script =
+      'address' in data
+        ? toOutputScript(data.address, this.network)
+        : data.script;
+
+    const outputIndex = super.addOutput({ script, value: data.value });
+
+    const {
+      redeemScript,
+      witnessScript,
+      bip32Derivation,
+      tapInternalKey,
+      tapTree,
+      tapBip32Derivation,
+    } = data;
+    const outputUpdate: OutputUpdateData = {
+      redeemScript,
+      witnessScript,
+      tapInternalKey,
+      tapTree,
+      // bip174 path is string, bip370 expects number[] — compatible at runtime
+      bip32Derivation: bip32Derivation as OutputUpdateData['bip32Derivation'],
+      tapBip32Derivation:
+        tapBip32Derivation as OutputUpdateData['tapBip32Derivation'],
+    };
+    if (Object.values(outputUpdate).some(v => v !== undefined)) {
+      this.updateOutput(this.outputCount - 1, outputUpdate);
+    }
+    return outputIndex;
+  }
+
+  // ─── Signer ────────────────────────────────────────────────────────────────
+
+  /**
+   * Sign an input. Computes the sighash internally from UTXO data,
+   * mirroring Psbt.signInput(). Handles legacy, segwit, and Taproot inputs.
+   * For Taproot, pass tapLeafHashToSign for script-path, omit for key-path.
+   */
+  signInput(
+    inputIndex: number,
+    keyPair: Signer,
+    tapLeafHashToSign?: Uint8Array,
+    sighashTypes?: number[],
+  ): this {
+    if (!keyPair?.publicKey) throw new Error('Need Signer to sign input');
+    return this._isTaprootInput(inputIndex)
+      ? this._signTaprootInput(
+          inputIndex,
+          keyPair,
+          tapLeafHashToSign,
+          sighashTypes,
+        )
+      : this._signNonTaprootInput(inputIndex, keyPair, sighashTypes);
+  }
+
+  signInputAsync(
+    inputIndex: number,
+    keyPair: SignerAsync,
+    tapLeafHashToSign?: Uint8Array,
+    sighashTypes?: number[],
+  ): Promise<void> {
+    return Promise.resolve().then(() => {
+      if (!keyPair?.publicKey) throw new Error('Need Signer to sign input');
+      return this._isTaprootInput(inputIndex)
+        ? this._signTaprootInputAsync(
+            inputIndex,
+            keyPair,
+            tapLeafHashToSign,
+            sighashTypes,
+          )
+        : this._signNonTaprootInputAsync(inputIndex, keyPair, sighashTypes);
+    });
+  }
+
+  private _signNonTaprootInput(
+    inputIndex: number,
+    keyPair: Signer,
+    sighashTypes: number[] = [Transaction.SIGHASH_ALL],
+  ): this {
+    const { hash, sighashType } = this._getHashForInput(
+      inputIndex,
+      sighashTypes,
+    );
+    const signature = bscript.signature.encode(keyPair.sign(hash), sighashType);
+    this.addPartialSig(inputIndex, { pubkey: keyPair.publicKey, signature });
+    return this;
+  }
+
+  private async _signNonTaprootInputAsync(
+    inputIndex: number,
+    keyPair: SignerAsync,
+    sighashTypes: number[] = [Transaction.SIGHASH_ALL],
+  ): Promise<void> {
+    const { hash, sighashType } = this._getHashForInput(
+      inputIndex,
+      sighashTypes,
+    );
+    const signature = bscript.signature.encode(
+      await keyPair.sign(hash),
+      sighashType,
+    );
+    this.addPartialSig(inputIndex, { pubkey: keyPair.publicKey, signature });
+  }
+
+  private _signTaprootInput(
+    inputIndex: number,
+    keyPair: Signer,
+    tapLeafHashToSign?: Uint8Array,
+    sighashTypes: number[] = [Transaction.SIGHASH_DEFAULT],
+  ): this {
+    if (typeof keyPair.signSchnorr !== 'function')
+      throw new Error(
+        `Need Schnorr Signer to sign taproot input #${inputIndex}`,
+      );
+
+    const hashes = this._getTaprootHashes(
+      inputIndex,
+      keyPair.publicKey,
+      tapLeafHashToSign,
+      sighashTypes,
+    );
+    if (!hashes.length)
+      throw new Error(
+        `Can not sign for input #${inputIndex} with key ${toHex(keyPair.publicKey)}`,
+      );
+
+    for (const { hash, leafHash } of hashes) {
+      this._addTaprootSig(
+        inputIndex,
+        keyPair.publicKey,
+        leafHash,
+        serializeTaprootSignature(
+          keyPair.signSchnorr!(hash),
+          this._getSighashType(inputIndex),
+        ),
+      );
+    }
+    return this;
+  }
+
+  private async _signTaprootInputAsync(
+    inputIndex: number,
+    keyPair: SignerAsync,
+    tapLeafHashToSign?: Uint8Array,
+    sighashTypes: number[] = [Transaction.SIGHASH_DEFAULT],
+  ): Promise<void> {
+    if (typeof keyPair.signSchnorr !== 'function')
+      throw new Error(
+        `Need Schnorr Signer to sign taproot input #${inputIndex}`,
+      );
+
+    const hashes = this._getTaprootHashes(
+      inputIndex,
+      keyPair.publicKey,
+      tapLeafHashToSign,
+      sighashTypes,
+    );
+    if (!hashes.length)
+      throw new Error(
+        `Can not sign for input #${inputIndex} with key ${toHex(keyPair.publicKey)}`,
+      );
+
+    await Promise.all(
+      hashes.map(async ({ hash, leafHash }) =>
+        this._addTaprootSig(
+          inputIndex,
+          keyPair.publicKey,
+          leafHash,
+          serializeTaprootSignature(
+            await keyPair.signSchnorr!(hash),
+            this._getSighashType(inputIndex),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /** Shared: store a taproot signature as key-sig or script-sig depending on leafHash. */
+  private _addTaprootSig(
+    inputIndex: number,
+    pubkey: Uint8Array,
+    leafHash: Uint8Array | undefined,
+    sig: Uint8Array,
+  ): void {
+    if (leafHash) {
+      this.addTapScriptSig(inputIndex, {
+        pubkey: toXOnly(pubkey),
+        leafHash,
+        signature: sig,
+      });
+    } else {
+      this.addTapKeySig(inputIndex, sig);
+    }
+  }
+
+  // ─── Validation ───────────────────────────────────────────────────────────
+
+  /**
+   * Validate signatures for a specific input. Recomputes the sighash from
+   * UTXO data. Mirrors Psbt.validateSignaturesOfInput().
+   */
+  validateSignaturesOfInput(
+    inputIndex: number,
+    validator: ValidateSigFunction,
+    pubkey?: Uint8Array,
+  ): boolean {
+    return this._isTaprootInput(inputIndex)
+      ? this._validateTaprootSignatures(inputIndex, validator, pubkey)
+      : this._validateNonTaprootSignatures(inputIndex, validator, pubkey);
+  }
+
+  /** Mirrors Psbt.validateSignaturesOfAllInputs(). */
+  validateSignaturesOfAllInputs(validator: ValidateSigFunction): boolean {
+    if (this.inputCount === 0) throw new Error('No inputs to validate');
+    return Array.from({ length: this.inputCount }, (_, i) => i).every(i =>
+      this.validateSignaturesOfInput(i, validator),
+    );
+  }
+
+  private _validateNonTaprootSignatures(
+    inputIndex: number,
+    validator: ValidateSigFunction,
+    pubkey?: Uint8Array,
+  ): boolean {
+    const partialSigs = this.getPartialSigs(inputIndex);
+    if (!partialSigs.length) throw new Error('No signatures to validate');
+
+    const sigsToCheck = pubkey
+      ? partialSigs.filter(ps => compare(ps.pubkey, pubkey) === 0)
+      : partialSigs;
+    if (!sigsToCheck.length) throw new Error('No signatures for this pubkey');
+
+    for (const pSig of sigsToCheck) {
+      const { signature, hashType } = bscript.signature.decode(pSig.signature);
+      const { hash } = this._getHashForInput(inputIndex, [hashType]);
+      try {
+        if (!validator(pSig.pubkey, hash, signature)) return false;
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private _validateTaprootSignatures(
+    inputIndex: number,
+    validator: ValidateSigFunction,
+    pubkey?: Uint8Array,
+  ): boolean {
+    const tapKeySig = this.getInput(inputIndex, InputTypes.TAP_KEY_SIG);
+    const tapScriptSigs = this.getTapScriptSigs(inputIndex);
+
+    if (!tapKeySig && !tapScriptSigs.length)
+      throw new Error('No signatures to validate');
+
+    const xOnlyPubkey = pubkey ? toXOnly(pubkey) : undefined;
+    let validated = 0;
+
+    if (tapKeySig) {
+      const tapInternalKeyBuf = this.getInput(
+        inputIndex,
+        InputTypes.TAP_INTERNAL_KEY,
+      );
+      const keyForHashes =
+        pubkey ??
+        (tapInternalKeyBuf
+          ? InputField[InputTypes.TAP_INTERNAL_KEY].decode(tapInternalKeyBuf)
+          : tapKeySig.slice(0, 32));
+
+      const keyHash = this._getTaprootHashes(inputIndex, keyForHashes).find(
+        h => !h.leafHash,
+      );
+      if (keyHash) {
+        const sig =
+          tapKeySig.length === 65 ? tapKeySig.slice(0, 64) : tapKeySig;
+        try {
+          if (!validator(keyHash.pubkey, keyHash.hash, sig)) return false;
+        } catch {
+          return false;
+        }
+        validated++;
+      }
+    }
+
+    for (const tapScriptSig of tapScriptSigs) {
+      if (xOnlyPubkey && compare(tapScriptSig.pubkey, xOnlyPubkey) !== 0)
+        continue;
+
+      const hashes = this._getTaprootHashes(
+        inputIndex,
+        tapScriptSig.pubkey,
+        tapScriptSig.leafHash,
+      );
+      const match = hashes.find(
+        h => h.leafHash && compare(h.leafHash, tapScriptSig.leafHash) === 0,
+      );
+
+      if (match) {
+        const sig =
+          tapScriptSig.signature.length === 65
+            ? tapScriptSig.signature.slice(0, 64)
+            : tapScriptSig.signature;
+        try {
+          if (!validator(tapScriptSig.pubkey, match.hash, sig)) return false;
+        } catch {
+          return false;
+        }
+        validated++;
+      }
+    }
+
+    if (validated === 0) throw new Error('No signatures for this pubkey');
+    return true;
+  }
+
+  /**
+   * Verify that NON_WITNESS_UTXO txid matches PREVIOUS_TXID.
+   * Only possible inside bitcoinjs-lib where we have Transaction.getHash().
+   */
+  verifyNonWitnessUtxo(inputIndex: number): boolean {
+    const nonWitnessUtxoBuf = this.getInput(
+      inputIndex,
+      InputTypes.NON_WITNESS_UTXO,
+    );
+    const previousTxidBuf = this.getInput(inputIndex, InputTypes.PREVIOUS_TXID);
+    if (!nonWitnessUtxoBuf || !previousTxidBuf) return false;
+    return (
+      compare(
+        Transaction.fromBuffer(nonWitnessUtxoBuf).getHash(),
+        previousTxidBuf,
+      ) === 0
+    );
+  }
+
+  // ─── Extractor ─────────────────────────────────────────────────────────────
+
+  /**
+   * Build a bitcoinjs-lib Transaction from the PSBT maps.
+   * Mirrors Psbt.extractTransaction() including the maximumFeeRate guard.
+   */
+  toTransaction(disableFeeCheck = false): Transaction {
+    const tx = new Transaction();
+
+    const versionBuf = this.getGlobal(GlobalTypes.TX_VERSION);
+    tx.version = versionBuf
+      ? GlobalField[GlobalTypes.TX_VERSION].decode(versionBuf)
+      : 2;
+    tx.locktime = this.computeLockTime();
+
+    for (let i = 0; i < this.inputCount; i++) {
+      const hashBuf = this.getInput(i, InputTypes.PREVIOUS_TXID);
+      const indexBuf = this.getInput(i, InputTypes.OUTPUT_INDEX);
+      if (!hashBuf || !indexBuf)
+        throw new Error(`Input ${i}: missing PREVIOUS_TXID or OUTPUT_INDEX`);
+
+      const seqBuf = this.getInput(i, InputTypes.SEQUENCE);
+      const finalScriptSig = this.getInput(i, InputTypes.FINAL_SCRIPTSIG);
+      const finalScriptWitness = this.getInput(
+        i,
+        InputTypes.FINAL_SCRIPTWITNESS,
+      );
+
+      if (!finalScriptSig && !finalScriptWitness)
+        throw new Error(
+          `Input ${i} is not finalized. Call finalizeInput() first.`,
+        );
+
+      tx.addInput(
+        InputField[InputTypes.PREVIOUS_TXID].decode(hashBuf),
+        InputField[InputTypes.OUTPUT_INDEX].decode(indexBuf),
+        seqBuf ? InputField[InputTypes.SEQUENCE].decode(seqBuf) : 0xffffffff,
+        finalScriptSig,
+      );
+      if (finalScriptWitness)
+        tx.setWitness(i, deserializeWitnessStack(finalScriptWitness));
+    }
+
+    for (let i = 0; i < this.outputCount; i++) {
+      const scriptBuf = this.getOutput(i, OutputTypes.SCRIPT);
+      const amountBuf = this.getOutput(i, OutputTypes.AMOUNT);
+      if (!scriptBuf || !amountBuf)
+        throw new Error(`Output ${i}: missing SCRIPT or AMOUNT`);
+      tx.addOutput(
+        OutputField[OutputTypes.SCRIPT].decode(scriptBuf),
+        OutputField[OutputTypes.AMOUNT].decode(amountBuf),
+      );
+    }
+
+    if (!disableFeeCheck) {
+      const inputTotal = this.getTotalInputValue();
+      if (inputTotal > 0n) {
+        const feeRate =
+          Number(inputTotal - this.getTotalOutputValue()) / tx.virtualSize();
+        if (feeRate >= this.maximumFeeRate)
+          throw new Error(
+            `Warning: fee rate ${feeRate} sat/vB exceeds maximumFeeRate ${this.maximumFeeRate}. ` +
+              `Use setMaximumFeeRate() to raise your threshold, or pass true to toTransaction().`,
+          );
+      }
+    }
+
+    return tx;
+  }
+
+  /**
+   * Get the sighash for a non-taproot input (legacy, P2WPKH, P2WSH).
+   * Sign externally, inject with addPartialSig(), then serialize with toHex().
+   *
+   * @example
+   * const { hash, sighashType } = psbt.getInputHashForSig(0);
+   * psbt.addPartialSig(0, { pubkey, signature: bscript.signature.encode(signer.sign(hash), sighashType) });
+   * const signedHex = psbt.toHex();
+   */
+  getInputHashForSig(
+    inputIndex: number,
+    sighashTypes: number[] = [Transaction.SIGHASH_ALL],
+  ): { hash: Uint8Array; sighashType: number } {
+    return this._getHashForInput(inputIndex, sighashTypes);
+  }
+
+  /**
+   * Get the sighash(es) for a taproot input (key-path or script-path).
+   * Sign externally, inject with addTapKeySig()/addTapScriptSig(), then serialize with toHex().
+   *
+   * @example
+   * const [{ hash }] = psbt.getTaprootHashesForSig(0, pubkey);
+   * psbt.addTapKeySig(0, serializeTaprootSignature(signer.signSchnorr(hash)));
+   * const signedHex = psbt.toHex();
+   */
+  getTaprootHashesForSig(
+    inputIndex: number,
+    pubkey: Uint8Array,
+    tapLeafHashToSign?: Uint8Array,
+    sighashTypes: number[] = [Transaction.SIGHASH_DEFAULT],
+  ): { pubkey: Uint8Array; hash: Uint8Array; leafHash?: Uint8Array }[] {
+    return this._getTaprootHashes(
+      inputIndex,
+      pubkey,
+      tapLeafHashToSign,
+      sighashTypes,
+    );
+  }
+
+  // ─── Private helpers ───────────────────────────────────────────────────────
+
+  /**
+   * Check if an input is taproot by inspecting its input map fields.
+   * Uses field presence rather than UTXO script type — more reliable and
+   * avoids WITNESS_UTXO decode issues with untweaked keys in tests.
+   * TAP_LEAF_SCRIPT and TAP_SCRIPT_SIG use key data so need a prefix scan.
+   */
+  private _isTaprootInput(inputIndex: number): boolean {
+    if (this.getInput(inputIndex, InputTypes.TAP_INTERNAL_KEY) != undefined)
+      return true;
+    if (this.getInput(inputIndex, InputTypes.TAP_KEY_SIG) != undefined)
+      return true;
+
+    const map = this._inputMaps[inputIndex];
+    if (!map) return false;
+    const tapLeafPrefix = keyFromType(InputTypes.TAP_LEAF_SCRIPT);
+    const tapScriptPrefix = keyFromType(InputTypes.TAP_SCRIPT_SIG);
+    for (const key of map.keys()) {
+      if (key.startsWith(tapLeafPrefix) || key.startsWith(tapScriptPrefix))
+        return true;
+    }
+    return false;
+  }
+
+  private _buildUnsignedTx(): Transaction {
+    const tx = new Transaction();
+    const versionBuf = this.getGlobal(GlobalTypes.TX_VERSION);
+    tx.version = versionBuf
+      ? GlobalField[GlobalTypes.TX_VERSION].decode(versionBuf)
+      : 2;
+    tx.locktime = this.computeLockTime();
+
+    for (let i = 0; i < this.inputCount; i++) {
+      const hashBuf = this.getInput(i, InputTypes.PREVIOUS_TXID);
+      const indexBuf = this.getInput(i, InputTypes.OUTPUT_INDEX);
+      const seqBuf = this.getInput(i, InputTypes.SEQUENCE);
+      tx.addInput(
+        InputField[InputTypes.PREVIOUS_TXID].decode(hashBuf!),
+        InputField[InputTypes.OUTPUT_INDEX].decode(indexBuf!),
+        seqBuf ? InputField[InputTypes.SEQUENCE].decode(seqBuf) : 0xffffffff,
+      );
+    }
+    for (let i = 0; i < this.outputCount; i++) {
+      const scriptBuf = this.getOutput(i, OutputTypes.SCRIPT);
+      const amountBuf = this.getOutput(i, OutputTypes.AMOUNT);
+      tx.addOutput(
+        OutputField[OutputTypes.SCRIPT].decode(scriptBuf!),
+        OutputField[OutputTypes.AMOUNT].decode(amountBuf!),
+      );
+    }
+    return tx;
+  }
+
+  private _getUtxoForInput(inputIndex: number): {
+    script: Uint8Array;
+    value: bigint;
+  } {
+    const witnessUtxoBuf = this.getInput(inputIndex, InputTypes.WITNESS_UTXO);
+    if (witnessUtxoBuf)
+      return InputField[InputTypes.WITNESS_UTXO].decode(witnessUtxoBuf);
+
+    const nonWitnessUtxoBuf = this.getInput(
+      inputIndex,
+      InputTypes.NON_WITNESS_UTXO,
+    );
+    const indexBuf = this.getInput(inputIndex, InputTypes.OUTPUT_INDEX);
+    if (nonWitnessUtxoBuf && indexBuf) {
+      const prevTx = Transaction.fromBuffer(nonWitnessUtxoBuf);
+      const out = prevTx.outs[
+        InputField[InputTypes.OUTPUT_INDEX].decode(indexBuf)
+      ] as Output;
+      return { script: out.script, value: out.value };
+    }
+    throw new Error(
+      `Input ${inputIndex}: missing WITNESS_UTXO or NON_WITNESS_UTXO`,
+    );
+  }
+
+  private _getSighashType(inputIndex: number): number | undefined {
+    const buf = this.getInput(inputIndex, InputTypes.SIGHASH_TYPE);
+    return buf ? InputField[InputTypes.SIGHASH_TYPE].decode(buf) : undefined;
+  }
+
+  private _getHashForInput(
+    inputIndex: number,
+    sighashTypes: number[] = [Transaction.SIGHASH_ALL],
+  ): { hash: Uint8Array; sighashType: number } {
+    const sighashType =
+      this._getSighashType(inputIndex) ?? Transaction.SIGHASH_ALL;
+    if (!sighashTypes.includes(sighashType))
+      throw new Error(
+        `Sighash type ${sighashType} not in allowed list: ${sighashTypes}`,
+      );
+
+    const tx = this._buildUnsignedTx();
+    const utxo = this._getUtxoForInput(inputIndex);
+
+    const redeemScriptBuf = this.getInput(inputIndex, InputTypes.REDEEM_SCRIPT);
+    const witnessScriptBuf = this.getInput(
+      inputIndex,
+      InputTypes.WITNESS_SCRIPT,
+    );
+    const redeemScript = redeemScriptBuf
+      ? InputField[InputTypes.REDEEM_SCRIPT].decode(redeemScriptBuf)
+      : undefined;
+    const witnessScript = witnessScriptBuf
+      ? InputField[InputTypes.WITNESS_SCRIPT].decode(witnessScriptBuf)
+      : undefined;
+
+    // Determine meaningful script (mirrors getMeaningfulScript in psbt.ts)
+    const meaningfulScript = witnessScript ?? redeemScript ?? utxo.script;
+
+    let hash: Uint8Array;
+    if (witnessScript || isP2WPKH(meaningfulScript)) {
+      const signingScript = isP2WPKH(meaningfulScript)
+        ? payments.p2pkh({ hash: meaningfulScript.slice(2) }).output!
+        : meaningfulScript;
+      hash = tx.hashForWitnessV0(
+        inputIndex,
+        signingScript,
+        utxo.value,
+        sighashType,
+      );
+    } else {
+      hash = tx.hashForSignature(inputIndex, meaningfulScript, sighashType);
+    }
+
+    return { hash, sighashType };
+  }
+
+  private _getTaprootHashes(
+    inputIndex: number,
+    pubkey: Uint8Array,
+    tapLeafHashToSign?: Uint8Array,
+    sighashTypes: number[] = [Transaction.SIGHASH_DEFAULT],
+  ): { pubkey: Uint8Array; hash: Uint8Array; leafHash?: Uint8Array }[] {
+    const sighashType =
+      this._getSighashType(inputIndex) ?? Transaction.SIGHASH_DEFAULT;
+    if (!sighashTypes.includes(sighashType))
+      throw new Error(`Sighash type ${sighashType} not in allowed list`);
+
+    const tx = this._buildUnsignedTx();
+
+    const witnessUtxos = Array.from({ length: this.inputCount }, (_, i) => {
+      const buf = this.getInput(i, InputTypes.WITNESS_UTXO);
+      if (!buf)
+        throw new Error(
+          `Input ${i}: missing WITNESS_UTXO (required for taproot)`,
+        );
+      return InputField[InputTypes.WITNESS_UTXO].decode(buf);
+    });
+    const scripts = witnessUtxos.map(u => u.script);
+    const values = witnessUtxos.map(u => u.value);
+
+    const xOnly = pubkey.length === 32 ? pubkey : toXOnly(pubkey);
+    const hashes: {
+      pubkey: Uint8Array;
+      hash: Uint8Array;
+      leafHash?: Uint8Array;
+    }[] = [];
+
+    // Key-path spend
+    // Key-path spend (synthetic/internal-key match only; does not derive tweaked output key)
+    if (
+      !tapLeafHashToSign &&
+      this.getInput(inputIndex, InputTypes.TAP_INTERNAL_KEY)
+    ) {
+      const outputKey = witnessUtxos[inputIndex].script.slice(2, 34);
+      if (compare(xOnly, outputKey) === 0) {
+        hashes.push({
+          pubkey: xOnly,
+          hash: tx.hashForWitnessV1(inputIndex, scripts, values, sighashType),
+        });
+      }
+    }
+
+    // Script-path spend
+    for (const leaf of this.getTapLeafScripts(inputIndex)) {
+      const leafHash = tapleafHash({
+        output: leaf.script,
+        version: leaf.leafVersion,
+      });
+      if (tapLeafHashToSign && compare(leafHash, tapLeafHashToSign) !== 0)
+        continue;
+
+      if (!pubkeyInScript(pubkey, leaf.script)) continue;
+
+      hashes.push({
+        pubkey: xOnly,
+        hash: tx.hashForWitnessV1(
+          inputIndex,
+          scripts,
+          values,
+          sighashType,
+          leafHash,
+        ),
+        leafHash,
+      });
+    }
+
+    return hashes;
+  }
+}


### PR DESCRIPTION
Adds PSBTv2 (BIP-370) support via a wrapper around bip370. Where bip370 only handles the structural side: map encoding, role enforcement and serialization. This wrapper adds signing and validation with an API similair to Psbt.

What's new over the base bip370 library:
- Signing and signature validation legacy, segwit, taproot key/script path
- toTransaction extracts a finalized tx with a fee rate guard
- verifyNonWitnessUtxo validates funding tx via Transaction.getHash()
- getInputHashForSig and getTaprootHashesForSig expose the raw sighash directly for hardware wallets and HSMs that cannot hold PSBT state. Prefer signInput() or passing the PSBT as hex where possible, these helpers skip the script and pubkey checks that signInput() enforces, placing full responsibility for correctness on the caller.

Before merge I would like someone to have a look at the bip370 implementation first (also need to fix one test) :)

closes #2316 